### PR TITLE
messages.pot: Add new entries

### DIFF
--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -6935,7 +6935,7 @@ msgctxt "dlgSgPreferences.lbl:"
 msgid "Changing these low-level properties can be harmful to the stability or performance of SmartGit. You should only continue if you are sure of what you are doing. Changed properties with a trailing \\* need a restart to be applied."
 msgstr "ローレベルのプロパティを変更すると、SmartGitの安定性や性能に悪影響を及ぼす可能性があります。\\r自分が何をしているのか確信が持てる場合のみ、作業を続行するべきです。\\r変更したプロパティの末尾に\\*が付いている場合は、再起動が必要です。"
 
-msgctxt "dlgSgPreferences.lbl\"Checkout \\(Switch branch\\)\""
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Checkout \\(Switch branch\\)"
 msgstr "チェックアウト \\(ブランチの切り替え\\)"
 
@@ -7183,7 +7183,7 @@ msgctxt "dlgSgPreferences.mni:"
 msgid "GitHub"
 msgstr "GitHub"
 
-msgctxt "dlgSgPreferences.mni\"GitLab \\(Self Hosted\\)\""
+msgctxt "dlgSgPreferences.mni:"
 msgid "GitLab \\(Self Hosted\\)"
 msgstr "GitLab \\(セルフホスト\\)"
 

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -101,19 +101,19 @@ msgctxt "dlgCommit.replaceMessage.btn:"
 msgid "Replace"
 msgstr "置換"
 
-msgctxt "dlgCommit.replaceMessage.chk"
+msgctxt "dlgCommit.replaceMessage.chk:"
 msgid "Always replace"
 msgstr "常に置き換える"
 
-msgctxt "dlgCommit.replaceMessage.fur"
+msgctxt "dlgCommit.replaceMessage.fur:"
 msgid "After replacing you can find the previous message when clicking the history button."
 msgstr "置き換えた後、履歴ボタンをクリックすると以前のメッセージを見つけることができます。"
 
-msgctxt "dlgCommit.replaceMessage.hdl"
+msgctxt "dlgCommit.replaceMessage.hdl:"
 msgid "Replace the existing message?"
 msgstr "既存のメッセージを置き換えますか?"
 
-msgctxt "dlgCommit.replaceMessage.tle"
+msgctxt "dlgCommit.replaceMessage.tle:"
 msgid "Replace Message"
 msgstr "メッセージを置き換える"
 
@@ -121,11 +121,11 @@ msgctxt "dlgCommitGitHubConfirmEmail.btn:"
 msgid "Confirm Email"
 msgstr "電子メールを確認"
 
-msgctxt "dlgCommitGitHubConfirmEmail.fur"
+msgctxt "dlgCommitGitHubConfirmEmail.fur:"
 msgid "If this repository is open-source, you might want to hide your email address, as \\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\], and use instead <username>@users.noreply.github.com."
 msgstr "このリポジトリがオープンソースである場合、GitHubが提案する\\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\]のようにメールアドレスを非表示にし、代わりに <username>@users.noreply.github.com  を使用することをお勧めします。"
 
-msgctxt "dlgCommitGitHubConfirmEmail.hdl"
+msgctxt "dlgCommitGitHubConfirmEmail.hdl:"
 msgid "Commit with default email address $1?"
 msgstr "デフォルトの電子メールアドレス $1 でコミットしますか？"
 
@@ -141,7 +141,7 @@ msgctxt "dlgCommitGitHubConfirmEmail.rbt:"
 msgid "Use following email address:"
 msgstr "下記のメールアドレスを使用:"
 
-msgctxt "dlgCommitGitHubConfirmEmail.tle"
+msgctxt "dlgCommitGitHubConfirmEmail.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -149,31 +149,31 @@ msgctxt "dlgCommitInvisibleIndex.btn:"
 msgid "Commit"
 msgstr "コミット"
 
-msgctxt "dlgCommitInvisibleIndex.fur"
+msgctxt "dlgCommitInvisibleIndex.fur:"
 msgid "Some staged files are not visible at the moment."
 msgstr "現在、一部のステージングされたファイルは表示されていません。"
 
-msgctxt "dlgCommitInvisibleIndex.hdl"
+msgctxt "dlgCommitInvisibleIndex.hdl:"
 msgid "Commit invisible staged files?"
 msgstr "表示されていないステージングされたファイルをコミットしますか？"
 
-msgctxt "dlgCommitInvisibleIndex.tle"
+msgctxt "dlgCommitInvisibleIndex.tle:"
 msgid "Commit"
 msgstr "コミット"
 
-msgctxt "dlgCommitView.hiddenOptions.chk"
+msgctxt "dlgCommitView.hiddenOptions.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgCommitView.hiddenOptions.fur"
+msgctxt "dlgCommitView.hiddenOptions.fur:"
 msgid "To use the options, they need to remain visible."
 msgstr "オプションを使用するには、表示されたままにしておく必要があります。"
 
-msgctxt "dlgCommitView.hiddenOptions.hdl"
+msgctxt "dlgCommitView.hiddenOptions.hdl:"
 msgid "Hidden options will be treated as unselected."
 msgstr "非表示のオプションは、選択されていないものとして扱われます。"
 
-msgctxt "dlgCommitView.hiddenOptions.tle"
+msgctxt "dlgCommitView.hiddenOptions.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -217,27 +217,27 @@ msgctxt "dlgDgAbout.tab:"
 msgid "Licensee"
 msgstr "ライセンス"
 
-msgctxt "dlgDgAbout.tle"
+msgctxt "dlgDgAbout.tle:"
 msgid "About DeepGit"
 msgstr "DeepGitについて"
 
-msgctxt "dlgDgClientException.hdl"
+msgctxt "dlgDgClientException.hdl:"
 msgid "Executing a command has failed."
 msgstr "コマンドの実行に失敗しました。"
 
-msgctxt "dlgDgClientException.tle"
+msgctxt "dlgDgClientException.tle:"
 msgid "Command Failed"
 msgstr "コマンドの失敗"
 
-msgctxt "dlgDgRefMapperGroupConfig.hdl"
+msgctxt "dlgDgRefMapperGroupConfig.hdl:"
 msgid "Configure patterns for grouping tags of this repository"
 msgstr "このリポジトリのタグをグループ化するためのパターンを設定します"
 
-msgctxt "dlgDgRefMapperGroupConfig.inf"
+msgctxt "dlgDgRefMapperGroupConfig.inf:"
 msgid "Tags, branches and other refs matched by this configuration will be displayed in the Navigation graph."
 msgstr "この設定にマッチしたタグ、ブランチ、その他の参照は、ナビゲーショングラフに表示されます。"
 
-msgctxt "dlgDgRefMapperGroupConfig.tle"
+msgctxt "dlgDgRefMapperGroupConfig.tle:"
 msgid "Configure Tag-Grouping"
 msgstr "タグ・グルーピングの設定"
 
@@ -245,31 +245,31 @@ msgctxt "dlgDgSetEncoding.edt:"
 msgid "Text File Encoding"
 msgstr "テキストファイルのエンコーディング"
 
-msgctxt "dlgDgSetEncoding.hdl"
+msgctxt "dlgDgSetEncoding.hdl:"
 msgid "Configure Encoding"
 msgstr "エンコーディング設定"
 
-msgctxt "dlgDgSetEncoding.inf"
+msgctxt "dlgDgSetEncoding.inf:"
 msgid "Specify the encoding which should be used for processing and viewing files. Note, that UTF-8 encoding will be auto-detected, regardless of the configuration here."
 msgstr "ファイルの処理と表示に使用するエンコーディングを指定します。なお、UTF-8のエンコーディングは、ここでの設定にかかわらず、自動検出されます。"
 
-msgctxt "dlgDgSetEncoding.tle"
+msgctxt "dlgDgSetEncoding.tle:"
 msgid "Set Encoding"
 msgstr "エンコーディングを設定する"
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.fur"
+msgctxt "dlgDgSetPerspectiveCantSwitch.fur:"
 msgid "In order to inspect available Origins, they have to be evaluated first. Select a line in the Blame view. Then wait until the calculation of possible Origins has finished."
 msgstr "利用可能なオリジンを検査するには、まずそれらを評価する必要があります。 Blame ビューで行を選択します。次に、可能なオリジンの計算が完了するまで待ちます。"
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.hdl"
+msgctxt "dlgDgSetPerspectiveCantSwitch.hdl:"
 msgid "Can't switch perspective."
 msgstr "パースペクティブを切り替えることができません。"
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.tle"
+msgctxt "dlgDgSetPerspectiveCantSwitch.tle:"
 msgid "Origins Perspective"
 msgstr "Origins パースペクティブ"
 
-msgctxt "dlgInfo.tle"
+msgctxt "dlgInfo.tle:"
 msgid "Discard"
 msgstr "破棄"
 
@@ -325,15 +325,15 @@ msgctxt "dlgProgress.tle:"
 msgid "Verifying executables"
 msgstr "実行ファイルを確認中"
 
-msgctxt "dlgQBugFileSendingFailed.fur"
+msgctxt "dlgQBugFileSendingFailed.fur:"
 msgid "Maybe you need to configure a proxy or our server is temporarily down.\\nDetails: $1"
 msgstr "プロキシの設定が必要なのか、サーバーが一時的にダウンしているのかもしれません。'$1'"
 
-msgctxt "dlgQBugFileSendingFailed.hdl"
+msgctxt "dlgQBugFileSendingFailed.hdl:"
 msgid "Could not send the crash logs to $1"
 msgstr "クラッシュ・ログを$1に送信できませんでした"
 
-msgctxt "dlgQBugFileSendingFailed.tle"
+msgctxt "dlgQBugFileSendingFailed.tle:"
 msgid "Native Crash Logs"
 msgstr "ネイティブクラッシュログ"
 
@@ -389,23 +389,23 @@ msgctxt "dlgQBugReportSend.lbl:"
 msgid "What did you do? We often solve a difficult bug after receiving just one good hint!"
 msgstr "あなたは何をしましたか？たった 1 つの良いヒントを頂けるだけで、難しいバグが解決されることがよくあります!"
 
-msgctxt "dlgQBugReportSend.tle"
+msgctxt "dlgQBugReportSend.tle:"
 msgid "Internal Error"
 msgstr "内部エラー"
 
-msgctxt "dlgQDockManagerClosedView.chk"
+msgctxt "dlgQDockManagerClosedView.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgQDockManagerClosedView.fur"
+msgctxt "dlgQDockManagerClosedView.fur:"
 msgid "To reopen it again, use the corresponding menu item from the Window menu."
 msgstr "再び開くには、「ウィンドウ」メニューから対応するメニューを使用します。"
 
-msgctxt "dlgQDockManagerClosedView.hdl"
+msgctxt "dlgQDockManagerClosedView.hdl:"
 msgid "You've closed the view '$1'."
 msgstr "ビュー'$1'を閉じました。"
 
-msgctxt "dlgQDockManagerClosedView.tle"
+msgctxt "dlgQDockManagerClosedView.tle:"
 msgid "Closed View"
 msgstr "閉じられたビュー"
 
@@ -413,15 +413,15 @@ msgctxt "dlgQFileSaveAcceptFilterOverwrite.btn:"
 msgid "Overwrite"
 msgstr "上書き"
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur:"
 msgid "To save to a different file, click 'Cancel'."
 msgstr "別のファイルに保存する場合は、「キャンセル」をクリックします。"
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl:"
 msgid "The file $1 already exists. Do you want to overwrite it?"
 msgstr "$1 は既に存在します。上書きしますか？"
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.tle"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.tle:"
 msgid "Overwrite File"
 msgstr "ファイルの上書き"
 
@@ -441,23 +441,23 @@ msgctxt "dlgQFrameManagerExit.fur:"
 msgid "There are unsaved changes which would be lost when exiting now!"
 msgstr "未保存の変更があります。ここで終了すると変更が失われます!"
 
-msgctxt "dlgQFrameManagerExit.hdl"
+msgctxt "dlgQFrameManagerExit.hdl:"
 msgid "Do you really want to exit SmartGit?"
 msgstr "本当にSmartGitを終了しますか?"
 
-msgctxt "dlgQFrameManagerExit.tle"
+msgctxt "dlgQFrameManagerExit.tle:"
 msgid "Exit"
 msgstr "終了"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.fur"
+msgctxt "dlgQIntegerInputProviderInvalidValue.fur:"
 msgid "Port must be in the range from $1 to $2."
 msgstr "Portは'$1'から'$2'の範囲でなければなりません。"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.hdl"
+msgctxt "dlgQIntegerInputProviderInvalidValue.hdl:"
 msgid "The text in field '$1' is not valid."
 msgstr "フィールド '$1' のテキストは有効ではありません。"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.tle"
+msgctxt "dlgQIntegerInputProviderInvalidValue.tle:"
 msgid "Input Validation"
 msgstr "入力の検証"
 
@@ -497,7 +497,7 @@ msgctxt "dlgQProxyConfigure.rbt:"
 msgid "Use following proxy"
 msgstr "以下のプロキシを使用"
 
-msgctxt "dlgQProxyConfigure.tle"
+msgctxt "dlgQProxyConfigure.tle:"
 msgid "Configure Proxy"
 msgstr "プロキシ設定"
 
@@ -509,15 +509,15 @@ msgctxt "dlgQProxyConnectionFailed.btn:"
 msgid "Retry"
 msgstr "再試行"
 
-msgctxt "dlgQProxyConnectionFailed.fur"
+msgctxt "dlgQProxyConnectionFailed.fur:"
 msgid "Details: syntevo.com"
 msgstr "詳細: syntevo.com"
 
-msgctxt "dlgQProxyConnectionFailed.hdl"
+msgctxt "dlgQProxyConnectionFailed.hdl:"
 msgid "Could not connect to $1."
 msgstr "$1 に接続できませんでした。"
 
-msgctxt "dlgQProxyConnectionFailed.tle"
+msgctxt "dlgQProxyConnectionFailed.tle:"
 msgid "Connection Failed"
 msgstr "接続に失敗しました"
 
@@ -537,27 +537,27 @@ msgctxt "dlgQUpdateCheckForNewVersion.btn:"
 msgid "Skip"
 msgstr "スキップ"
 
-msgctxt "dlgQUpdateCheckForNewVersion.hdl"
+msgctxt "dlgQUpdateCheckForNewVersion.hdl:"
 msgid "SmartGit needs to check for updates"
 msgstr "SmartGit は更新を確認する必要があります"
 
-msgctxt "dlgQUpdateCheckForNewVersion.inf"
+msgctxt "dlgQUpdateCheckForNewVersion.inf:"
 msgid "If necessary, please configure the proxy and retry."
 msgstr "必要であれば、プロキシの設定を行い、再試行してください。"
 
-msgctxt "dlgQUpdateCheckForNewVersion.tle"
+msgctxt "dlgQUpdateCheckForNewVersion.tle:"
 msgid "Check for New Version"
 msgstr "新しいバージョンの確認"
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.fur"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.fur:"
 msgid "Details: Failed to connect to '$1'."
 msgstr "詳細: '$1'への接続に失敗しました。"
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.hdl"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.hdl:"
 msgid "Checking for new versions has failed."
 msgstr "新しいバージョンのチェックに失敗しました。"
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.tle"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.tle:"
 msgid "Check for New Version"
 msgstr "新しいバージョンの確認"
 
@@ -565,27 +565,27 @@ msgctxt "dlgQUpdateCheckLatestBuild.btn:"
 msgid "Get Latest Build"
 msgstr "最新のビルドを入手する"
 
-msgctxt "dlgQUpdateCheckLatestBuild.fur"
+msgctxt "dlgQUpdateCheckLatestBuild.fur:"
 msgid "Only use the latest build if requested by the support team."
 msgstr "サポートチームから要請があった場合のみ、最新のビルドを使用してください。"
 
-msgctxt "dlgQUpdateCheckLatestBuild.hdl"
+msgctxt "dlgQUpdateCheckLatestBuild.hdl:"
 msgid "Do you want to download the latest build?"
 msgstr "最新のビルドをダウンロードしますか？"
 
-msgctxt "dlgQUpdateCheckLatestBuild.tle"
+msgctxt "dlgQUpdateCheckLatestBuild.tle:"
 msgid "Check for Latest Build"
 msgstr "最新ビルドの確認"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur:"
 msgid "Details: $1"
 msgstr "詳細: $1"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.hdl"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.hdl:"
 msgid "Initializing upgrade failed."
 msgstr "アップグレードの初期化に失敗しました。"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.tle"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.tle:"
 msgid "Check for Latest Build"
 msgstr "最新ビルドの確認"
 
@@ -593,39 +593,39 @@ msgctxt "dlgQUpdateCheckNewVersion.btn:"
 msgid "Download"
 msgstr "ダウンロード"
 
-msgctxt "dlgQUpdateCheckNewVersion.fur"
+msgctxt "dlgQUpdateCheckNewVersion.fur:"
 msgid "It's recommended to update to the new version."
 msgstr "新しいバージョンにアップデートすることをお勧めします。"
 
-msgctxt "dlgQUpdateCheckNewVersion.hdl"
+msgctxt "dlgQUpdateCheckNewVersion.hdl:"
 msgid "A new version of SmartGit is available."
 msgstr "SmartGitの新しいバージョンが利用可能です。"
 
-msgctxt "dlgQUpdateCheckNewVersion.tle"
+msgctxt "dlgQUpdateCheckNewVersion.tle:"
 msgid "Check for New Version"
 msgstr "新しいバージョンの確認"
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.fur"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.fur:"
 msgid "You are already using the latest build."
 msgstr "すでに最新のビルドを使用しています。"
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.hdl"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.hdl:"
 msgid "No newer build found."
 msgstr "新しいビルドは見つかりませんでした。"
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.tle"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.tle:"
 msgid "Check for Latest Build"
 msgstr "最新ビルドの確認"
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.fur"
+msgctxt "dlgQUpdateCheckNowNewerVersion.fur:"
 msgid "You are already using the latest version."
 msgstr "すでに最新のバージョンを使用しています。"
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.hdl"
+msgctxt "dlgQUpdateCheckNowNewerVersion.hdl:"
 msgid "No newer version found."
 msgstr "新しいバージョンは見つかりませんでした。"
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.tle"
+msgctxt "dlgQUpdateCheckNowNewerVersion.tle:"
 msgid "Check for New Version"
 msgstr "新しいバージョンの確認"
 
@@ -653,15 +653,15 @@ msgctxt "dlgRewriteTextFiles.edt:"
 msgid "Line-Endings"
 msgstr "改行コード"
 
-msgctxt "dlgRewriteTextFiles.hdl"
+msgctxt "dlgRewriteTextFiles.hdl:"
 msgid "Rewrite text files with selected line-endings"
 msgstr "選択した改行コードでテキスト ファイルを書き換える"
 
-msgctxt "dlgRewriteTextFiles.inf"
+msgctxt "dlgRewriteTextFiles.inf:"
 msgid "Select the line-endings that should be used to write the text files."
 msgstr "テキスト ファイルの書き込みに使用する改行コードを選択します。"
 
-msgctxt "dlgRewriteTextFiles.tle"
+msgctxt "dlgRewriteTextFiles.tle:"
 msgid "Fix Line-Endings"
 msgstr "改行コードを修正する"
 
@@ -669,15 +669,15 @@ msgctxt "dlgScAboutUpdateInstallation.btn:"
 msgid "Upgrade Installation"
 msgstr "アップグレードのインストール"
 
-msgctxt "dlgScAboutUpdateInstallation.fur"
+msgctxt "dlgScAboutUpdateInstallation.fur:"
 msgid "This will take a few moments and has to restart SmartGit."
 msgstr "これには少し時間がかかり、SmartGitを再起動する必要があります。"
 
-msgctxt "dlgScAboutUpdateInstallation.hdl"
+msgctxt "dlgScAboutUpdateInstallation.hdl:"
 msgid "Do you want to upgrade the installation directory to version $1?"
 msgstr "インストールディレクトリをバージョン$1にアップグレードしますか？"
 
-msgctxt "dlgScAboutUpdateInstallation.tle"
+msgctxt "dlgScAboutUpdateInstallation.tle:"
 msgid "Upgrade Installation"
 msgstr "アップグレードのインストール"
 
@@ -693,59 +693,59 @@ msgctxt "dlgScApplicationStarterRestart.btn:"
 msgid "Restart"
 msgstr "再起動"
 
-msgctxt "dlgScApplicationStarterRestart.fur"
+msgctxt "dlgScApplicationStarterRestart.fur:"
 msgid "The downloaded program update should be applied now."
 msgstr "ダウンロードしたプログラムの更新が適用されます。"
 
-msgctxt "dlgScApplicationStarterRestart.hdl"
+msgctxt "dlgScApplicationStarterRestart.hdl:"
 msgid "SmartGit requires a restart."
 msgstr "SmartGitは再起動が必要です。"
 
-msgctxt "dlgScApplicationStarterRestart.tle"
+msgctxt "dlgScApplicationStarterRestart.tle:"
 msgid "Restart"
 msgstr "再起動"
 
-msgctxt "dlgScConflictSolverAdd.hdl"
+msgctxt "dlgScConflictSolverAdd.hdl:"
 msgid "Add conflict solver"
 msgstr "コンフリクトソルバーの追加"
 
-msgctxt "dlgScConflictSolverAdd.tle"
+msgctxt "dlgScConflictSolverAdd.tle:"
 msgid "Add"
 msgstr "追加"
 
-msgctxt "dlgScConflictSolverEdit.hdl"
+msgctxt "dlgScConflictSolverEdit.hdl:"
 msgid "Edit conflict solver"
 msgstr "コンフリクトソルバーの編集"
 
-msgctxt "dlgScConflictSolverEdit.tle"
+msgctxt "dlgScConflictSolverEdit.tle:"
 msgid "Edit"
 msgstr "編集"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.fur"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.fur:"
 msgid "The merge file content contains mixed \\(inconsistent\\) line-endings. If these line-endings are intentionally mixed, be sure to not overwrite them while saving this file."
 msgstr "マージ ファイルの内容に、混在した \\(一貫性のない\\) 改行文字が含まれています。これらの改行文字の混在が意図的なものである場合は、このファイルを保存するときに上書きしないように注意してください。"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl:"
 msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr "ファイルには、混在した \\(一貫性のない\\) 改行文字が含まれています。"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - コンフリクトソルバー"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.chk"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.chk:"
 msgid "Don't warn me again"
 msgstr "次回から警告しない"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.fur"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.fur:"
 msgid "Not all conflicts have been resolved."
 msgstr "すべての競合が解決されたわけではありません。"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.hdl"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.hdl:"
 msgid "Do you want to close the Conflict Solver?"
 msgstr "コンフリクトソルバーを終了しますか？"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.tle"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.tle:"
 msgid "Unresolved Conflicts"
 msgstr "未解決の競合"
 
@@ -761,7 +761,7 @@ msgctxt "dlgScConflictSolver(Add|Edit).edt:"
 msgid "File Pattern"
 msgstr "ファイルパターン"
 
-msgctxt "dlgScConflictSolver(Add|Edit).inf"
+msgctxt "dlgScConflictSolver(Add|Edit).inf:"
 msgid "Define the file pattern \\(e.g. \\*.txt\\) and select the merge tool which should be used to resolve conflicting files matching this pattern."
 msgstr "ファイルパターン\\(例: \\*.txt\\)を定義し、このパターンに一致するファイルの競合を解決するために使用するマージツールを選択します。"
 
@@ -841,15 +841,15 @@ msgctxt "dlgScCustomizeAccelerators.edt:"
 msgid "Accelerator"
 msgstr "ショートカット"
 
-msgctxt "dlgScCustomizeAccelerators.hdl"
+msgctxt "dlgScCustomizeAccelerators.hdl:"
 msgid "Customize Accelerators"
 msgstr "ショートカットのカスタマイズ"
 
-msgctxt "dlgScCustomizeAccelerators.inf"
+msgctxt "dlgScCustomizeAccelerators.inf:"
 msgid "Double click on the menu item for which the accelerator should be changed, then press the accelerator keys and click the Assign button."
 msgstr "ショートカットを変更するメニュー項目をダブルクリックし、アクセラレータ キーを押して [アサイン] ボタンをクリックします。"
 
-msgctxt "dlgScCustomizeAccelerators.tle"
+msgctxt "dlgScCustomizeAccelerators.tle:"
 msgid "Customize"
 msgstr "カスタマイズ"
 
@@ -901,7 +901,7 @@ msgctxt "dlgScCustomizeToolBar.mni:"
 msgid "Remove"
 msgstr "削除"
 
-msgctxt "dlgScCustomizeToolBar.tle"
+msgctxt "dlgScCustomizeToolBar.tle:"
 msgid "Configure Toolbar"
 msgstr "ツールバーの設定"
 
@@ -921,15 +921,15 @@ msgctxt "dlgScDevOpsCredentials.edt:"
 msgid "User Name"
 msgstr "ユーザ名"
 
-msgctxt "dlgScDevOpsCredentials.hdl"
+msgctxt "dlgScDevOpsCredentials.hdl:"
 msgid "Login to '$1'"
 msgstr "'$1' にログイン"
 
-msgctxt "dlgScDevOpsCredentials.inf"
+msgctxt "dlgScDevOpsCredentials.inf:"
 msgid "Provide the user name and password for authenticating to JIRA."
 msgstr "JIRAに認証するためのユーザー名とパスワードを入力します。"
 
-msgctxt "dlgScDevOpsCredentials.tle"
+msgctxt "dlgScDevOpsCredentials.tle:"
 msgid "Login to JIRA"
 msgstr "JIRAにログインする"
 
@@ -953,15 +953,15 @@ msgctxt "dlgScDevOpsSslClientCertificate.edt:"
 msgid "Passphrase"
 msgstr "パスフレーズ"
 
-msgctxt "dlgScDevOpsSslClientCertificate.hdl"
+msgctxt "dlgScDevOpsSslClientCertificate.hdl:"
 msgid "Select the client certificate for $1"
 msgstr "$1 用クライアント証明書を選択する"
 
-msgctxt "dlgScDevOpsSslClientCertificate.inf"
+msgctxt "dlgScDevOpsSslClientCertificate.inf:"
 msgid "Select the client certificate file for authenticating to JIRA."
 msgstr "JIRAに認証するためのクライアント証明書ファイルを選択します。"
 
-msgctxt "dlgScDevOpsSslClientCertificate.tle"
+msgctxt "dlgScDevOpsSslClientCertificate.tle:"
 msgid "JIRA Client Certificate"
 msgstr "JIRAクライアント証明書"
 
@@ -997,7 +997,7 @@ msgctxt "dlgScDevOpsSslFingerprintNew.lbl:"
 msgid "When in doubt, contact your server administrator."
 msgstr "不明な点がある場合は、サーバー管理者に問い合わせてください。"
 
-msgctxt "dlgScDevOpsSslFingerprintNew.tle"
+msgctxt "dlgScDevOpsSslFingerprintNew.tle:"
 msgid "SSL Authentication"
 msgstr "SSL認証"
 
@@ -1021,7 +1021,7 @@ msgctxt "dlgScDialogAssertionHandler.lbl:"
 msgid "SmartGit has crashed due to insufficient system memory"
 msgstr "システムメモリ不足のため、SmartGitがクラッシュしました"
 
-msgctxt "dlgScDialogAssertionHandler.tle"
+msgctxt "dlgScDialogAssertionHandler.tle:"
 msgid "Native Crash Logs"
 msgstr "ネイティブクラッシュログ"
 
@@ -1037,7 +1037,7 @@ msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
 msgid "SmartGit has detected inconsistencies within its installation files \\(JAR files\\), what has most likely been caused by a faulty installation.\\n\\nPlease uninstall SmartGit completely, make sure there are no more installation files left \\(especially JAR files\\), then reinstall.\\n\\nIf the problem persists, send following log file as an attachment to smartgit@syntevo.com."
 msgstr "SmartGit のインストール ファイル (JAR ファイル) に不整合があることが判明しました。\\n\\nSmartGit を完全にアンインストールし、インストール ファイル (特に JAR ファイル) が残っていないことを確認してから、再インストールしてください。\\n\\n問題が解決しない場合は、次のログ ファイルを smartgit@syntevo.com に添付して送信してください。"
 
-msgctxt "dlgScDialogAssertionHandlerLinkageError.tle"
+msgctxt "dlgScDialogAssertionHandlerLinkageError.tle:"
 msgid "Internal Error"
 msgstr "内部エラー"
 
@@ -1045,15 +1045,15 @@ msgctxt "dlgScDialogAssertionHandlerOutOfMemory.btn:"
 msgid "Force Exit"
 msgstr "強制終了"
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur:"
 msgid "It is strongly recommended to restart SmartGit.\\n\\nTo increase the maximum memory limit edit $1, increase the value of the -Xmx option, for example to -Xmx1024m \\(or add it if not yet existing\\) and restart SmartGit."
 msgstr "SmartGit を再起動することを強くお勧めします。\\n\\n最大メモリ制限を増やすには、$1 を編集し、-Xmx オプションの値を増やします。例えば、-Xmx1024m を設定し（まだ存在していない場合は追加し）、SmartGit を再起動してください。"
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.hdl"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.hdl:"
 msgid "SmartGit ran out of memory!"
 msgstr "SmartGit はメモリ不足に陥りました!"
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.tle"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.tle:"
 msgid "Out Of Memory"
 msgstr "メモリ不足"
 
@@ -1065,27 +1065,27 @@ msgctxt "dlgScEvaluationReminderContinue.btn:"
 msgid "Register"
 msgstr "登録"
 
-msgctxt "dlgScEvaluationReminderContinue.fur"
+msgctxt "dlgScEvaluationReminderContinue.fur:"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
 msgstr "商用環境で SmartGit を使用するには、\\[$1 ライセンスを購入\\]する必要があります。\\n\\n \\[$2 特定の用途\\] については、無料のライセンスを付与します。"
 
-msgctxt "dlgScEvaluationReminderContinue.hdl"
+msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr "SmartGit の評価期間は $1 日後に終了します。"
 
-msgctxt "dlgScEvaluationReminderContinue.tle"
+msgctxt "dlgScEvaluationReminderContinue.tle:"
 msgid "Evaluation"
 msgstr "評価"
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl:"
 msgid "Cannot run program \"$1\": $2"
 msgstr "プログラム「\"$1\": $2」を実行できません"
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - コンフリクトソルバー"
 
-msgctxt "dlgScFileComparatorAdd.hdl"
+msgctxt "dlgScFileComparatorAdd.hdl:"
 msgid "Add external diff tool"
 msgstr "外部Diffツールの追加"
 
@@ -1101,11 +1101,11 @@ msgctxt "dlgScFileComparatorAdd.mni:"
 msgid "Base Title"
 msgstr "ベースタイトル"
 
-msgctxt "dlgScFileComparatorAdd.tle"
+msgctxt "dlgScFileComparatorAdd.tle:"
 msgid "Add"
 msgstr "追加"
 
-msgctxt "dlgScFileComparatorEdit.hdl"
+msgctxt "dlgScFileComparatorEdit.hdl:"
 msgid "Edit external diff tool"
 msgstr "外部Diffツールの編集"
 
@@ -1121,7 +1121,7 @@ msgctxt "dlgScFileComparatorEdit.mni:"
 msgid "Base Title"
 msgstr "ベースタイトル"
 
-msgctxt "dlgScFileComparatorEdit.tle"
+msgctxt "dlgScFileComparatorEdit.tle:"
 msgid "Edit"
 msgstr "編集"
 
@@ -1137,7 +1137,7 @@ msgctxt "dlgScFileComparator(Add|Edit).edt:"
 msgid "File Pattern"
 msgstr "ファイルパターン"
 
-msgctxt "dlgScFileComparator(Add|Edit).inf"
+msgctxt "dlgScFileComparator(Add|Edit).inf:"
 msgid "Define the file pattern \\(e.g. \\*.png\\) and select the compare command which should be used to compare files matching the file pattern."
 msgstr "ファイルパターン（例：*.png）を定義し、ファイルパターンに一致するファイルを比較するために使用する比較コマンドを選択します。"
 
@@ -1201,15 +1201,15 @@ msgctxt "dlgScFileCompareFileChanged.btn:"
 msgid "Save"
 msgstr "保存"
 
-msgctxt "dlgScFileCompareFileChanged.fur"
+msgctxt "dlgScFileCompareFileChanged.fur:"
 msgid "Your changes will be lost, if you don't save them."
 msgstr "保存しない場合、変更内容が失われます。"
 
-msgctxt "dlgScFileCompareFileChanged.hdl"
+msgctxt "dlgScFileCompareFileChanged.hdl:"
 msgid "Do you want to save your changes?"
 msgstr "変更内容を保存しますか？"
 
-msgctxt "dlgScFileCompareFileChanged.tle"
+msgctxt "dlgScFileCompareFileChanged.tle:"
 msgid "File Changed"
 msgstr "ファイルが変更されています"
 
@@ -1229,15 +1229,15 @@ msgctxt "dlgScFileCompareSaveAll.chk:"
 msgid "Right file"
 msgstr "右のファイル"
 
-msgctxt "dlgScFileCompareSaveAll.hdl"
+msgctxt "dlgScFileCompareSaveAll.hdl:"
 msgid "Save file changes"
 msgstr "ファイルの変更を保存"
 
-msgctxt "dlgScFileCompareSaveAll.inf"
+msgctxt "dlgScFileCompareSaveAll.inf:"
 msgid "Decide which file content to save."
 msgstr "保存するファイルの内容を決定します。"
 
-msgctxt "dlgScFileCompareSaveAll.tle"
+msgctxt "dlgScFileCompareSaveAll.tle:"
 msgid "Save Changes"
 msgstr "変更を保存する"
 
@@ -1245,11 +1245,11 @@ msgctxt "dlgScFilePatternsEdit.edt:"
 msgid "File Pattern"
 msgstr "ファイルパターン"
 
-msgctxt "dlgScFilePatternsEdit.hdl"
+msgctxt "dlgScFilePatternsEdit.hdl:"
 msgid "Language: $1"
 msgstr "言語: $1"
 
-msgctxt "dlgScFilePatternsEdit.inf"
+msgctxt "dlgScFilePatternsEdit.inf:"
 msgid "File patterns are used to determine file language, which is used for syntax coloring."
 msgstr "ファイルパターンは、ファイル言語を決定するために使用され、シンタックスカラーリングに使用されます。"
 
@@ -1257,7 +1257,7 @@ msgctxt "dlgScFilePatternsEdit.lbl:"
 msgid "Valid wildcards are ?\\u00a0\\(one arbitrary character\\) and \\*\\u00a0\\(any number of arbitrary characters\\). Separate multiple patterns by comma. Example:\\u00a0\\*.txt,\\u00a0\\*.html"
 msgstr "有効なワイルドカードは下記のとおりです。複数のパターンはコンマで区切ります。\\r例：*.txt,*.html \\r ? (任意の1文字) \\r * (任意の数の任意の文字)"
 
-msgctxt "dlgScFilePatternsEdit.tle"
+msgctxt "dlgScFilePatternsEdit.tle:"
 msgid "File Patterns"
 msgstr "ファイルパターン"
 
@@ -1265,7 +1265,7 @@ msgctxt "dlgScFindAction.edt:"
 msgid "Action name"
 msgstr "アクション名"
 
-msgctxt "dlgScFindAction.tle"
+msgctxt "dlgScFindAction.tle:"
 msgid "Find Command"
 msgstr "コマンドを検索"
 
@@ -1285,15 +1285,15 @@ msgctxt "dlgScHostKeyVerifier.edt:"
 msgid "Server"
 msgstr "サーバ"
 
-msgctxt "dlgScHostKeyVerifier.fur"
+msgctxt "dlgScHostKeyVerifier.fur:"
 msgid "If you are unsure, contact your administrator."
 msgstr "不明な場合は、管理者に問い合わせてください。"
 
-msgctxt "dlgScHostKeyVerifier.hdl"
+msgctxt "dlgScHostKeyVerifier.hdl:"
 msgid "Please confirm the SSH server fingerprint."
 msgstr "SSH サーバーのフィンガープリントを確認してください。"
 
-msgctxt "dlgScHostKeyVerifier.tle"
+msgctxt "dlgScHostKeyVerifier.tle:"
 msgid "SSH Server Verification"
 msgstr "SSH サーバーの検証"
 
@@ -1329,11 +1329,11 @@ msgctxt "dlgScJiraCommitMessageSelect.col:"
 msgid "Summary"
 msgstr "概要"
 
-msgctxt "dlgScJiraCommitMessageSelect.hdl"
+msgctxt "dlgScJiraCommitMessageSelect.hdl:"
 msgid "Select commit message by JIRA issue"
 msgstr "コミットメッセージをJIRAの課題から選択する"
 
-msgctxt "dlgScJiraCommitMessageSelect.inf"
+msgctxt "dlgScJiraCommitMessageSelect.inf:"
 msgid "The selected issue summary will be used as commit message."
 msgstr "選択された課題の概要がコミットメッセージとして使用されます。"
 
@@ -1349,7 +1349,7 @@ msgctxt "dlgScJiraCommitMessageSelect.lbl:"
 msgid "Query Configuration"
 msgstr "クエリーの構成"
 
-msgctxt "dlgScJiraCommitMessageSelect.tle"
+msgctxt "dlgScJiraCommitMessageSelect.tle:"
 msgid "Select Issue"
 msgstr "課題の選択"
 
@@ -1377,15 +1377,15 @@ msgctxt "dlgScJiraResolveIssue.edt:"
 msgid "Summary"
 msgstr "概要"
 
-msgctxt "dlgScJiraResolveIssue.hdl"
+msgctxt "dlgScJiraResolveIssue.hdl:"
 msgid "Resolve issue $1"
 msgstr "課題 $1 を解決"
 
-msgctxt "dlgScJiraResolveIssue.inf"
+msgctxt "dlgScJiraResolveIssue.inf:"
 msgid "Select whether to resolve this issue and for which version to mark as resolved."
 msgstr "この問題を解決するかどうか、どのバージョンで解決済みとしてマークするかを選択します。"
 
-msgctxt "dlgScJiraResolveIssue.tle"
+msgctxt "dlgScJiraResolveIssue.tle:"
 msgid "Resolve JIRA Issue"
 msgstr "JIRAの課題を解決する"
 
@@ -1401,11 +1401,11 @@ msgctxt "dlgScMasterPasswordChange.edt:"
 msgid "Retype New Master Password"
 msgstr "新しいマスターパスワードの再入力"
 
-msgctxt "dlgScMasterPasswordChange.hdl"
+msgctxt "dlgScMasterPasswordChange.hdl:"
 msgid "Change or reset the master password"
 msgstr "マスターパスワードの変更・再設定"
 
-msgctxt "dlgScMasterPasswordChange.inf"
+msgctxt "dlgScMasterPasswordChange.inf:"
 msgid "To change the master password, enter the current one. To go without a master password, leave the new field blank."
 msgstr "マスターパスワードを変更する場合は、現在のパスワードを入力してください。マスターパスワードを使用しない場合は、新しいパスワードを空白にします。"
 
@@ -1421,7 +1421,7 @@ msgctxt "dlgScMasterPasswordChange.rbt:"
 msgid "Set new master password"
 msgstr "新しいマスターパスワードの設定"
 
-msgctxt "dlgScMasterPasswordChange.tle"
+msgctxt "dlgScMasterPasswordChange.tle:"
 msgid "Change Master Password"
 msgstr "マスターパスワードの変更"
 
@@ -1433,11 +1433,11 @@ msgctxt "dlgScMasterPasswordCreate.edt:"
 msgid "Retype Again"
 msgstr "もう一度入力"
 
-msgctxt "dlgScMasterPasswordCreate.hdl"
+msgctxt "dlgScMasterPasswordCreate.hdl:"
 msgid "Configure the master password for the encrypted password store"
 msgstr "暗号化されたパスワードストアのマスターパスワードを設定する"
 
-msgctxt "dlgScMasterPasswordCreate.inf"
+msgctxt "dlgScMasterPasswordCreate.inf:"
 msgid "The master password is used to protect passwords and passphrases which are used to authenticate with servers."
 msgstr "マスターパスワードは、サーバーとの認証に使用されるパスワードやパスフレーズを保護するために使用されます。"
 
@@ -1457,7 +1457,7 @@ msgctxt "dlgScMasterPasswordCreate.rbt:"
 msgid "Use the following master password"
 msgstr "以下のマスターパスワードを使用します"
 
-msgctxt "dlgScMasterPasswordCreate.tle"
+msgctxt "dlgScMasterPasswordCreate.tle:"
 msgid "Master Password"
 msgstr "マスターパスワード"
 
@@ -1465,39 +1465,39 @@ msgctxt "dlgScMasterPasswordEnter.edt:"
 msgid "Master Password"
 msgstr "マスターパスワード"
 
-msgctxt "dlgScMasterPasswordEnter.hdl"
+msgctxt "dlgScMasterPasswordEnter.hdl:"
 msgid "Enter the master password"
 msgstr "マスターパスワードの入力"
 
-msgctxt "dlgScMasterPasswordEnter.inf"
+msgctxt "dlgScMasterPasswordEnter.inf:"
 msgid "A stored password or passphrase has been requested from the password store."
 msgstr "保存されたパスワードまたはパスフレーズがパスワードストアから要求されました。"
 
-msgctxt "dlgScMasterPasswordEnter.tle"
+msgctxt "dlgScMasterPasswordEnter.tle:"
 msgid "Passwords"
 msgstr "パスワード"
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.fur"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.fur:"
 msgid "The process could not be started."
 msgstr "プロセスを開始できませんでした。"
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.hdl"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr "アップデータの直接起動に失敗しました。"
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.tle"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.tle:"
 msgid "SmartGit Installation Update"
 msgstr "SmartGit インストールの更新"
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.fur"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.fur:"
 msgid "Be sure to remember it, otherwise you won't be able to access your stored passwords anymore."
 msgstr "忘れないようにしてください。忘れた場合、保存したパスワードにアクセスできなくなります。"
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.hdl"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.hdl:"
 msgid "The master password has been changed."
 msgstr "マスターパスワードが変更されました。"
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.tle"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.tle:"
 msgid "Change Master Password"
 msgstr "マスターパスワードを変更"
 
@@ -1505,15 +1505,15 @@ msgctxt "dlgScPropertiesReset.btn:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "dlgScPropertiesReset.fur"
+msgctxt "dlgScPropertiesReset.fur:"
 msgid "The new values will be active after restarting SmartGit."
 msgstr "新しい値は、SmartGitを再起動すると有効になります。"
 
-msgctxt "dlgScPropertiesReset.hdl"
+msgctxt "dlgScPropertiesReset.hdl:"
 msgid "Do you want to reset $1 system properties to their defaults?"
 msgstr "$1 システムのプロパティをデフォルトにリセットしますか？"
 
-msgctxt "dlgScPropertiesReset.tle"
+msgctxt "dlgScPropertiesReset.tle:"
 msgid "Reset Properties"
 msgstr "プロパティのリセット"
 
@@ -1521,11 +1521,11 @@ msgctxt "dlgScPropertyEdit.edt:"
 msgid "Value"
 msgstr "値"
 
-msgctxt "dlgScPropertyEdit.hdl"
+msgctxt "dlgScPropertyEdit.hdl:"
 msgid "Edit low-level property value"
 msgstr "ローレベルのプロパティ値を編集する"
 
-msgctxt "dlgScPropertyEdit.inf"
+msgctxt "dlgScPropertyEdit.inf:"
 msgid "Set the value for property '$1'"
 msgstr "プロパティ '$1' の値を設定します。"
 
@@ -1537,7 +1537,7 @@ msgctxt "dlgScPropertyEdit.rbt:"
 msgid "true"
 msgstr "true"
 
-msgctxt "dlgScPropertyEdit.tle"
+msgctxt "dlgScPropertyEdit.tle:"
 msgid "Edit Property"
 msgstr "プロパティの編集"
 
@@ -1577,7 +1577,7 @@ msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "User Count"
 msgstr "ユーザ数"
 
-msgctxt "dlgScRegisterFormLicenseConfirmDetails.tle"
+msgctxt "dlgScRegisterFormLicenseConfirmDetails.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit ライセンス"
 
@@ -1585,27 +1585,27 @@ msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.btn:"
 msgid "Purchase Update"
 msgstr "アップデートを購入"
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.fur"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.fur:"
 msgid "You may use an older SmartGit version or purchase an update license."
 msgstr "古いバージョンのSmartGitを使用することもできますし、アップデートライセンスを購入することもできます。"
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.hdl"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.hdl:"
 msgid "The free update period for this license does not cover this version."
 msgstr "本ライセンスの無償アップデート期間は、このバージョンには適用されません。"
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.tle"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit ライセンス"
 
-msgctxt "dlgScRegisterRequestRejected.fur"
+msgctxt "dlgScRegisterRequestRejected.fur:"
 msgid "The license server rejected the request. Please manually register the latest license file you've got by email or try again later."
 msgstr "ライセンスサーバーが要求を拒否しました。電子メールで受け取った最新のライセンスファイルを手動で登録するか、後ほどもう一度お試しください。"
 
-msgctxt "dlgScRegisterRequestRejected.hdl"
+msgctxt "dlgScRegisterRequestRejected.hdl:"
 msgid "Failed to update license file."
 msgstr "ライセンスファイルの更新に失敗しました。"
 
-msgctxt "dlgScRegisterRequestRejected.tle"
+msgctxt "dlgScRegisterRequestRejected.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit ライセンス"
 
@@ -1633,15 +1633,15 @@ msgctxt "dlgScSetupLicense.edt:"
 msgid "License Server URL"
 msgstr "ライセンスサーバーのURL"
 
-msgctxt "dlgScSetupLicense.hdl"
+msgctxt "dlgScSetupLicense.hdl:"
 msgid "Register license file"
 msgstr "ライセンスファイルを登録"
 
-msgctxt "dlgScSetupLicense.inf"
+msgctxt "dlgScSetupLicense.inf:"
 msgid "Please provide your SmartGit license file you've received by email after purchase."
 msgstr "購入後にメールで送られてきたSmartGitのライセンスファイルを指定してください。"
 
-msgctxt "dlgScSetupLicense.tle"
+msgctxt "dlgScSetupLicense.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit ライセンス"
 
@@ -1653,19 +1653,19 @@ msgctxt "dlgScSpellCheckDictionaryAdd.err:"
 msgid "Please select a dictionary file."
 msgstr "辞書ファイルを選択してください。"
 
-msgctxt "dlgScSpellCheckDictionaryAdd.hdl"
+msgctxt "dlgScSpellCheckDictionaryAdd.hdl:"
 msgid "Add spell checker dictionary"
 msgstr "スペルチェッカー辞書の追加"
 
-msgctxt "dlgScSpellCheckDictionaryAdd.tle"
+msgctxt "dlgScSpellCheckDictionaryAdd.tle:"
 msgid "Add"
 msgstr "追加"
 
-msgctxt "dlgScSpellCheckDictionaryEdit.hdl"
+msgctxt "dlgScSpellCheckDictionaryEdit.hdl:"
 msgid "Edit spell checker dictionary"
 msgstr "スペルチェッカー辞書の編集"
 
-msgctxt "dlgScSpellCheckDictionaryEdit.tle"
+msgctxt "dlgScSpellCheckDictionaryEdit.tle:"
 msgid "Edit"
 msgstr "編集"
 
@@ -1677,7 +1677,7 @@ msgctxt "dlgScSpellCheckDictionary(Add|Edit).edt:"
 msgid "Name"
 msgstr "名前"
 
-msgctxt "dlgScSpellCheckDictionary(Add|Edit).inf"
+msgctxt "dlgScSpellCheckDictionary(Add|Edit).inf:"
 msgid "Specify the MySpell dictionary file to use, e.g. \\*.dic from Mozilla Firefox' or Thunderbird's \"dictionary\" directory\\). The name is used when switching between different dictionaries."
 msgstr "使用するMySpell辞書ファイルを指定します（例：Mozilla FirefoxまたはThunderbirdの「辞書」ディレクトリにある*.dic）\\r名前は、異なる辞書を切り替える際に使用されます。"
 
@@ -1705,7 +1705,7 @@ msgctxt "dlgScSslFingerprint.lbl:"
 msgid "This might indicate a security problem! When in doubt, contact your server administrator."
 msgstr "これは、セキュリティ上の問題を示している可能性があります。疑わしい場合は、サーバー管理者に連絡してください。"
 
-msgctxt "dlgScSslFingerprint.tle"
+msgctxt "dlgScSslFingerprint.tle:"
 msgid "Server Fingerprint"
 msgstr "サーバーのフィンガープリント"
 
@@ -1713,15 +1713,15 @@ msgctxt "dlgScTextFinderFindFromEnd.btn:"
 msgid "Find from End"
 msgstr "末尾から検索"
 
-msgctxt "dlgScTextFinderFindFromEnd.fur"
+msgctxt "dlgScTextFinderFindFromEnd.fur:"
 msgid "No occurrences have been found until the beginning of the document."
 msgstr "ドキュメントの先頭まで見つかりませんでした。"
 
-msgctxt "dlgScTextFinderFindFromEnd.hdl"
+msgctxt "dlgScTextFinderFindFromEnd.hdl:"
 msgid "Do you want to continue from the end of the document?"
 msgstr "ドキュメントの最後から続けますか？"
 
-msgctxt "dlgScTextFinderFindFromEnd.tle"
+msgctxt "dlgScTextFinderFindFromEnd.tle:"
 msgid "Find Text"
 msgstr "テキストの検索"
 
@@ -1729,23 +1729,23 @@ msgctxt "dlgScTextFinderFindFromStart.btn:"
 msgid "Find from Beginning"
 msgstr "初めから検索"
 
-msgctxt "dlgScTextFinderFindFromStart.fur"
+msgctxt "dlgScTextFinderFindFromStart.fur:"
 msgid "No occurrences have been found until the end of the document."
 msgstr "ドキュメントの最後まで見つかりませんでした。"
 
-msgctxt "dlgScTextFinderFindFromStart.hdl"
+msgctxt "dlgScTextFinderFindFromStart.hdl:"
 msgid "Do you want to continue from the beginning of the document?"
 msgstr "ドキュメントの先頭から続けますか？"
 
-msgctxt "dlgScTextFinderFindFromStart.tle"
+msgctxt "dlgScTextFinderFindFromStart.tle:"
 msgid "Find Text"
 msgstr "テキストの検索"
 
-msgctxt "dlgScTextFinderNothingFound.hdl"
+msgctxt "dlgScTextFinderNothingFound.hdl:"
 msgid "No \\(more\\) occurrences have been found."
 msgstr "見つかりませんでした。"
 
-msgctxt "dlgScTextFinderNothingFound.tle"
+msgctxt "dlgScTextFinderNothingFound.tle:"
 msgid "Find Text"
 msgstr "テキストの検索"
 
@@ -1753,11 +1753,11 @@ msgctxt "dlgScTextMultiComponentGoToLine.edt:"
 msgid "Line Number"
 msgstr "行番号"
 
-msgctxt "dlgScTextMultiComponentGoToLine.tle"
+msgctxt "dlgScTextMultiComponentGoToLine.tle:"
 msgid "Go to Line"
 msgstr "指定の行へ移動"
 
-msgctxt "dlgScTextMultiComponentSyntaxHighlightingSelection.tle"
+msgctxt "dlgScTextMultiComponentSyntaxHighlightingSelection.tle:"
 msgid "Select Syntax-Highlighting"
 msgstr "シンタックスハイライトの言語選択"
 
@@ -1869,43 +1869,43 @@ msgctxt "dlgScTextSettings.tab:"
 msgid "General"
 msgstr "一般"
 
-msgctxt "dlgScTextSettings.tle"
+msgctxt "dlgScTextSettings.tle:"
 msgid "Settings"
 msgstr "設定"
 
-msgctxt "dlgScUpdateInstallationResumeFailure.fur"
+msgctxt "dlgScUpdateInstallationResumeFailure.fur:"
 msgid "The process could not be started."
 msgstr "プロセスを開始できませんでした。"
 
-msgctxt "dlgScUpdateInstallationResumeFailure.hdl"
+msgctxt "dlgScUpdateInstallationResumeFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr "アップデータの直接起動に失敗しました。"
 
-msgctxt "dlgScUpdateInstallationResumeFailure.tle"
+msgctxt "dlgScUpdateInstallationResumeFailure.tle:"
 msgid "Upgrade"
 msgstr "アップグレード"
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.fur"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.fur:"
 msgid "The process could not be started."
 msgstr "プロセスを開始できませんでした。"
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.hdl"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr "アップデータの直接起動に失敗しました。"
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle:"
 msgid "SmartGit Installation Update"
 msgstr "SmartGit インストールの更新"
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur:"
 msgid "Please get rid of '$1' manually and retry the upgrade."
 msgstr "'$1' を手動で削除して、アップグレードを再試行してください。"
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.hdl"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.hdl:"
 msgid "Clearing updater directory failed."
 msgstr "アップデータのディレクトリの消去に失敗しました。"
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.tle"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.tle:"
 msgid "SmartGit Installation Update"
 msgstr "SmartGit インストールの更新"
 
@@ -1913,15 +1913,15 @@ msgctxt "dlgScUpdateInstallationUpgrade.btn:"
 msgid "Upgrade Now"
 msgstr "今すぐアップグレード"
 
-msgctxt "dlgScUpdateInstallationUpgrade.fur"
+msgctxt "dlgScUpdateInstallationUpgrade.fur:"
 msgid "The new version $1 has been downloaded which needs to be installed."
 msgstr "インストールが必要な新しいバージョン $1 がダウンロードされました。"
 
-msgctxt "dlgScUpdateInstallationUpgrade.hdl"
+msgctxt "dlgScUpdateInstallationUpgrade.hdl:"
 msgid "Do you want to upgrade SmartGit now?"
 msgstr "今すぐSmartGitをアップグレードしますか？"
 
-msgctxt "dlgScUpdateInstallationUpgrade.tle"
+msgctxt "dlgScUpdateInstallationUpgrade.tle:"
 msgid "Upgrade SmartGit"
 msgstr "SmartGitのアップグレード"
 
@@ -1929,11 +1929,11 @@ msgctxt "dlgSelectDiff.col:"
 msgid "Command"
 msgstr "コマンド"
 
-msgctxt "dlgSelectDiff.hdl"
+msgctxt "dlgSelectDiff.hdl:"
 msgid "Select the diff tool"
 msgstr "差分比較ツールを選択する"
 
-msgctxt "dlgSelectDiff.inf"
+msgctxt "dlgSelectDiff.inf:"
 msgid "Select which matching diff tool should be used."
 msgstr "どの差分比較ツールを使用するかを選択します。"
 
@@ -1945,7 +1945,7 @@ msgctxt "dlgSelectDiff.lbl:"
 msgid "Diff tool:"
 msgstr "比較ツール:"
 
-msgctxt "dlgSelectDiff.tle"
+msgctxt "dlgSelectDiff.tle:"
 msgid "File Compare"
 msgstr "ファイルの比較"
 
@@ -1953,15 +1953,15 @@ msgctxt "dlgSgAbortBisectingConfirm.btn:"
 msgid "Abort Bisect"
 msgstr "問題箇所の特定('bisect')を中止"
 
-msgctxt "dlgSgAbortBisectingConfirm.fur"
+msgctxt "dlgSgAbortBisectingConfirm.fur:"
 msgid "Your working tree is in 'bisecting' state. You may abort it to get out of this state.\\n\\nAborting will checkout the branch or commit before starting bisect."
 msgstr "作業ツリーは「問題箇所の特定中」の状態になっています。\\n\\n中止すると、問題箇所の特定\\('bisect'\\) を開始する前のブランチまたはコミットがチェックアウトされます。"
 
-msgctxt "dlgSgAbortBisectingConfirm.hdl"
+msgctxt "dlgSgAbortBisectingConfirm.hdl:"
 msgid "Do you want to reset your working tree?"
 msgstr "作業ツリーをリセットしますか？"
 
-msgctxt "dlgSgAbortBisectingConfirm.tle"
+msgctxt "dlgSgAbortBisectingConfirm.tle:"
 msgid "Abort"
 msgstr "中止"
 
@@ -1969,15 +1969,15 @@ msgctxt "dlgSgAbortCherryPickingConfirm.btn:"
 msgid "Abort Cherry-Pick"
 msgstr "チェリーピックを中止"
 
-msgctxt "dlgSgAbortCherryPickingConfirm.fur"
+msgctxt "dlgSgAbortCherryPickingConfirm.fur:"
 msgid "Your working tree is in 'cherry-picking' state. You may abort it to get out of this state and freshly start over with the cherry-picking afterwards.\\n\\nAborting will clean any local modification \\(by invoking 'git cherry-pick --abort'\\)!"
 msgstr "作業ツリーが「チェリーピック中」の状態になっています。中止してこの状態から抜け出し、チェリーピックをやり直すこともできます。\\n\\n中止すると、ローカルでの変更が完全に破棄されます! \\('git cherry-pick --abort' が実行されます\\)"
 
-msgctxt "dlgSgAbortCherryPickingConfirm.hdl"
+msgctxt "dlgSgAbortCherryPickingConfirm.hdl:"
 msgid "Do you want to abort the current cherry-pick?"
 msgstr "チェリーピックを中止しますか？"
 
-msgctxt "dlgSgAbortCherryPickingConfirm.tle"
+msgctxt "dlgSgAbortCherryPickingConfirm.tle:"
 msgid "Abort"
 msgstr "中止"
 
@@ -1985,15 +1985,15 @@ msgctxt "dlgSgAbortMergingConfirm.btn:"
 msgid "Abort Merge"
 msgstr "マージを中止"
 
-msgctxt "dlgSgAbortMergingConfirm.fur"
+msgctxt "dlgSgAbortMergingConfirm.fur:"
 msgid "Your working tree is in 'merging' state. You may abort it to get out of this state and freshly start over with the merge afterwards.\\n\\nAborting will try to reconstruct the pre-merge state \\(by invoking 'git merge --abort'\\)!"
 msgstr "作業ツリーは「マージ中」の状態です。中止してこの状態から抜け出し、後でマージをやり直すことができます。\\n\\n中止すると、マージ前の状態を再構築しようとします! \\( 'git merge --abort' の実行\\)"
 
-msgctxt "dlgSgAbortMergingConfirm.hdl"
+msgctxt "dlgSgAbortMergingConfirm.hdl:"
 msgid "Do you want to abort the current merge?"
 msgstr "現在のマージを中止しますか？"
 
-msgctxt "dlgSgAbortMergingConfirm.tle"
+msgctxt "dlgSgAbortMergingConfirm.tle:"
 msgid "Abort"
 msgstr "中止"
 
@@ -2001,15 +2001,15 @@ msgctxt "dlgSgAbortRebasingConfirm.btn:"
 msgid "Abort Rebase"
 msgstr "リベースを中止"
 
-msgctxt "dlgSgAbortRebasingConfirm.fur"
+msgctxt "dlgSgAbortRebasingConfirm.fur:"
 msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 msgstr "作業ツリーは「リベース中」の状態です。リベースを中止できます。現在のパッチをスキップしたい場合は、代わりに\\[ブランチ\\]→\\[リベース\\]→\\[リベース HEAD to\\] を使用してください。\\n\\n中止すると、ローカルの変更を消去することができます。\\('git reset --hard' の実行\\）"
 
-msgctxt "dlgSgAbortRebasingConfirm.hdl"
+msgctxt "dlgSgAbortRebasingConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
 msgstr "リベースを中止しますか？"
 
-msgctxt "dlgSgAbortRebasingConfirm.tle"
+msgctxt "dlgSgAbortRebasingConfirm.tle:"
 msgid "Abort"
 msgstr "中止"
 
@@ -2021,7 +2021,7 @@ msgctxt "dlgSgAbortRevertingConfirm.btn:"
 msgid "Abort Revert"
 msgstr "リバートを中止"
 
-msgctxt "dlgSgAbortRevertingConfirm.fur"
+msgctxt "dlgSgAbortRevertingConfirm.fur:"
 msgid "Your working tree is in 'reverting' state. You may abort it to get out of this state and freshly start over with the revert afterwards.\\n\\nAborting will clean any local modification \\(by invoking 'git reset --hard'\\)!"
 msgstr "作業ツリーが 「リバート中」 の状態です。この状態から抜け出すためにこの処理を中止し、その後、新たにリバートをやり直すことができます。\\n\\n中止すると、すべてのローカル修正が消去されます! \\('git reset--hard' の実行\\)"
 
@@ -2105,31 +2105,31 @@ msgctxt "dlgSgAbout.tab:"
 msgid "Licensee"
 msgstr "ライセンス"
 
-msgctxt "dlgSgAbout.tle"
+msgctxt "dlgSgAbout.tle:"
 msgid "About SmartGit"
 msgstr "SmartGitについて"
 
-msgctxt "dlgSgApplicationAlreadyRunning.fur"
+msgctxt "dlgSgApplicationAlreadyRunning.fur:"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
 msgstr "別々のインスタンスを実行する代わりに、SmartGit で複数のプロジェクト ウィンドウを開くことができます。\\n\\n SmartGit のインスタンスがもう実行されていないことが確実な場合は、ロック ファイルを削除する必要があります。\\n $1"
 
-msgctxt "dlgSgApplicationAlreadyRunning.hdl"
+msgctxt "dlgSgApplicationAlreadyRunning.hdl:"
 msgid "It seems that SmartGit is already running."
 msgstr "SmartGit が既に実行されているようです。"
 
-msgctxt "dlgSgApplicationAlreadyRunning.tle"
+msgctxt "dlgSgApplicationAlreadyRunning.tle:"
 msgid "SmartGit"
 msgstr "SmartGit"
 
-msgctxt "dlgSgApplicationUpgradeError.fur"
+msgctxt "dlgSgApplicationUpgradeError.fur:"
 msgid "The process could not be started."
 msgstr "プロセスを開始できませんでした。"
 
-msgctxt "dlgSgApplicationUpgradeError.hdl"
+msgctxt "dlgSgApplicationUpgradeError.hdl:"
 msgid "Launching updater directly failed."
 msgstr "アップデータの直接起動に失敗しました。"
 
-msgctxt "dlgSgApplicationUpgradeError.tle"
+msgctxt "dlgSgApplicationUpgradeError.tle:"
 msgid "Upgrade"
 msgstr "アップグレード"
 
@@ -2137,15 +2137,15 @@ msgctxt "dlgSgAuthenticationRemoveAllCredentials.btn:"
 msgid "Remove All"
 msgstr "全て削除"
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.fur"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.fur:"
 msgid "You will have to re-enter all authentication details."
 msgstr "すべての認証情報を再入力する必要があります。"
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.hdl"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.hdl:"
 msgid "Do you want to remove all known credentials?"
 msgstr "既知の認証情報をすべて削除しますか？"
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.tle"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.tle:"
 msgid "Remove All"
 msgstr "全て削除"
 
@@ -2153,7 +2153,7 @@ msgctxt "dlgSgAuthenticationShowPassword.edt:"
 msgid "Password"
 msgstr "パスワード"
 
-msgctxt "dlgSgAuthenticationShowPassword.tle"
+msgctxt "dlgSgAuthenticationShowPassword.tle:"
 msgid "Password for $1"
 msgstr "$1 のパスワード"
 
@@ -2165,11 +2165,11 @@ msgctxt "dlgSgAzureGenerateToken.edt:"
 msgid "Link"
 msgstr "リンク"
 
-msgctxt "dlgSgAzureGenerateToken.hdl"
+msgctxt "dlgSgAzureGenerateToken.hdl:"
 msgid "Enter the generated code"
 msgstr "生成されたコードを入力する"
 
-msgctxt "dlgSgAzureGenerateToken.inf"
+msgctxt "dlgSgAzureGenerateToken.inf:"
 msgid "Authenticate at Azure DevOps and enter the generated token."
 msgstr "Azure DevOpsで認証し、生成されたトークンを入力します。"
 
@@ -2177,15 +2177,15 @@ msgctxt "dlgSgAzureGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at Azure DevOps and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr "ブラウザが自動的に開き、Azure DevOpsのアカウントで認証を行い、SmartGitへのアクセスを許可します。自動的に開かなかった場合は、以下のリンクを手動で開いてください："
 
-msgctxt "dlgSgAzureGenerateToken.tle"
+msgctxt "dlgSgAzureGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr "アクセストークンを要求する"
 
-msgctxt "dlgSgAzureRefreshFailed.hdl"
+msgctxt "dlgSgAzureRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr "更新に失敗しました。"
 
-msgctxt "dlgSgAzureRefreshFailed.tle"
+msgctxt "dlgSgAzureRefreshFailed.tle:"
 msgid "Azure DevOps"
 msgstr "Azure DevOps"
 
@@ -2197,15 +2197,15 @@ msgctxt "dlgSgBisectResult.btn:"
 msgid "Leave Bisect"
 msgstr "問題箇所の特定をやめる"
 
-msgctxt "dlgSgBisectResult.fur"
+msgctxt "dlgSgBisectResult.fur:"
 msgid "$1"
 msgstr "$1"
 
-msgctxt "dlgSgBisectResult.hdl"
+msgctxt "dlgSgBisectResult.hdl:"
 msgid "Bisect has determined the first bad commit."
 msgstr "最初のバッドコミットを特定しました。"
 
-msgctxt "dlgSgBisectResult.tle"
+msgctxt "dlgSgBisectResult.tle:"
 msgid "Bisect Finished"
 msgstr "問題箇所の特定を終了"
 
@@ -2217,15 +2217,15 @@ msgctxt "dlgSgBisectStartConfirm.btn:"
 msgid "Start Bisect"
 msgstr "問題箇所の特定を開始"
 
-msgctxt "dlgSgBisectStartConfirm.fur"
+msgctxt "dlgSgBisectStartConfirm.fur:"
 msgid "You need to mark 1 commit as good and 1 commit as bad before Git can start the binary search."
 msgstr "Gitが二分探索で問題箇所の特定を開始する前に、1つのコミットをgood、1つのコミットをbadとしてマークする必要があります。"
 
-msgctxt "dlgSgBisectStartConfirm.hdl"
+msgctxt "dlgSgBisectStartConfirm.hdl:"
 msgid "Should the bisect be started with a bad commit?"
 msgstr "バッドコミットで問題箇所の特定を開始する必要がありますか?"
 
-msgctxt "dlgSgBisectStartConfirm.tle"
+msgctxt "dlgSgBisectStartConfirm.tle:"
 msgid "Start Bisect"
 msgstr "問題箇所の特定\\(bisect\\)を開始"
 
@@ -2237,11 +2237,11 @@ msgctxt "dlgSgBitbucketGenerateToken.edt:"
 msgid "Link"
 msgstr "リンク"
 
-msgctxt "dlgSgBitbucketGenerateToken.hdl"
+msgctxt "dlgSgBitbucketGenerateToken.hdl:"
 msgid "Enter the generated code"
 msgstr "生成されたコードを入力する"
 
-msgctxt "dlgSgBitbucketGenerateToken.inf"
+msgctxt "dlgSgBitbucketGenerateToken.inf:"
 msgid "Authenticate at Bitbucket and enter the generated token"
 msgstr "Bitbucketで認証し、生成されたトークンを入力します"
 
@@ -2249,15 +2249,15 @@ msgctxt "dlgSgBitbucketGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at Bitbucket and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr "ブラウザが自動的に開き、Bitbucketのアカウントで認証を行い、SmartGitへのアクセスを許可します。自動的に開かなかった場合は、以下のリンクを手動で開いてください："
 
-msgctxt "dlgSgBitbucketGenerateToken.tle"
+msgctxt "dlgSgBitbucketGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr "アクセストークンを要求する"
 
-msgctxt "dlgSgBitbucketRefreshFailed.hdl"
+msgctxt "dlgSgBitbucketRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr "更新に失敗しました。"
 
-msgctxt "dlgSgBitbucketRefreshFailed.tle"
+msgctxt "dlgSgBitbucketRefreshFailed.tle:"
 msgid "Bitbucket"
 msgstr "Bitbucket"
 
@@ -2305,11 +2305,11 @@ msgctxt "dlgSgBranchAddCheckout.hdl:"
 msgid "Create new branch at current branch \\(HEAD\\)"
 msgstr "現在のブランチ \\(HEAD\\) に新しいブランチを作成します"
 
-msgctxt "dlgSgBranchAddCheckout.inf"
+msgctxt "dlgSgBranchAddCheckout.inf:"
 msgid "Enter the name of the local branch to create."
 msgstr "作成するローカルブランチの名前を入力してください。"
 
-msgctxt "dlgSgBranchAddCheckout.tle"
+msgctxt "dlgSgBranchAddCheckout.tle:"
 msgid "Add Branch"
 msgstr "ブランチを追加"
 
@@ -2317,27 +2317,27 @@ msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.btn:"
 msgid "Overwrite"
 msgstr "上書き"
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr "「キャンセル」をクリックすると、別のブランチ名を選択することができます。"
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr "ブランチ '$1' はすでに存在しています。上書きしますか？"
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.tle"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.tle:"
 msgid "Add Branch"
 msgstr "ブランチを追加"
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.fur"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.fur:"
 msgid "By default, SmartGit disallows to delete the current branch. To skip this restriction, switch to a different branch or set the low-level property 'branch.delete.allowToDeleteCurrentBranch'."
 msgstr "デフォルトでは、SmartGit は現在のブランチを削除することを許可していません。この制限を解除するには、ローレベルプロパティ 'branch.delete.allowToDeleteCurrentBranch' を設定します。"
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.hdl"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.hdl:"
 msgid "You can't delete the current branch."
 msgstr "現在のブランチを削除することはできません。"
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.tle"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.tle:"
 msgid "Delete"
 msgstr "削除"
 
@@ -2369,7 +2369,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr "プッシュされていない変更が失われたり、ブランチの復元が困難になる可能性があります!"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr "$1個のローカルブランチを削除しますか？"
 
@@ -2377,7 +2377,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr "$1 件のローカル ブランチを削除しますか?"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle:"
 msgid "Delete"
 msgstr "削除"
 
@@ -2409,7 +2409,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.fur:"
 msgid "Your local branch is tracking branch '$1'. Decide whether you also want to delete this branch from the remote repository."
 msgstr "ローカルブランチが '$1' ブランチを追跡しています。リモートリポジトリからもこのブランチを削除するか検討してください。"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "ローカルブランチ'$1'を削除しますか？"
 
@@ -2417,7 +2417,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "ローカル ブランチ '$1' を削除しますか?"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle:"
 msgid "Delete"
 msgstr "削除"
 
@@ -2425,7 +2425,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.btn:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.tle"
+msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.tle:"
 msgid "Delete"
 msgstr ""
 
@@ -2433,7 +2433,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "削除"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr "リモートリポジトリ '$1' から削除する"
 
@@ -2445,11 +2445,11 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr "リモートリポジトリ'$1'から削除"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur:"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
 msgstr "ローカルにあるリモートブランチリストからブランチを削除するだけで、次のフェッチでブランチが復活する可能性があります。"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the branch '$1'?"
 msgstr "ブランチ '$1' を削除しますか？"
 
@@ -2461,7 +2461,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr "リモートブランチ'$1'を削除しますか？"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle:"
 msgid "Delete"
 msgstr "削除"
 
@@ -2469,15 +2469,15 @@ msgctxt "dlgSgBranchTrackingResetConfirm.btn:"
 msgid "Stop Tracking"
 msgstr "追跡を停止"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.fur"
+msgctxt "dlgSgBranchTrackingResetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "必要な設定は .git/config ファイルで行います。"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.hdl"
+msgctxt "dlgSgBranchTrackingResetConfirm.hdl:"
 msgid "Should branch '$1' stop tracking '$2'?"
 msgstr "ブランチ'$1'は'$2'の追跡を停止しますか?"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.tle"
+msgctxt "dlgSgBranchTrackingResetConfirm.tle:"
 msgid "Stop Tracking"
 msgstr "追跡を停止"
 
@@ -2485,15 +2485,15 @@ msgctxt "dlgSgBranchTrackingSetConfirm.btn:"
 msgid "Configure"
 msgstr "設定"
 
-msgctxt "dlgSgBranchTrackingSetConfirm.fur"
+msgctxt "dlgSgBranchTrackingSetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "必要な設定は .git/config ファイルで行います。"
 
-msgctxt "dlgSgBranchTrackingSetConfirm.hdl"
+msgctxt "dlgSgBranchTrackingSetConfirm.hdl:"
 msgid "Do you want to configure '$1' to track '$2'?"
 msgstr "$1'を'$2'に追従させるように設定しますか？"
 
-msgctxt "dlgSgBranchTrackingSetConfirm.tle"
+msgctxt "dlgSgBranchTrackingSetConfirm.tle:"
 msgid "Set Tracked Branch"
 msgstr "追跡ブランチの設定"
 
@@ -2513,11 +2513,11 @@ msgctxt "dlgSgBugReportSettings.err:"
 msgid "Sending 'crash footprints' is required for preview builds, because their main purposes is to get as much as possible bugs reported and fixed before release."
 msgstr "プレビュービルドには「クラッシュフットプリント」を送信する必要があります。\\rこれは、プレビュービルドの主な目的が、リリース前にできるだけ多くのバグを報告して修正することであるためです。"
 
-msgctxt "dlgSgBugReportSettings.hdl"
+msgctxt "dlgSgBugReportSettings.hdl:"
 msgid "Crash Reporting"
 msgstr "クラッシュレポート"
 
-msgctxt "dlgSgBugReportSettings.inf"
+msgctxt "dlgSgBugReportSettings.inf:"
 msgid "Please help to improve SmartGit's quality by automatically sending 'crash footprints'."
 msgstr "「クラッシュ フットプリント」と使用状況統計を自動的に送信することで、SmartGit の品質向上にご協力ください。 \" このオプションは、後で [環境設定] で変更できます。"
 
@@ -2529,7 +2529,7 @@ msgctxt "dlgSgBugReportSettings.lbl:"
 msgid "Sent data contains \\*no potentially sensitive information\\* like user names, email addresses, file contents, file paths or server names."
 msgstr "送信されるデータには、ユーザー名、メールアドレス、ファイルの内容、ファイルパス、サーバー名などの\\*機密情報になり得る情報\\*は一切含まれていません。"
 
-msgctxt "dlgSgBugReportSettings.tle"
+msgctxt "dlgSgBugReportSettings.tle:"
 msgid "SmartGit"
 msgstr "SmartGit"
 
@@ -2541,15 +2541,15 @@ msgctxt "dlgSgCheckout.btn:"
 msgid "Check Out"
 msgstr "チェックアウト"
 
-msgctxt "dlgSgCheckout.hdl"
+msgctxt "dlgSgCheckout.hdl:"
 msgid "Check out a commit"
 msgstr "コミットをチェックアウトする"
 
-msgctxt "dlgSgCheckout.inf"
+msgctxt "dlgSgCheckout.inf:"
 msgid "Select the commit to check out. This allows to switch \\(back\\) the working tree to any commit."
 msgstr "チェックアウトするコミットを選択します。これにより、作業ツリーを任意のコミットに切り替える\\(戻す\\)ことができます。"
 
-msgctxt "dlgSgCheckout.tle"
+msgctxt "dlgSgCheckout.tle:"
 msgid "Check Out"
 msgstr "チェックアウト"
 
@@ -2561,15 +2561,15 @@ msgctxt "dlgSgCheckoutFastForwardMerge.btn:"
 msgid "Just Checkout"
 msgstr "チェックアウトのみ"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.fur"
+msgctxt "dlgSgCheckoutFastForwardMerge.fur:"
 msgid "Fast-forward-merging automatically moves the branch forward to the tracked remote branch."
 msgstr "ファストフォワードマージは、ブランチを追跡対象のリモート ブランチに自動的に移動します。"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.hdl"
+msgctxt "dlgSgCheckoutFastForwardMerge.hdl:"
 msgid "Do you want to fast-forward-merge remote changes after checking out '$1'?"
 msgstr "$1'をチェックアウトした後、リモートの変更を ファストフォワードマージしますか？"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.tle"
+msgctxt "dlgSgCheckoutFastForwardMerge.tle:"
 msgid "Check Out"
 msgstr "チェックアウト"
 
@@ -2577,19 +2577,19 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.btn:"
 msgid "Checkout"
 msgstr "チェックアウト"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.chk"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.fur"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.fur:"
 msgid "This will make '$1' your current branch."
 msgstr "この操作により '$1' が現在のブランチになります。"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl:"
 msgid "Do you want to checkout the branch '$1'?"
 msgstr "ブランチ '$1' をチェックアウトしますか？"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.tle"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.tle:"
 msgid "Check Out"
 msgstr "チェックアウト"
 
@@ -2621,7 +2621,7 @@ msgctxt "dlgSgCheckoutTarget.hdl:"
 msgid "Checkout remote branch"
 msgstr "リモートブランチのチェックアウト"
 
-msgctxt "dlgSgCheckoutTarget.inf"
+msgctxt "dlgSgCheckoutTarget.inf:"
 msgid "Create and checkout a new local branch for the selected commit"
 msgstr "ローカルブランチではなくコミットをチェックアウトする場合は注意してください。コミットの上にあるコミットは簡単に失われてしまう可能性があります。"
 
@@ -2641,7 +2641,7 @@ msgctxt "dlgSgCheckoutTarget.rbt:"
 msgid "Don't create local branch \\(just work read-only\\)"
 msgstr "ローカルブランチを作成しない \\(読み取り専用で作業\\)"
 
-msgctxt "dlgSgCheckoutTarget.tle"
+msgctxt "dlgSgCheckoutTarget.tle:"
 msgid "Check Out"
 msgstr "チェックアウト"
 
@@ -2669,15 +2669,15 @@ msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.btn:"
 msgid "Overwrite"
 msgstr "上書き"
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr "「キャンセル」をクリックすると、別のブランチ名を選択することができます。"
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr "ブランチ '$1' はすでに存在しています。上書きしますか？"
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.tle"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.tle:"
 msgid "Check Out"
 msgstr "チェックアウト"
 
@@ -2685,7 +2685,7 @@ msgctxt "dlgSgCherryPickConfigurationFile.btn:"
 msgid "Cherry-Pick"
 msgstr "チェリーピック"
 
-msgctxt "dlgSgCherryPickConfigurationFile.fur"
+msgctxt "dlgSgCherryPickConfigurationFile.fur:"
 msgid "Only changes of these files will be cherry-picked \\(without committing\\)."
 msgstr "これらのファイルの変更点のみが（コミットせずに）チェリーピックされます。"
 
@@ -2697,7 +2697,7 @@ msgctxt "dlgSgCherryPickConfigurationFile.hdl:"
 msgid "Do you want to cherry-pick changes of '$1'?"
 msgstr "'$1' の変更をチェリーピックしますか?"
 
-msgctxt "dlgSgCherryPickConfigurationFile.tle"
+msgctxt "dlgSgCherryPickConfigurationFile.tle:"
 msgid "Cherry-Pick"
 msgstr "チェリーピック"
 
@@ -2709,35 +2709,35 @@ msgctxt "dlgSgCherryPickConfirmation.btn:"
 msgid "Cherry-Pick"
 msgstr "チェリーピック"
 
-msgctxt "dlgSgCherryPickConfirmation.chk"
+msgctxt "dlgSgCherryPickConfirmation.chk:"
 msgid "Append source commit ID to commit message"
 msgstr "コミットメッセージにソースSHAを追加する"
 
-msgctxt "dlgSgCherryPickConfirmation.fur"
+msgctxt "dlgSgCherryPickConfirmation.fur:"
 msgid "This will cherry-pick the selected commit into the Working Tree."
 msgstr "これにより、選択されたコミットが作業ツリーにチェリーピックされます。"
 
-msgctxt "dlgSgCherryPickConfirmation.hdl"
+msgctxt "dlgSgCherryPickConfirmation.hdl:"
 msgid "Do you want to cherry-pick?"
 msgstr "チェリーピックしますか？"
 
-msgctxt "dlgSgCherryPickConfirmation.tle"
+msgctxt "dlgSgCherryPickConfirmation.tle:"
 msgid "Cherry-Pick"
 msgstr "チェリーピック"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.chk"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.fur"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.fur:"
 msgid "You may need to resolve the conflicts before proceeding."
 msgstr "先に進む前に、コンフリクトを解消する必要があるかもしれません。"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.hdl"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.hdl:"
 msgid "Cherry-picking failed because of conflicts."
 msgstr "チェリーピッキングはコンフリクトのため失敗しました。"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.tle"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.tle:"
 msgid "Cherry Pick"
 msgstr "チェリーピック"
 
@@ -2745,15 +2745,15 @@ msgctxt "dlgSgCherryPickUnpushedCommits.btn:"
 msgid "Cherry-Pick"
 msgstr "チェリーピック"
 
-msgctxt "dlgSgCherryPickUnpushedCommits.fur"
+msgctxt "dlgSgCherryPickUnpushedCommits.fur:"
 msgid "At least one of the selected commits has not been pushed yet, hence cherry-pick is only local and won't be translated to SVN \\(mergeinfo\\)."
 msgstr "選択されたコミットのうち少なくとも一つはまだプッシュされていないため、チェリーピックはローカルにのみ適用され、SVN\\(マージ情報\\)には変換されません。"
 
-msgctxt "dlgSgCherryPickUnpushedCommits.hdl"
+msgctxt "dlgSgCherryPickUnpushedCommits.hdl:"
 msgid "Do you want to cherry-pick unpushed commits?"
 msgstr "プッシュされていないコミットをチェリーピックしますか？"
 
-msgctxt "dlgSgCherryPickUnpushedCommits.tle"
+msgctxt "dlgSgCherryPickUnpushedCommits.tle:"
 msgid "Cherry-Pick"
 msgstr "チェリーピック"
 
@@ -2773,11 +2773,11 @@ msgctxt "dlgSgClean.edt:"
 msgid "Delete"
 msgstr "削除"
 
-msgctxt "dlgSgClean.hdl"
+msgctxt "dlgSgClean.hdl:"
 msgid "Delete unversioned files"
 msgstr "バージョン管理されていないファイルの削除"
 
-msgctxt "dlgSgClean.inf"
+msgctxt "dlgSgClean.inf:"
 msgid "Select which unversioned files should be deleted."
 msgstr "どの未追跡ファイルを削除するかを選択します。"
 
@@ -2801,7 +2801,7 @@ msgctxt "dlgSgClean.rbt:"
 msgid "Untracked"
 msgstr "未追跡"
 
-msgctxt "dlgSgClean.tle"
+msgctxt "dlgSgClean.tle:"
 msgid "Clean Working Tree"
 msgstr "作業ツリーのクリーンアップ"
 
@@ -2809,27 +2809,27 @@ msgctxt "dlgSgCleanDeleteFiles.btn:"
 msgid "Delete Files"
 msgstr "ファイルを削除する"
 
-msgctxt "dlgSgCleanDeleteFiles.fur"
+msgctxt "dlgSgCleanDeleteFiles.fur:"
 msgid "Git reported following files and directories to be deleted:"
 msgstr "Git は以下のファイルとディレクトリが削除されたと報告しました。:"
 
-msgctxt "dlgSgCleanDeleteFiles.hdl"
+msgctxt "dlgSgCleanDeleteFiles.hdl:"
 msgid "Do you want to delete these files?"
 msgstr "これらのファイルを削除しますか？"
 
-msgctxt "dlgSgCleanDeleteFiles.tle"
+msgctxt "dlgSgCleanDeleteFiles.tle:"
 msgid "Clean Working Tree"
 msgstr "作業ツリーのクリーンアップ"
 
-msgctxt "dlgSgCleanNoFilesFound.fur"
+msgctxt "dlgSgCleanNoFilesFound.fur:"
 msgid "Your repository only seems to contain tracked files."
 msgstr "リポジトリには追跡されたファイルのみが含まれているようです。"
 
-msgctxt "dlgSgCleanNoFilesFound.hdl"
+msgctxt "dlgSgCleanNoFilesFound.hdl:"
 msgid "No files found to be deleted."
 msgstr "削除対象のファイルが見つかりませんでした。"
 
-msgctxt "dlgSgCleanNoFilesFound.tle"
+msgctxt "dlgSgCleanNoFilesFound.tle:"
 msgid "Clean Working Tree"
 msgstr "作業ツリーのクリーンアップ"
 
@@ -2861,7 +2861,7 @@ msgctxt "dlgSgClone.chk:"
 msgid "Map SVN trunk, tags and branches to Git"
 msgstr "SVNのトランク、タグ、ブランチをGitにマップする"
 
-msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\""
+msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
 msgid "Skip large files \\(\"partial clone\"\\)"
 msgstr "大きなファイルをスキップする \\(\"partial clone\"\\)"
 
@@ -3009,7 +3009,7 @@ msgctxt "dlgSgClone.rbt:"
 msgid "Remote repository"
 msgstr "リモートリポジトリ"
 
-msgctxt "dlgSgClone.tle"
+msgctxt "dlgSgClone.tle:"
 msgid "Clone"
 msgstr "クローン"
 
@@ -3025,15 +3025,15 @@ msgctxt "dlgSgClone.ttpPartialWarning:"
 msgid "This functionality depends on the capabilities of your server."
 msgstr "この機能はサーバーの機能に依存します。"
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.fur"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.fur:"
 msgid "Please select an empty, local directory for the new repository."
 msgstr "新しいリポジトリ用に空のローカル ディレクトリを選択してください。"
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.hdl"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.hdl:"
 msgid "The selected directory is a Git repository."
 msgstr "選択されたディレクトリはGitリポジトリです。"
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.tle"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.tle:"
 msgid "Input Validation"
 msgstr "入力の検証"
 
@@ -3045,15 +3045,15 @@ msgctxt "dlgSgCloneRepositoryType.btn:"
 msgid "SVN"
 msgstr "SVN"
 
-msgctxt "dlgSgCloneRepositoryType.fur"
+msgctxt "dlgSgCloneRepositoryType.fur:"
 msgid "The specified URL protocol is ambiguous and may refer to different types of repositories."
 msgstr "指定された URL プロトコルがあいまいで、異なるタイプのリポジトリを参照している可能性があります。"
 
-msgctxt "dlgSgCloneRepositoryType.hdl"
+msgctxt "dlgSgCloneRepositoryType.hdl:"
 msgid "Select the type of repository you are going to clone."
 msgstr "クローンを作成するリポジトリの種類を選択します。"
 
-msgctxt "dlgSgCloneRepositoryType.tle"
+msgctxt "dlgSgCloneRepositoryType.tle:"
 msgid "Clone"
 msgstr "クローン"
 
@@ -3065,11 +3065,11 @@ msgctxt "dlgSgCloneSetCredentialHelper.btn:"
 msgid "Set SmartGit as Credential-Helper"
 msgstr "SmartGit を Credential-Helper として設定する"
 
-msgctxt "dlgSgCloneSetCredentialHelper.fur"
+msgctxt "dlgSgCloneSetCredentialHelper.fur:"
 msgid "If selected, SmartGit will be set as `credential.helper` in the `.git\\\\/config` of newly cloned repositories that are cloned directly from a configured Hosting Provider. Executing remote Git commands \\(e.g. \\*pull\\* or \\*push\\*\\) in the terminal or a shell script will then use the credentials known to SmartGit.\\n\\nThis repository setting will only affect new clones and takes precedence over any `credential.helper` configuration in your user `~\\\\/.gitconfig`.\\n\\nFor already cloned repositories the setting \\*Use SmartGit as credential helper\\* can be changed in \\*Repository \\| Settings\\*.\\n\\n\\*When to select?\\*\\nIf you solely use SmartGit as your GUI client and you use Git from the command line, we suggest selecting this option. It will simplify the authentication process when accessing platforms like GitHub.\\n\\n\\*When not to set?\\*\\nIf you also use other GUI clients, adding this configuration may disrupt the authentication of these tools and should be avoided.\\n\\nIf you do not use Git on command line or other GUI clients, selecting this option serves no purpose and is not recommended."
 msgstr "選択した場合、設定済みのホスティングプロバイダーから直接クローンされた新しいリポジトリの `.git/config` に、SmartGit が `credential.helper` として設定されます。ターミナルまたはシェルスクリプトでリモート Git コマンド (例: *pull* または *push*) を実行すると、SmartGit に認識されている資格情報が使用されます。\\n\\nこのリポジトリ設定は、新しいクローンにのみ影響し、ユーザーの `~/.gitconfig` にある `credential.helper` 設定よりも優先されます。\\n\\n既にクローンされているリポジトリの場合、*SmartGit を認証ヘルパーとして使用する* 設定は、*リポジトリ | 設定* で変更できます。\\n\\n*いつ選択するか？*\\nSmartGit のみを GUI クライアントとして使用し、コマンドラインから Git を使用する場合は、このオプションを選択することをお勧めします。GitHub などのプラットフォームにアクセスする際の認証プロセスが簡素化されます。\\n\\n*いつ設定しないか？*\\n他の GUI クライアントも使用している場合、この設定を追加すると、これらのツールの認証が中断される可能性があるため、避ける必要があります。\\n\\nコマンドラインまたは他の GUI クライアントで Git を使用しない場合、このオプションを選択しても意味がないため、推奨されません。"
 
-msgctxt "dlgSgCloneSetCredentialHelper.hdl"
+msgctxt "dlgSgCloneSetCredentialHelper.hdl:"
 msgid "Do you want to configure SmartGit as credential helper?"
 msgstr "SmartGit を認証ヘルパーとして設定しますか？"
 
@@ -3077,19 +3077,19 @@ msgctxt "dlgSgCloneSetCredentialHelper.mni:"
 msgid "Copy"
 msgstr "コピー"
 
-msgctxt "dlgSgCloneSetCredentialHelper.tle"
+msgctxt "dlgSgCloneSetCredentialHelper.tle:"
 msgid "Clone"
 msgstr "クローン"
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.fur"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.fur:"
 msgid "SmartGit now continues to fetch all other revisions in the background. You may safely start working with the repository now; only log-related operations will be affected by this intermediate state.\\n\\nOnce SmartGit has finished the background part of the clone, it will let you know in the notifications area \\(status bar\\) and you can complete the clone there."
 msgstr "SmartGit は現在、バックグラウンドで他のすべてのリビジョンの取得を続けています。ログ関連の操作だけが、この中間状態の影響を受けます。\\n\\nSmartGit がバックグラウンドでのクローンを完了すると、通知領域でそれを知らせますので、そこでクローンを完了することができます。"
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.hdl"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.hdl:"
 msgid "HEAD revision has been successfully cloned."
 msgstr "HEADリビジョンのクローンに成功しました。"
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.tle"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.tle:"
 msgid "Clone"
 msgstr "クローン"
 
@@ -3153,11 +3153,11 @@ msgctxt "dlgSgCommit.err:"
 msgid "Select at least one file to commit."
 msgstr "コミットするファイルを少なくとも 1 つ選択してください。"
 
-msgctxt "dlgSgCommit.hdl"
+msgctxt "dlgSgCommit.hdl:"
 msgid "Commit local or staged changes"
 msgstr "ローカルまたはステージングされた変更のコミット"
 
-msgctxt "dlgSgCommit.inf"
+msgctxt "dlgSgCommit.inf:"
 msgid "Select the files you want to commit and provide a commit message."
 msgstr "コミットしたいファイルを選択し、コミットメッセージを記入します。"
 
@@ -3197,7 +3197,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Merge commit \\(multiple parents\\)"
 msgstr "マージ コミット \\(複数の親\\)"
 
-msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\""
+msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
 msgid "Simple commit \\(one parent, \"squash\"\\)"
 msgstr "シンプルなコミット \\(一つの親 、\"スカッシュ\" \\)"
 
@@ -3205,7 +3205,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Staged Changes"
 msgstr "ステージされた変更"
 
-msgctxt "dlgSgCommit.tle"
+msgctxt "dlgSgCommit.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -3221,27 +3221,27 @@ msgctxt "dlgSgCommitAmendAlreadyPushedCommit.btn:"
 msgid "Amend"
 msgstr "修正する"
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.fur"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.fur:"
 msgid "If you amend a pushed commit, you will need to force-push it later. This might overwrite other users' changes."
 msgstr "プッシュしたコミットを修正した場合、後で強制的にプッシュする必要があります。\\rこの場合、他のユーザーの変更を上書きしてしまう可能性があります。"
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.hdl"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.hdl:"
 msgid "Do you want to amend an already pushed commit?"
 msgstr "すでにプッシュされているコミットを修正しますか？"
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.tle"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.tle:"
 msgid "Commit"
 msgstr "コミット"
 
-msgctxt "dlgSgCommitCantAmend.fur"
+msgctxt "dlgSgCommitCantAmend.fur:"
 msgid "Can't modify an already pushed commit. If you know what you are doing and want to enable it, select the option 'Allow modifying pushed commits' in the preferences."
 msgstr "すでにプッシュされたコミットを変更することはできません。何をしているのか分かっていて有効にしたい場合は、設定で「プッシュされたコミットの変更を許可する」オプションを選択してください。"
 
-msgctxt "dlgSgCommitCantAmend.hdl"
+msgctxt "dlgSgCommitCantAmend.hdl:"
 msgid "Can't amend commit."
 msgstr "コミットを修正できません。"
 
-msgctxt "dlgSgCommitCantAmend.tle"
+msgctxt "dlgSgCommitCantAmend.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -3253,15 +3253,15 @@ msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.btn:"
 msgid "Create Commit"
 msgstr "コミットを作成"
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.fur"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.fur:"
 msgid "The repository is in 'rebasing' state. Instead of creating an additional commit as part of your rebased commits, you will usually just want continue the rebase."
 msgstr "リポジトリは「リベース中」の状態です。リベース コミットの一部として追加のコミットを作成する代わりに、通常はリベースを続行するだけです。"
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.hdl"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.hdl:"
 msgid "Do you want to continue the rebase or create an additional commit?"
 msgstr "リベースを続行しますか、それとも追加のコミットを作成しますか?"
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.tle"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -3269,15 +3269,15 @@ msgctxt "dlgSgCommitDirectlyTo.btn:"
 msgid "Commit Anyway"
 msgstr "とにかくコミットする"
 
-msgctxt "dlgSgCommitDirectlyTo.fur"
+msgctxt "dlgSgCommitDirectlyTo.fur:"
 msgid "You have Git-Flow configured and committing to the Git-Flow master branch should not happen directly but only with the help of the Git-Flow commands and merging.\\n\\nIf in doubt, please contact your administrator."
 msgstr "Git-Flow が設定されており、Git-Flow の master ブランチへのコミットは直接行わず、Git-Flow コマンドとマージの助けを借りて行う必要があります。\\n\\n不明な点がある場合は、管理者にお問い合わせください。"
 
-msgctxt "dlgSgCommitDirectlyTo.hdl"
+msgctxt "dlgSgCommitDirectlyTo.hdl:"
 msgid "Do you want to commit directly to 'master'?"
 msgstr "'master' に直接コミットしますか？"
 
-msgctxt "dlgSgCommitDirectlyTo.tle"
+msgctxt "dlgSgCommitDirectlyTo.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -3297,27 +3297,27 @@ msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.chk:"
 msgid "Include untracked files"
 msgstr "追跡されていないファイルを含める"
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.fur"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.fur:"
 msgid "No file is staged yet. To commit all \\(visible\\) working tree changes, click Commit All. To stage individual changes, click Cancel."
 msgstr "まだステージングされているファイルはありません。\\(表示されている\\)作業ツリーのすべての変更をコミットするには、「すべての変更をコミット」 をクリックします。個別の変更をステージングするには、「キャンセル」 をクリックします。"
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.hdl"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.hdl:"
 msgid "Do you want to commit all \\(visible\\) working tree changes?"
 msgstr "すべての \\(表示されている\\) 作業ツリーの変更をコミットしますか?"
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.tle"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.tle:"
 msgid "Commit"
 msgstr "コミット"
 
-msgctxt "dlgSgCommitIndexNoFilesFound.fur"
+msgctxt "dlgSgCommitIndexNoFilesFound.fur:"
 msgid "There is nothing to commit."
 msgstr "コミットするものは何もありません。"
 
-msgctxt "dlgSgCommitIndexNoFilesFound.hdl"
+msgctxt "dlgSgCommitIndexNoFilesFound.hdl:"
 msgid "There is nothing to commit."
 msgstr "コミットするものは何もありません。"
 
-msgctxt "dlgSgCommitIndexNoFilesFound.tle"
+msgctxt "dlgSgCommitIndexNoFilesFound.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -3329,27 +3329,27 @@ msgctxt "dlgSgCommitMessageContainsComments.btn:"
 msgid "Strip Comments"
 msgstr "コメントを除去"
 
-msgctxt "dlgSgCommitMessageContainsComments.fur"
+msgctxt "dlgSgCommitMessageContainsComments.fur:"
 msgid "The commit message contains lines starting with # which Git would treat as comment \\(and thus strip from the message\\).\\n\\nFor advanced comment-handling you may consider to use Git's config option 'core.commentChar'.\\n\\nIf you always want to keep or strip comment lines, you can configure this in the Preferences."
 msgstr "コミット メッセージには # で始まる行が含まれており、Git はこれをコメントとして扱います \\(したがって、メッセージから削除されます\\)。\\n\\n高度なコメント処理については、Git の設定オプション'core.commentChar'を使用してください。\\n\\nコメント行を常に保持するか、削除するかを指定するには、環境設定で設定することができます。"
 
-msgctxt "dlgSgCommitMessageContainsComments.hdl"
+msgctxt "dlgSgCommitMessageContainsComments.hdl:"
 msgid "Should comment lines be committed as-is?"
 msgstr "コメント行はそのままコミットすべきですか？"
 
-msgctxt "dlgSgCommitMessageContainsComments.tle"
+msgctxt "dlgSgCommitMessageContainsComments.tle:"
 msgid "Commit"
 msgstr "コミット"
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.fur"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.fur:"
 msgid "Neither staged files nor locally changed files were found."
 msgstr "ステージングされたファイルやローカルで変更されたファイルは見つかりませんでした。"
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.hdl"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.hdl:"
 msgid "There is nothing to commit."
 msgstr "コミットするものは何もありません。"
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.tle"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -3365,7 +3365,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.chk:"
 msgid "Add 'fixup!' prefix for easier automatic squashing using Interactive Rebase"
 msgstr "インタラクティブなリベースを使用した自動スカッシュを容易にするために、'fixup!' プレフィックスを追加します。"
 
-msgctxt "dlgSgCommitSelectMessageFromLog.hdl"
+msgctxt "dlgSgCommitSelectMessageFromLog.hdl:"
 msgid "Select a commit"
 msgstr "コミットを選択する"
 
@@ -3373,7 +3373,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
 msgid "No repository selected."
 msgstr "リポジトリが選択されていません。"
 
-msgctxt "dlgSgCommitSelectMessageFromLog.inf"
+msgctxt "dlgSgCommitSelectMessageFromLog.inf:"
 msgid "Choose the commit whose message should be used."
 msgstr "メッセージを使用するコミットを選択します。"
 
@@ -3433,7 +3433,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.tbt:"
 msgid "Interpret the search pattern as regular expression."
 msgstr ""
 
-msgctxt "dlgSgCommitSelectMessageFromLog.tle"
+msgctxt "dlgSgCommitSelectMessageFromLog.tle:"
 msgid "Select Commit Message"
 msgstr "コミットメッセージを選択"
 
@@ -3445,15 +3445,15 @@ msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.btn:"
 msgid "Commit File"
 msgstr "ファイルをコミット"
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.fur"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.fur:"
 msgid "You either can commit the single selected file or all \\(visible\\) changed files."
 msgstr "単一の選択されたファイルをコミットするか、すべての \\(表示されている\\) 変更されたファイルをコミットできます。"
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.hdl"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.hdl:"
 msgid "What do you want to commit?"
 msgstr "何をコミットしますか？"
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.tle"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -3461,15 +3461,15 @@ msgctxt "dlgSgCommitToDetachedHead.btn:"
 msgid "Commit Anyway"
 msgstr "とにかくコミットする"
 
-msgctxt "dlgSgCommitToDetachedHead.fur"
+msgctxt "dlgSgCommitToDetachedHead.fur:"
 msgid "The repository HEAD currently does not point to a branch, but directly refers to a commit \\(SHA\\). When committing, the newly created commit will only be reachable by its SHA and hence may get lost easily.\\n\\nInstead of committing now, you should first create a branch for your current HEAD and commit afterwards."
 msgstr "リポジトリの HEAD は現在、ブランチを指しておらず、コミット(SHA)を直接参照しています。コミットする際に、新しく作成したコミットはSHAでしか到達できないため、簡単に見失ってしまう可能性があります。今すぐコミットするのではなく、まず現在のHEADにブランチを作成し、その後にコミットしてください。"
 
-msgctxt "dlgSgCommitToDetachedHead.hdl"
+msgctxt "dlgSgCommitToDetachedHead.hdl:"
 msgid "Do you want to commit to a detached HEAD?"
 msgstr "切り離されたHEADにコミットしますか?"
 
-msgctxt "dlgSgCommitToDetachedHead.tle"
+msgctxt "dlgSgCommitToDetachedHead.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -3481,23 +3481,23 @@ msgctxt "dlgSgCompareTwoFiles.btn:"
 msgid "Compare with Repository"
 msgstr "リポジトリとの比較"
 
-msgctxt "dlgSgCompareTwoFiles.fur"
+msgctxt "dlgSgCompareTwoFiles.fur:"
 msgid "The files can be compared to their repository content or to each other."
 msgstr "ファイルはリポジトリの内容と比較したり、ファイル同士で比較することができます。"
 
-msgctxt "dlgSgCompareTwoFiles.hdl"
+msgctxt "dlgSgCompareTwoFiles.hdl:"
 msgid "Should the selected two files be compared with each other?"
 msgstr "選択された2つのファイルを比較しますか？"
 
-msgctxt "dlgSgCompareTwoFiles.tle"
+msgctxt "dlgSgCompareTwoFiles.tle:"
 msgid "Compare"
 msgstr "比較"
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.fur"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.fur:"
 msgid "To prevent overwriting intentional mixed line-endings, editing and saving is disabled."
 msgstr "意図的に混在させた可能性がある行末の改行コードの上書きを防ぐため、編集と保存を無効にしています。"
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl:"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr "右側のファイルは、改行コードが混在しているため編集できません。"
 
@@ -3505,15 +3505,15 @@ msgctxt "dlgSgConflictResolverExternalStarted.btn:"
 msgid "Mark Resolved"
 msgstr "解決済みとしてマーク"
 
-msgctxt "dlgSgConflictResolverExternalStarted.fur"
+msgctxt "dlgSgConflictResolverExternalStarted.fur:"
 msgid "The external conflict solver has been started. After you have resolved the conflict, you may now mark the file as resolved."
 msgstr "外部コンフリクトソルバーが開始されました。競合を解決した後、ファイルを解決済みとしてマークすることができます。"
 
-msgctxt "dlgSgConflictResolverExternalStarted.hdl"
+msgctxt "dlgSgConflictResolverExternalStarted.hdl:"
 msgid "Do you want to mark the file as resolved?"
 msgstr "ファイルを解決済みとしてマークしますか？"
 
-msgctxt "dlgSgConflictResolverExternalStarted.tle"
+msgctxt "dlgSgConflictResolverExternalStarted.tle:"
 msgid "External Conflict Solver"
 msgstr "外部コンフリクトソルバー"
 
@@ -3525,15 +3525,15 @@ msgctxt "dlgSgConflictSolverMarkResolved.btn:"
 msgid "Mark Resolved"
 msgstr "解決済みとしてマーク"
 
-msgctxt "dlgSgConflictSolverMarkResolved.fur"
+msgctxt "dlgSgConflictSolverMarkResolved.fur:"
 msgid "To complete a conflict resolution, the file needs to be marked as resolved \\(git stage\\). Until marked as resolved, the file remains in conflicted state and you can try other conflict resolutions."
 msgstr "競合の解決を完了するには、そのファイルを解決済みとしてマークする必要があります。 \\(git stage\\)\\n 解決済みとマークされるまでは、ファイルは競合状態のままであり、他の競合解決を試すことができます。"
 
-msgctxt "dlgSgConflictSolverMarkResolved.hdl"
+msgctxt "dlgSgConflictSolverMarkResolved.hdl:"
 msgid "Do you want to mark the file as resolved?"
 msgstr "ファイルを解決済みとしてマークしますか？"
 
-msgctxt "dlgSgConflictSolverMarkResolved.tle"
+msgctxt "dlgSgConflictSolverMarkResolved.tle:"
 msgid "Mark Resolved"
 msgstr "解決済みとしてマーク"
 
@@ -3545,15 +3545,15 @@ msgctxt "dlgSgConflictSolverStageForCommit.btn:"
 msgid "Stage"
 msgstr "ステージ"
 
-msgctxt "dlgSgConflictSolverStageForCommit.fur"
+msgctxt "dlgSgConflictSolverStageForCommit.fur:"
 msgid "Staging is necessary to resolve the file's conflict status."
 msgstr "ファイルの競合状態を解消するためには、ステージングが必要です。"
 
-msgctxt "dlgSgConflictSolverStageForCommit.hdl"
+msgctxt "dlgSgConflictSolverStageForCommit.hdl:"
 msgid "Do you want to stage the file for commit now?"
 msgstr "今すぐコミットするためにファイルをステージングしますか？"
 
-msgctxt "dlgSgConflictSolverStageForCommit.tle"
+msgctxt "dlgSgConflictSolverStageForCommit.tle:"
 msgid "Stage for Commit"
 msgstr "コミットするためにステージ"
 
@@ -3617,7 +3617,7 @@ msgctxt "dlgSgCustomizeProjectUi.tab:"
 msgid "Toolbar"
 msgstr "ツールバー"
 
-msgctxt "dlgSgCustomizeProjectUi.tle"
+msgctxt "dlgSgCustomizeProjectUi.tle:"
 msgid "Customize"
 msgstr "カスタマイズ"
 
@@ -3629,23 +3629,23 @@ msgctxt "dlgSgDeleteDirTrash.btn:"
 msgid "Move to Trash"
 msgstr "ゴミ箱へ移動"
 
-msgctxt "dlgSgDeleteDirTrash.fur"
+msgctxt "dlgSgDeleteDirTrash.fur:"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr "「削除」をクリックすると、削除されたファイルを復元するためにファイル復旧ツールが必要になる可能性があります!"
 
-msgctxt "dlgSgDeleteDirTrash.hdl"
+msgctxt "dlgSgDeleteDirTrash.hdl:"
 msgid "Do you want to delete '$1' recursively?"
 msgstr "'$1' を再帰的に削除しますか？"
 
-msgctxt "dlgSgDeleteDirTrash.tle"
+msgctxt "dlgSgDeleteDirTrash.tle:"
 msgid "Delete"
 msgstr "削除"
 
-msgctxt "dlgSgDeleteFileTrash.hdl"
+msgctxt "dlgSgDeleteFileTrash.hdl:"
 msgid "Do you want to delete '$1'?"
 msgstr "'$1'を削除しますか？"
 
-msgctxt "dlgSgDeleteFilesTrash.hdl"
+msgctxt "dlgSgDeleteFilesTrash.hdl:"
 msgid "Do you want to delete the $1 selected files?"
 msgstr "選択した$1個のファイルを削除しますか？"
 
@@ -3669,11 +3669,11 @@ msgctxt "dlgSgDiscard.edt:"
 msgid "Revert to"
 msgstr "次の状態に戻す"
 
-msgctxt "dlgSgDiscard.hdl"
+msgctxt "dlgSgDiscard.hdl:"
 msgid "Discard local or staged changes"
 msgstr "ローカルまたはステージングされた変更を破棄する"
 
-msgctxt "dlgSgDiscard.inf"
+msgctxt "dlgSgDiscard.inf:"
 msgid "Select the files for which changes should be discarded and whether to set them back to Index or HEAD state."
 msgstr "変更を破棄するファイルと、インデックスとHEADのどちらの状態に戻すかを選択します。"
 
@@ -3713,39 +3713,39 @@ msgctxt "dlgSgDiscard.rbt:"
 msgid "Index"
 msgstr "インデックス"
 
-msgctxt "dlgSgDiscard.tle"
+msgctxt "dlgSgDiscard.tle:"
 msgid "Discard"
 msgstr "破棄"
 
-msgctxt "dlgSgDiscardNoFilesFound.fur"
+msgctxt "dlgSgDiscardNoFilesFound.fur:"
 msgid "Neither staged files nor locally changed files were found."
 msgstr "ステージングされたファイルやローカルで変更されたファイルは見つかりませんでした。"
 
-msgctxt "dlgSgDiscardNoFilesFound.hdl"
+msgctxt "dlgSgDiscardNoFilesFound.hdl:"
 msgid "There is nothing to discard."
 msgstr "破棄するものはありません。"
 
-msgctxt "dlgSgDiscardNoFilesFound.tle"
+msgctxt "dlgSgDiscardNoFilesFound.tle:"
 msgid "Discard"
 msgstr "破棄"
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.fur"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.fur:"
 msgid "You have selected to discard only the Index changes of one or more files. However, at least one of the files is also modified in the working tree. It is not possible to discard only Index changes in this case.\\n\\nIf you actually want to discard the working tree changes, select the file in the working tree table."
 msgstr "1つ以上のファイルのインデックスの変更のみを破棄するように選択しました。ただし、少なくとも1つのファイルは作業ツリーでも変更されています。この場合、インデックスの変更のみを破棄することはできません。\\n\\n作業ツリーの変更を実際に破棄したい場合は、作業ツリー テーブルのファイルを選択してください。"
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.hdl"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.hdl:"
 msgid "Discarding Index changes is not possible."
 msgstr "インデックスの変更を破棄することはできません。"
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle:"
 msgid "Discard"
 msgstr "破棄"
 
-msgctxt "dlgSgDiscardRevertToHead.hdl"
+msgctxt "dlgSgDiscardRevertToHead.hdl:"
 msgid "Do you want to reset $1 files back to their HEAD state?"
 msgstr "$1 個のファイルを HEAD の状態に戻しますか?"
 
-msgctxt "dlgSgDiscardRevertToIndex.hdl"
+msgctxt "dlgSgDiscardRevertToIndex.hdl:"
 msgid "Do you want to reset $1 files back to their Index state?"
 msgstr "$1 個のファイルをインデックスの状態に戻しますか?"
 
@@ -3753,17 +3753,17 @@ msgctxt "dlgSgDiscardRevertTo(Head|Index).btn:"
 msgid "Discard"
 msgstr "破棄"
 
-msgctxt "dlgSgDiscardRevertTo(Head|Index).fur"
+msgctxt "dlgSgDiscardRevertTo(Head|Index).fur:"
 msgid "The content might be hard to restore!"
 msgstr "内容を復元するのは難しいかもしれません。"
 
-msgctxt "dlgSgDiscardRevertTo(Head|Index).tle"
+msgctxt "dlgSgDiscardRevertTo(Head|Index).tle:"
 msgid "Discard"
 msgstr "破棄"
 
 # Needs review: Check whether the URL needs to be made variable
 #, fuzzy
-msgctxt "dlgSgErrorUtilsClientException.fur"
+msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
 msgstr "サーバーが URL: https://gitlab.com/oauth/token に対して HTTP 応答コード: 400 を返しました"
 
@@ -3787,11 +3787,11 @@ msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "svn: $1"
 msgstr "svn: $1"
 
-msgctxt "dlgSgErrorUtilsClientException.hdl"
+msgctxt "dlgSgErrorUtilsClientException.hdl:"
 msgid "Executing a command has failed."
 msgstr "コマンドの実行に失敗しました。"
 
-msgctxt "dlgSgErrorUtilsClientException.tle"
+msgctxt "dlgSgErrorUtilsClientException.tle:"
 msgid "Command Failed"
 msgstr "コマンドの失敗"
 
@@ -3799,19 +3799,19 @@ msgctxt "dlgSgExitConfirmation.btn:"
 msgid "Exit Now"
 msgstr "終了する"
 
-msgctxt "dlgSgExitConfirmation.chk"
+msgctxt "dlgSgExitConfirmation.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgExitConfirmation.fur"
+msgctxt "dlgSgExitConfirmation.fur:"
 msgid "By closing the last window you will exit SmartGit."
 msgstr "最後のウィンドウを閉じることで、SmartGitが終了します。"
 
-msgctxt "dlgSgExitConfirmation.hdl"
+msgctxt "dlgSgExitConfirmation.hdl:"
 msgid "Do you want to exit SmartGit now?"
 msgstr "SmartGitを終了しますか？"
 
-msgctxt "dlgSgExitConfirmation.tle"
+msgctxt "dlgSgExitConfirmation.tle:"
 msgid "Exit"
 msgstr "終了"
 
@@ -3819,19 +3819,19 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.btn:"
 msgid "Force Opening"
 msgstr "強制的に開く"
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl:"
 msgid "Could not open Conflict Solver for '$1', because it seems to be no text file."
 msgstr "'$1'はテキスト ファイルではないようなので、コンフリクトソルバーを開くことができませんでした。"
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle:"
 msgid "Conflict Solver"
 msgstr "コンフリクトソルバー"
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.hdl"
+msgctxt "dlgSgFileCompareInvokerFailedIO.hdl:"
 msgid "'$1' could not be invoked."
 msgstr "'$1' を呼び出すことができませんでした。"
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.tle"
+msgctxt "dlgSgFileCompareInvokerFailedIO.tle:"
 msgid "Open"
 msgstr "開く"
 
@@ -3839,19 +3839,19 @@ msgctxt "dlgSgFileCompareNoChanges.btn:"
 msgid "Open"
 msgstr "開く"
 
-msgctxt "dlgSgFileCompareNoChanges.chk"
+msgctxt "dlgSgFileCompareNoChanges.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgFileCompareNoChanges.fur"
+msgctxt "dlgSgFileCompareNoChanges.fur:"
 msgid "Both file contents are byte-wise equal.\\nTo see the file contents anyway, click 'Open'."
 msgstr "ファイルの内容を確認するには、「開く」をクリックしてください。"
 
-msgctxt "dlgSgFileCompareNoChanges.hdl"
+msgctxt "dlgSgFileCompareNoChanges.hdl:"
 msgid "Open the file compare though no changes will be shown?"
 msgstr "変更は表示されませんが、ファイルの比較を開きますか?"
 
-msgctxt "dlgSgFileCompareNoChanges.tle"
+msgctxt "dlgSgFileCompareNoChanges.tle:"
 msgid "File Compare"
 msgstr "ファイルの比較"
 
@@ -3859,7 +3859,7 @@ msgctxt "dlgSgFindObject.edt:"
 msgid "Repository Path, Commit ID or Ref"
 msgstr "リポジトリパス、コミットID、Ref"
 
-msgctxt "dlgSgFindObject.tle"
+msgctxt "dlgSgFindObject.tle:"
 msgid "Find Object"
 msgstr "オブジェクトを検索"
 
@@ -3867,15 +3867,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.btn:"
 msgid "Fast-Forward"
 msgstr "ファストフォワード"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur:"
 msgid "The local branch '$1' is behind its tracked branch '$2'. You may fast-forward now or do it manually later, e.g. by checking out the branch '$3'."
 msgstr "ローカル ブランチ '$1' は、追跡されているブランチ '$2' の後ろにあります。ここでファストフォワードすることも、後で手動で行うこともできます。\\nたとえば、ブランチ '$3' をチェックアウトするなど、手動で行っても良いでしょう。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl:"
 msgid "Should branch '$1' be fast-forwarded to '$2'?"
 msgstr "ブランチ '$1' を '$2' にファストフォワードする必要がありますか?"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.tle:"
 msgid "Start Feature"
 msgstr "Featureを開始"
 
@@ -3883,15 +3883,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.btn:"
 msgid "Replace"
 msgstr "置換"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur:"
 msgid "The local branch '$1' seems to contain more recent but rewritten commits of remote branch '$2'.\\n\\nIf you are not sure whether the local branch is actually more recent than the remote branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr "ローカルブランチ '$1' には、リモートブランチ '$2' の書き換えられたコミットよりも新しいものが含まれているようです。\\n\\nローカルブランチがリモートブランチよりも実際に新しいかどうかわからない場合は、この操作をキャンセルしてローカルおよびリモートでの変更をより詳細に調査することをお勧めします。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl:"
 msgid "Should branch '$1' replace remote branch '$2'?"
 msgstr "リモートブランチ'$2'をブランチ'$1'に置き換えますか?"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.tle:"
 msgid "Finish Feature"
 msgstr "Featureを完了"
 
@@ -3899,15 +3899,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.btn:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur:"
 msgid "The remote branch '$1' seems to contain more recent but rewritten commits of local branch '$2'.\\n\\nIf you are not sure whether the remote branch is actually more recent than the local branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr "リモート ブランチ '$1' には、ローカル ブランチ '$2' の最近の書き換えられたコミットが含まれているようです。\\n\\nリモート ブランチが実際にローカル ブランチよりも新しいかどうかわからない場合は、この操作をキャンセルして、ローカルおよびリモートの変更をより詳細に調査することをお勧めします。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl:"
 msgid "Should branch '$1' be reset to remote branch '$2'?"
 msgstr "ブランチ '$1' をリモート ブランチ '$2' にリセットする必要がありますか?"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.tle:"
 msgid "Finish Feature"
 msgstr "Featureを完了"
 
@@ -3959,11 +3959,11 @@ msgctxt "dlgSgFlowConfigure.edt:"
 msgid "Version Tags"
 msgstr "バージョン タグ"
 
-msgctxt "dlgSgFlowConfigure.hdl"
+msgctxt "dlgSgFlowConfigure.hdl:"
 msgid "Configure the branch naming scheme"
 msgstr "ブランチの命名規則を構成する"
 
-msgctxt "dlgSgFlowConfigure.inf"
+msgctxt "dlgSgFlowConfigure.inf:"
 msgid "Configure how your feature, release and hotfix branches should be named."
 msgstr "featureブランチ、releaseブランチ、Hotfixブランチにどのような名前を付けるかを設定します。"
 
@@ -3979,7 +3979,7 @@ msgctxt "dlgSgFlowConfigure.rbt:"
 msgid "Light \\(just feature branches\\)"
 msgstr "ライト \\(feature ブランチのみ\\)"
 
-msgctxt "dlgSgFlowConfigure.tle"
+msgctxt "dlgSgFlowConfigure.tle:"
 msgid "Configure Git-Flow"
 msgstr "Git-Flowの設定"
 
@@ -3991,15 +3991,15 @@ msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.btn:"
 msgid "Switch-Off Git-Flow"
 msgstr "Git-Flowの機能をオフにする"
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.fur"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.fur:"
 msgid "Git-Flow is already configured for this repository. You may change the Git-Flow configuration or switch-off the Git-Flow features. In both cases, the file ~/.git/config will be modified accordingly."
 msgstr "このリポジトリには、すでにGit-Flowが設定されています。Git-Flow の設定を変更するか、Git-Flow の機能をオフにすることができます。どちらの場合も、~/.git/config ファイルが適宜変更されます。"
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.hdl"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.hdl:"
 msgid "Do you want to change or switch-off the Git-Flow configuration?"
 msgstr "Git-Flow の設定を変更もしくは機能をオフにしますか?"
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.tle"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.tle:"
 msgid "Configure Git-Flow"
 msgstr "Git-Flowの設定"
 
@@ -4027,7 +4027,7 @@ msgctxt "dlgSgFlowFeatureFinish.edt:"
 msgid "Commit Message"
 msgstr "コミットメッセージ"
 
-msgctxt "dlgSgFlowFeatureFinish.hdl"
+msgctxt "dlgSgFlowFeatureFinish.hdl:"
 msgid "Finish current feature"
 msgstr "現在のfeatureを完了"
 
@@ -4059,7 +4059,7 @@ msgctxt "dlgSgFlowFeatureFinish.rbt:"
 msgid "Rebase onto '$1'"
 msgstr "'$1' にリベースする。"
 
-msgctxt "dlgSgFlowFeatureFinish.tle"
+msgctxt "dlgSgFlowFeatureFinish.tle:"
 msgid "Finish Feature"
 msgstr "Featureを完了"
 
@@ -4083,11 +4083,11 @@ msgctxt "dlgSgFlowFeatureStart.err:"
 msgid "Invalid feature name: The name must not end with a slash or dot."
 msgstr "無効なfeature名: 名前の末尾にスラッシュまたはドットを使用することはできません。"
 
-msgctxt "dlgSgFlowFeatureStart.hdl"
+msgctxt "dlgSgFlowFeatureStart.hdl:"
 msgid "Start a new feature"
 msgstr "新しい feature を開始する"
 
-msgctxt "dlgSgFlowFeatureStart.inf"
+msgctxt "dlgSgFlowFeatureStart.inf:"
 msgid "Enter the name of the new feature branch. This operation will fork a new branch from the '$1' branch."
 msgstr "新しいFeatureブランチの名前を入力します。この操作により、'$1' ブランチから新しいブランチがフォークされます。"
 
@@ -4095,7 +4095,7 @@ msgctxt "dlgSgFlowFeatureStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "作成されるブランチ名: $1"
 
-msgctxt "dlgSgFlowFeatureStart.tle"
+msgctxt "dlgSgFlowFeatureStart.tle:"
 msgid "Start Feature"
 msgstr "Featureを開始"
 
@@ -4163,7 +4163,7 @@ msgctxt "dlgSgFlowHotfixFinish.inf:"
 msgid "Choose how to finish the hotfix branch '$1'."
 msgstr "Hotfix ブランチ '$1' を完了する方法を選択します。"
 
-msgctxt "dlgSgFlowHotfixFinish.tle"
+msgctxt "dlgSgFlowHotfixFinish.tle:"
 msgid "Finish Hotfix"
 msgstr "Hotfixを完了"
 
@@ -4187,11 +4187,11 @@ msgctxt "dlgSgFlowHotfixStart.edt:"
 msgid "Hotfix Name"
 msgstr "Hotfix名"
 
-msgctxt "dlgSgFlowHotfixStart.hdl"
+msgctxt "dlgSgFlowHotfixStart.hdl:"
 msgid "Start a new hotfix"
 msgstr "新しい hotfix を開始する"
 
-msgctxt "dlgSgFlowHotfixStart.inf"
+msgctxt "dlgSgFlowHotfixStart.inf:"
 msgid "Enter the name of the new hotfix branch. This operation will fork a new branch from the '$1' branch."
 msgstr "新しいHotfixブランチの名前を入力します。この操作により、'$1'ブランチから新しいブランチがフォークされます。"
 
@@ -4199,7 +4199,7 @@ msgctxt "dlgSgFlowHotfixStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "作成されるブランチ名: $1"
 
-msgctxt "dlgSgFlowHotfixStart.tle"
+msgctxt "dlgSgFlowHotfixStart.tle:"
 msgid "Start Hotfix"
 msgstr "Hotfixの開始"
 
@@ -4211,7 +4211,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.chk:"
 msgid "Fetch latest '$1' commits from remote repository"
 msgstr "リモートリポジトリから最新の '$1' コミットを取得する"
 
-msgctxt "dlgSgFlowIntegrateDevelop.hdl"
+msgctxt "dlgSgFlowIntegrateDevelop.hdl:"
 msgid "Integrate commits from '$1'"
 msgstr "'$1' からコミットを統合"
 
@@ -4235,7 +4235,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.rbt:"
 msgid "Rebase current feature onto '$1'"
 msgstr "現在のfeatureを '$1' にリベースします"
 
-msgctxt "dlgSgFlowIntegrateDevelop.tle"
+msgctxt "dlgSgFlowIntegrateDevelop.tle:"
 msgid "Integrate Develop"
 msgstr "Develop を統合"
 
@@ -4295,7 +4295,7 @@ msgctxt "dlgSgFlowReleaseFinish.inf:"
 msgid "Choose how to finish the release branch '$1'."
 msgstr "Release ブランチ '$1' の完了方法を選択します。"
 
-msgctxt "dlgSgFlowReleaseFinish.tle"
+msgctxt "dlgSgFlowReleaseFinish.tle:"
 msgid "Finish Release"
 msgstr "Releaseを完了"
 
@@ -4319,11 +4319,11 @@ msgctxt "dlgSgFlowReleaseStart.edt:"
 msgid "Release Name"
 msgstr "Release 名"
 
-msgctxt "dlgSgFlowReleaseStart.hdl"
+msgctxt "dlgSgFlowReleaseStart.hdl:"
 msgid "Start a new release"
 msgstr "新しい release を開始する"
 
-msgctxt "dlgSgFlowReleaseStart.inf"
+msgctxt "dlgSgFlowReleaseStart.inf:"
 msgid "Enter the name of the new release branch. This operation will fork a new branch from the '$1' branch."
 msgstr "新しいReleaseブランチの名前を入力してください。この操作により、'$1' ブランチから新しいブランチがフォークされます。"
 
@@ -4331,7 +4331,7 @@ msgctxt "dlgSgFlowReleaseStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "作成されるブランチ名: $1"
 
-msgctxt "dlgSgFlowReleaseStart.tle"
+msgctxt "dlgSgFlowReleaseStart.tle:"
 msgid "Start Release"
 msgstr "Releaseを開始"
 
@@ -4355,11 +4355,11 @@ msgctxt "dlgSgFlowSupportStart.edt:"
 msgid "Support Name"
 msgstr "サポートブランチ名"
 
-msgctxt "dlgSgFlowSupportStart.hdl"
+msgctxt "dlgSgFlowSupportStart.hdl:"
 msgid "Start a new support"
 msgstr "サポートを開始"
 
-msgctxt "dlgSgFlowSupportStart.inf"
+msgctxt "dlgSgFlowSupportStart.inf:"
 msgid "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 msgstr "新しいサポート ブランチの名前を入力します。この操作により、'$1' ブランチから新しいブランチがフォークされます。"
 
@@ -4367,7 +4367,7 @@ msgctxt "dlgSgFlowSupportStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "作成されるブランチ名: $1"
 
-msgctxt "dlgSgFlowSupportStart.tle"
+msgctxt "dlgSgFlowSupportStart.tle:"
 msgid "Start Support"
 msgstr "サポートを開始"
 
@@ -4387,15 +4387,15 @@ msgctxt "dlgSgGarbageCollector.chk:"
 msgid "Optimize repository more aggressively \\(may take a while\\)"
 msgstr "リポジトリの最適化をより積極的に行う \\(時間がかかる可能性あり\\)"
 
-msgctxt "dlgSgGarbageCollector.hdl"
+msgctxt "dlgSgGarbageCollector.hdl:"
 msgid "Run Garbage Collector"
 msgstr "ガベージコレクタ"
 
-msgctxt "dlgSgGarbageCollector.inf"
+msgctxt "dlgSgGarbageCollector.inf:"
 msgid "Running the Git garbage collector will prune unreachable objects and optimize the local repository in order to reduce disk space and increase performance."
 msgstr "Gitガベージコレクタを実行すると、到達できないオブジェクトが削除され、ローカルリポジトリが最適化されます。\\rディスク消費量が削減され、パフォーマンスが向上します。"
 
-msgctxt "dlgSgGarbageCollector.tle"
+msgctxt "dlgSgGarbageCollector.tle:"
 msgid "Run Garbage Collector"
 msgstr "ガベージコレクタ"
 
@@ -4403,15 +4403,15 @@ msgctxt "dlgSgGarbageCollectorDeleteAllStashes.btn:"
 msgid "Delete Stashes"
 msgstr "スタッシュを削除"
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.fur"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.fur:"
 msgid "Expiring the reflog now will also delete all stashes."
 msgstr "今すぐ reflog を期限切れにすると、すべての スタッシュ も削除されます。"
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.hdl"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.hdl:"
 msgid "Do you want to also delete all stashes?"
 msgstr "すべてのスタッシュも削除しますか？"
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle:"
 msgid "Run Garbage Collector"
 msgstr "ガベージコレクタの実行"
 
@@ -4435,11 +4435,11 @@ msgctxt "dlgSgGitHubGenerateToken.edt:"
 msgid "Password"
 msgstr "パスワード"
 
-msgctxt "dlgSgGitHubGenerateToken.hdl"
+msgctxt "dlgSgGitHubGenerateToken.hdl:"
 msgid "Generate a new API token for GitHub"
 msgstr "GitHub 用の新しいAPIトークンの生成"
 
-msgctxt "dlgSgGitHubGenerateToken.inf"
+msgctxt "dlgSgGitHubGenerateToken.inf:"
 msgid "Authenticate at GitHub and grant access to SmartGit."
 msgstr "OAuthまたは認証情報を用いてGitHubで認証します。"
 
@@ -4455,7 +4455,7 @@ msgctxt "dlgSgGitHubGenerateToken.rbt:"
 msgid "Authenticate with your GitHub account and password"
 msgstr "GitHubのアカウントとパスワードで認証"
 
-msgctxt "dlgSgGitHubGenerateToken.tle"
+msgctxt "dlgSgGitHubGenerateToken.tle:"
 msgid "Generate API Token"
 msgstr "APIトークンを生成"
 
@@ -4475,15 +4475,15 @@ msgctxt "dlgSgGitHubPullRequestCreate.edt:"
 msgid "Title and Description"
 msgstr "タイトルと説明"
 
-msgctxt "dlgSgGitHubPullRequestCreate.hdl"
+msgctxt "dlgSgGitHubPullRequestCreate.hdl:"
 msgid "Create a Pull Request"
 msgstr "プルリクエストを作成"
 
-msgctxt "dlgSgGitHubPullRequestCreate.inf"
+msgctxt "dlgSgGitHubPullRequestCreate.inf:"
 msgid "Send pull request to another repository or branch."
 msgstr "別のリポジトリやブランチにプルリクエストを送信します。"
 
-msgctxt "dlgSgGitHubPullRequestCreate.tle"
+msgctxt "dlgSgGitHubPullRequestCreate.tle:"
 msgid "Create Pull Request"
 msgstr "プルリクエストを作成"
 
@@ -4499,11 +4499,11 @@ msgctxt "dlgSgGitHubPullRequestMerge.edt:"
 msgid "Commit Message"
 msgstr "コミットメッセージ"
 
-msgctxt "dlgSgGitHubPullRequestMerge.hdl"
+msgctxt "dlgSgGitHubPullRequestMerge.hdl:"
 msgid "Merge a Pull Request"
 msgstr "プル リクエストをマージする"
 
-msgctxt "dlgSgGitHubPullRequestMerge.inf"
+msgctxt "dlgSgGitHubPullRequestMerge.inf:"
 msgid "Choose how to merge the selected Pull Request."
 msgstr "選択したプルリクエストをどのようにマージしますか?"
 
@@ -4531,7 +4531,7 @@ msgctxt "dlgSgGitHubPullRequestMerge.rbt:"
 msgid "Merge to Local Repository"
 msgstr "ローカルリポジトリにマージ"
 
-msgctxt "dlgSgGitHubPullRequestMerge.tle"
+msgctxt "dlgSgGitHubPullRequestMerge.tle:"
 msgid "Merge Pull Request"
 msgstr "プルリクエストのマージ"
 
@@ -4547,11 +4547,11 @@ msgctxt "dlgSgGitLabGenerateToken.edt:"
 msgid "Token"
 msgstr "トークン"
 
-msgctxt "dlgSgGitLabGenerateToken.hdl"
+msgctxt "dlgSgGitLabGenerateToken.hdl:"
 msgid "Generate a new API token for GitLab"
 msgstr "GitLab 用に新しい API トークンを生成する"
 
-msgctxt "dlgSgGitLabGenerateToken.inf"
+msgctxt "dlgSgGitLabGenerateToken.inf:"
 msgid "Paste the OAuth code from your browser."
 msgstr "ブラウザのOAuthコードを貼り付けます。"
 
@@ -4561,7 +4561,7 @@ msgctxt "dlgSgGitLabGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at GitLab and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr "ブラウザが自動的に開き、GitLabのアカウントで認証を行い、SmartGitへのアクセスを許可します。自動的に開かなかった場合は、以下のリンクを手動で開いてください："
 
-msgctxt "dlgSgGitLabGenerateToken.tle"
+msgctxt "dlgSgGitLabGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr "アクセストークンを要求する"
 
@@ -4577,39 +4577,39 @@ msgctxt "dlgSgGitLabMergeRequestCreate.edt:"
 msgid "Title and Description"
 msgstr "タイトルと説明"
 
-msgctxt "dlgSgGitLabMergeRequestCreate.hdl"
+msgctxt "dlgSgGitLabMergeRequestCreate.hdl:"
 msgid "Create a Merge Request"
 msgstr "マージリクエストを作成"
 
-msgctxt "dlgSgGitLabMergeRequestCreate.inf"
+msgctxt "dlgSgGitLabMergeRequestCreate.inf:"
 msgid "Send merge request to another repository or branch."
 msgstr "別のリポジトリやブランチにマージリクエストを送信します。"
 
-msgctxt "dlgSgGitLabMergeRequestCreate.tle"
+msgctxt "dlgSgGitLabMergeRequestCreate.tle:"
 msgid "Create Merge Request"
 msgstr "マージリクエストを作成"
 
-msgctxt "dlgSgGitLabRefreshFailed.fur"
+msgctxt "dlgSgGitLabRefreshFailed.fur:"
 msgid "Your SmartGit Hosting Provider configuration for GitLab is probably invalid.\\n\\nReview your settings in the Preferences."
 msgstr "GitLab の SmartGit ホスティングプロバイダの設定が無効になっている可能性があります。\\n\\n環境設定で設定を確認してください。"
 
-msgctxt "dlgSgGitLabRefreshFailed.hdl"
+msgctxt "dlgSgGitLabRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr "更新に失敗しました。"
 
-msgctxt "dlgSgGitLabRefreshFailed.tle"
+msgctxt "dlgSgGitLabRefreshFailed.tle:"
 msgid "GitLab"
 msgstr "GitLab"
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.fur"
+msgctxt "dlgSgGitLabSettingsInvalidToken.fur:"
 msgid "Use a Personal Access Token from your GitLab account."
 msgstr "GitLabアカウントのPersonal Access Tokenを使用します。"
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.hdl"
+msgctxt "dlgSgGitLabSettingsInvalidToken.hdl:"
 msgid "Please enter a Personal Access Token for your GitLab account."
 msgstr "GitLab アカウントの個人用アクセストークンを入力してください。"
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.tle"
+msgctxt "dlgSgGitLabSettingsInvalidToken.tle:"
 msgid "Input Validation"
 msgstr "入力検証"
 
@@ -4621,31 +4621,31 @@ msgctxt "dlgSgHeadMessageListenerReplaceMessage.btn:"
 msgid "Replace This Time"
 msgstr "置換する"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.chk"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.chk:"
 msgid "Never replace if a message is already entered"
 msgstr "メッセージがすでに入力されている場合は、決して置き換えない"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.fur"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.fur:"
 msgid "If the commit message input field is empty, the HEAD commit's message will be re-used automatically."
 msgstr "コミットメッセージの入力欄が空の場合は、HEADのコミットメッセージが自動的に再利用されます。"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.hdl"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.hdl:"
 msgid "Replace entered commit message with the HEAD commit's message?"
 msgstr "入力されたコミットメッセージをHEADコミットのメッセージに置換しますか？"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle:"
 msgid "Commit"
 msgstr "コミット"
 
-msgctxt "dlgSgHistoryCommitCantBeModified.fur"
+msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
 msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
 msgstr "影響を受けるコミットのうち少なくとも1つは、HEADの最初の親となる履歴の一部ではありません。"
 
-msgctxt "dlgSgHistoryCommitCantBeModified.hdl"
+msgctxt "dlgSgHistoryCommitCantBeModified.hdl:"
 msgid "At least one selected commit can't be modified."
 msgstr "少なくとも1つの選択されたコミットを変更できません。"
 
-msgctxt "dlgSgHistoryCommitCantBeModified.tle"
+msgctxt "dlgSgHistoryCommitCantBeModified.tle:"
 msgid "Modify Commit"
 msgstr "コミットの修正"
 
@@ -4677,15 +4677,15 @@ msgctxt "dlgSgHistoryEditAuthor.edt:"
 msgid "User Name"
 msgstr "ユーザ名"
 
-msgctxt "dlgSgHistoryEditAuthor.hdl"
+msgctxt "dlgSgHistoryEditAuthor.hdl:"
 msgid "Edit commit author"
 msgstr "作者を編集"
 
-msgctxt "dlgSgHistoryEditAuthor.inf"
+msgctxt "dlgSgHistoryEditAuthor.inf:"
 msgid "Enter the new commit author and its email address."
 msgstr "新しいコミットの作者とそのメールアドレスを入力します。"
 
-msgctxt "dlgSgHistoryEditAuthor.tle"
+msgctxt "dlgSgHistoryEditAuthor.tle:"
 msgid "Edit Author"
 msgstr "作者を編集"
 
@@ -4709,11 +4709,11 @@ msgctxt "dlgSgHistoryEditMessage.edt:"
 msgid "Commit Message"
 msgstr "コミットメッセージ"
 
-msgctxt "dlgSgHistoryEditMessage.hdl"
+msgctxt "dlgSgHistoryEditMessage.hdl:"
 msgid "Edit commit message"
 msgstr "コミットメッセージを編集"
 
-msgctxt "dlgSgHistoryEditMessage.inf"
+msgctxt "dlgSgHistoryEditMessage.inf:"
 msgid "Enter the new commit message."
 msgstr "新しいコミットメッセージを入力します。"
 
@@ -4749,7 +4749,7 @@ msgctxt "dlgSgHistoryEditMessage.mni:"
 msgid "Rewrap"
 msgstr "折り返し"
 
-msgctxt "dlgSgHistoryEditMessage.tle"
+msgctxt "dlgSgHistoryEditMessage.tle:"
 msgid "Edit Message"
 msgstr "メッセージの編集"
 
@@ -4757,19 +4757,19 @@ msgctxt "dlgSgHistoryModifyConfirm.btn:"
 msgid "Modify"
 msgstr "変更"
 
-msgctxt "dlgSgHistoryModifyConfirm.chk"
+msgctxt "dlgSgHistoryModifyConfirm.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgHistoryModifyConfirm.fur"
+msgctxt "dlgSgHistoryModifyConfirm.fur:"
 msgid "This allows you to step by step walk from the selected commit to HEAD and modify them by amend-committing."
 msgstr "選択したコミットから最新のコミットまで段階的に確認しながら、修正コミットで内容を変更することができます。"
 
-msgctxt "dlgSgHistoryModifyConfirm.hdl"
+msgctxt "dlgSgHistoryModifyConfirm.hdl:"
 msgid "Do you want to modify the commits?"
 msgstr "コミットを修正しますか?"
 
-msgctxt "dlgSgHistoryModifyConfirm.tle"
+msgctxt "dlgSgHistoryModifyConfirm.tle:"
 msgid "Modify Commit"
 msgstr "コミットの修正"
 
@@ -4781,15 +4781,15 @@ msgctxt "dlgSgHistoryModifySplitConfirm.btn:"
 msgid "Split"
 msgstr "分割"
 
-msgctxt "dlgSgHistoryModifySplitConfirm.fur"
+msgctxt "dlgSgHistoryModifySplitConfirm.fur:"
 msgid "'Modify' will stop after the commit.\\n\\n'Split' will put the changes into the Index. You may discard some changes that should go into the second commit.\\n\\nAfter you've done the changes, process the remaining commits by continuing the rebase."
 msgstr "「変更」はコミット後に停止します。\\n\\n 「分割」は、変更をインデックスに格納します。 2 番目のコミットに入れる必要があるいくつかの変更を破棄することができます。\\n\\n変更を行った後、リベースを続行して残りのコミットを処理します。"
 
-msgctxt "dlgSgHistoryModifySplitConfirm.hdl"
+msgctxt "dlgSgHistoryModifySplitConfirm.hdl:"
 msgid "Do you want to modify or split commit $1?"
 msgstr "コミットした $1 を修正又は分割しますか?"
 
-msgctxt "dlgSgHistoryModifySplitConfirm.tle"
+msgctxt "dlgSgHistoryModifySplitConfirm.tle:"
 msgid "Modify or Split Commit"
 msgstr "コミットの変更または分割"
 
@@ -4797,15 +4797,15 @@ msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.btn:"
 msgid "Force Push"
 msgstr "強制プッシュ"
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr "リモートブランチへのプッシュは ファストフォワードできないので、強制的にプッシュする必要があります。リモートブランチでのコミットは失われます。"
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl:"
 msgid "Do you want to replace the remote branch by commit $1?"
 msgstr "リモートブランチをコミット $1 で置き換えますか？"
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.tle"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.tle:"
 msgid "Push Up To"
 msgstr "プッシュアップ"
 
@@ -4813,15 +4813,15 @@ msgctxt "dlgSgHistoryPushCommitsUpToCommit.btn:"
 msgid "Push"
 msgstr "プッシュ"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur:"
 msgid "All commits up to the selected commit will be pushed to the remote repository."
 msgstr "選択したコミットまでのすべてのコミットが、リモートリポジトリにプッシュされます。"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl:"
 msgid "Do you want to push changes up to commit $1?"
 msgstr "コミット$1まで変更をプッシュしますか？"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.tle"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.tle:"
 msgid "Push Up To"
 msgstr "プッシュアップ"
 
@@ -4829,11 +4829,11 @@ msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.btn:"
 msgid "Modify Pushed Commits"
 msgstr "既にプッシュされたコミットを修正する"
 
-msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.fur"
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.fur:"
 msgid "Commits which are already pushed are known to other users and may have been used by them to build theirs commits upon. When modifying such commits, these users may run into unexpected conflicts later."
 msgstr "既にプッシュされているコミットは、他のユーザーにも知られており、そのユーザーが自分のコミットを構築する際に使用されている可能性があります。\\rこのようなコミットを変更すると、後で予期せぬ衝突が起こる可能性があります。"
 
-msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl"
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl:"
 msgid "Do you want to modify commits which are already pushed?"
 msgstr "既にプッシュされているコミットを修正しますか?"
 
@@ -4869,19 +4869,19 @@ msgctxt "dlgSgHistorySplitConfirm.btn:"
 msgid "Split"
 msgstr "分割"
 
-msgctxt "dlgSgHistorySplitConfirm.chk"
+msgctxt "dlgSgHistorySplitConfirm.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgHistorySplitConfirm.fur"
+msgctxt "dlgSgHistorySplitConfirm.fur:"
 msgid "This will put the commit's changes into the Index. Unstage those changes that should go into a second commit, then commit the staged changes. Commit the remaining changes in a second \\(or third\\) commit.\\n\\nAfter you are done, process the remaining commits by continuing the rebase."
 msgstr "これにより、コミットの変更がインデックスに格納されます。2 番目のコミットで行うべき変更をアンステージしてからステージングされた変更をコミットします。続けて2 回目\\(または 3 回目\\) のコミットで残りの変更をコミットします。\\n\\n完了後、リベースを続行して残りのコミットを処理します。"
 
-msgctxt "dlgSgHistorySplitConfirm.hdl"
+msgctxt "dlgSgHistorySplitConfirm.hdl:"
 msgid "Do you want to split the selected commit into multiple commits?"
 msgstr "選択したコミットを複数のコミットに分割しますか?"
 
-msgctxt "dlgSgHistorySplitConfirm.tle"
+msgctxt "dlgSgHistorySplitConfirm.tle:"
 msgid "Split Commit"
 msgstr "コミットの分割"
 
@@ -4909,11 +4909,11 @@ msgctxt "dlgSgHistorySquash.edt:"
 msgid "Commit Message"
 msgstr "コミットメッセージ"
 
-msgctxt "dlgSgHistorySquash.hdl"
+msgctxt "dlgSgHistorySquash.hdl:"
 msgid "Squash multiple commits"
 msgstr "複数のコミットをスカッシュする"
 
-msgctxt "dlgSgHistorySquash.inf"
+msgctxt "dlgSgHistorySquash.inf:"
 msgid "The selected commits will be replaced by one squashed commit containing all changes of the individual commits."
 msgstr "選択されたコミットは、個々のコミットのすべての変更を含む1つのスカッシュコミットに置き換わります。"
 
@@ -4925,7 +4925,7 @@ msgctxt "dlgSgHistorySquash.mni:"
 msgid "Log"
 msgstr "ログ"
 
-msgctxt "dlgSgHistorySquash.tle"
+msgctxt "dlgSgHistorySquash.tle:"
 msgid "Squash Commits"
 msgstr "スカッシュコミット"
 
@@ -5079,7 +5079,7 @@ msgctxt "dlgSgHostingProviderAdd.lbl:"
 msgid "You can review Azure DevOps applications in the Authorizations section located at the bottom left of your \\[https://aex.dev.azure.com/me profile\\]."
 msgstr "Azure DevOps アプリケーションは、\\[https://aex.dev.azure.com/me プロフィール\\] の左下に表示される「承認」セクションで確認できます。"
 
-msgctxt "dlgSgHostingProviderAdd.tle"
+msgctxt "dlgSgHostingProviderAdd.tle:"
 msgid "Add Hosting Provider"
 msgstr "ホスティングプロバイダーを追加"
 
@@ -5183,11 +5183,11 @@ msgctxt "dlgSgHostingProviderEdit.err:"
 msgid "The provided SSL client certificate path is invalid."
 msgstr "指定されたSSLクライアント証明書のパスが無効です。"
 
-msgctxt "dlgSgHostingProviderEdit.hdl"
+msgctxt "dlgSgHostingProviderEdit.hdl:"
 msgid "Configure $1 account"
 msgstr "$1 アカウントの設定"
 
-msgctxt "dlgSgHostingProviderEdit.inf"
+msgctxt "dlgSgHostingProviderEdit.inf:"
 msgid "Please specify your credentials to connect to $1."
 msgstr "$1 に接続するための認証情報を指定してください。"
 
@@ -5291,7 +5291,7 @@ msgctxt "dlgSgHostingProviderSelectRepository.mni:"
 msgid "Repository"
 msgstr "リポジトリ"
 
-msgctxt "dlgSgHostingProviderSelectRepository.tle"
+msgctxt "dlgSgHostingProviderSelectRepository.tle:"
 msgid "GitHub Projects"
 msgstr "GitHub プロジェクト"
 
@@ -5299,15 +5299,15 @@ msgctxt "dlgSgHostingProvider(Add|Edit).lbl:"
 msgid "Optional SSL configuration"
 msgstr "オプションのSSL設定"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur:"
 msgid "The OAuth-access token could not be requested. Most likely your $1 configuration has changed and SmartGit's stored OAuth credentials are invalid.\\n\\nTo resolve, recreate the $2 hosting provider in the Preferences.\\n\\nDetails:\\n\\n$3"
 msgstr "OAuth アクセス トークンを要求できませんでした。 ほとんどの場合 $1 の設定が変更され、SmartGit に保存されている OAuth 資格情報が無効になっています。\\n\\n解決するには、環境設定で $2 ホスティング プロバイダーを再作成します。\\n\\n詳細：\\n\\n $3"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl:"
 msgid "$1 OAuth-authentication failed"
 msgstr "$1 OAuth認証に失敗しました"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.tle"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.tle:"
 msgid "HTTP authentication"
 msgstr "HTTP 認証"
 
@@ -5327,15 +5327,15 @@ msgctxt "dlgSgHttpPasswordCredentials.edt:"
 msgid "User Name"
 msgstr "ユーザ名"
 
-msgctxt "dlgSgHttpPasswordCredentials.hdl"
+msgctxt "dlgSgHttpPasswordCredentials.hdl:"
 msgid "Login to '$1'"
 msgstr "'$1' にログインする"
 
-msgctxt "dlgSgHttpPasswordCredentials.inf"
+msgctxt "dlgSgHttpPasswordCredentials.inf:"
 msgid "Provide the user name and password for authenticating to the repository."
 msgstr "リポジトリに認証するためのユーザー名とパスワードを入力します。"
 
-msgctxt "dlgSgHttpPasswordCredentials.tle"
+msgctxt "dlgSgHttpPasswordCredentials.tle:"
 msgid "Login"
 msgstr "ログイン"
 
@@ -5343,15 +5343,15 @@ msgctxt "dlgSgIgnoreChanged.btn:"
 msgid "Discard Changes"
 msgstr "変更を破棄"
 
-msgctxt "dlgSgIgnoreChanged.fur"
+msgctxt "dlgSgIgnoreChanged.fur:"
 msgid "The changes will be discarded when proceeding!"
 msgstr "続行すると、変更は破棄されます。"
 
-msgctxt "dlgSgIgnoreChanged.hdl"
+msgctxt "dlgSgIgnoreChanged.hdl:"
 msgid "Are you sure to remove changed files?"
 msgstr "本当に変更されたファイルを削除しますか?"
 
-msgctxt "dlgSgIgnoreChanged.tle"
+msgctxt "dlgSgIgnoreChanged.tle:"
 msgid "Ignore"
 msgstr "無視"
 
@@ -5375,15 +5375,15 @@ msgctxt "dlgSgIgnoreDirectoryConfirm.edt:"
 msgid "Ignore File"
 msgstr "Ignoreファイル"
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.fur"
+msgctxt "dlgSgIgnoreDirectoryConfirm.fur:"
 msgid "The directory name will be added to the ignore file. If the ignore file does not exist, it will be created."
 msgstr "このディレクトリ名は、.ignore ファイルに追加されます。 .ignore ファイルが存在しない場合は、作成されます。"
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.hdl"
+msgctxt "dlgSgIgnoreDirectoryConfirm.hdl:"
 msgid "Do you want to ignore directory '$1'?"
 msgstr "ディレクトリ'$1'を無視しますか？"
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.tle"
+msgctxt "dlgSgIgnoreDirectoryConfirm.tle:"
 msgid "Ignore"
 msgstr "無視"
 
@@ -5391,11 +5391,11 @@ msgctxt "dlgSgIgnoreEdit.btn:"
 msgid "Edit"
 msgstr "編集"
 
-msgctxt "dlgSgIgnoreEdit.hdl"
+msgctxt "dlgSgIgnoreEdit.hdl:"
 msgid "Edit Git ignore file"
 msgstr "Git ignore ファイルの編集"
 
-msgctxt "dlgSgIgnoreEdit.inf"
+msgctxt "dlgSgIgnoreEdit.inf:"
 msgid "Select the Git ignore file to edit."
 msgstr "編集する Git ignore ファイルを選択します。"
 
@@ -5407,7 +5407,7 @@ msgctxt "dlgSgIgnoreEdit.mni:"
 msgid "Reveal"
 msgstr "表示する"
 
-msgctxt "dlgSgIgnoreEdit.tle"
+msgctxt "dlgSgIgnoreEdit.tle:"
 msgid "Edit Ignore File"
 msgstr "無視リストを編集"
 
@@ -5439,11 +5439,11 @@ msgctxt "dlgSgIgnoreFile.err:"
 msgid "The pattern must match all selected file names. For instance, '$1' is not matched."
 msgstr "パターンは、選択されたすべてのファイル名と一致する必要があります。例えば、'$1' はマッチしません。"
 
-msgctxt "dlgSgIgnoreFile.hdl"
+msgctxt "dlgSgIgnoreFile.hdl:"
 msgid "Mark files to be ignored"
 msgstr "無視するファイルを指定する"
 
-msgctxt "dlgSgIgnoreFile.inf"
+msgctxt "dlgSgIgnoreFile.inf:"
 msgid "Choose whether to ignore only the selected file or all files matching the specified pattern. Tracked files will be removed \\(stopped from tracking\\)."
 msgstr "選択したファイルだけを無視するか、指定したパターンに一致するすべてのファイルを無視するかを選択します。\\r追跡されたファイルは以降のバージョン管理の対象から除外されます。"
 
@@ -5459,7 +5459,7 @@ msgctxt "dlgSgIgnoreFile.rbt:"
 msgid "Ignore explicitly \\(e.g. 'Makefile'\\)"
 msgstr "明示的に無視する \\(例：'Makefile'\\)"
 
-msgctxt "dlgSgIgnoreFile.tle"
+msgctxt "dlgSgIgnoreFile.tle:"
 msgid "Ignore"
 msgstr "無視"
 
@@ -5467,11 +5467,11 @@ msgctxt "dlgSgIgnoreFile.wrn:"
 msgid "Because of performance reasons it is recommended to ignore by pattern - if possible."
 msgstr "パフォーマンス上の理由から、可能であればパターンで無視することをお勧めします。"
 
-msgctxt "dlgSgIndexEditorMixedLineEndings.fur"
+msgctxt "dlgSgIndexEditorMixedLineEndings.fur:"
 msgid "At least one of the file contents contains mixed \\(inconsistent\\) line-endings. To prevent overwriting intentional mixed line-endings, editing and saving is disabled."
 msgstr "少なくとも 1 つのファイルの内容に、混合した (不整合な) 改行コードが含まれています。意図的な改行コードの混合の上書きを防ぐため、編集と保存は無効になっています。"
 
-msgctxt "dlgSgIndexEditorMixedLineEndings.hdl"
+msgctxt "dlgSgIndexEditorMixedLineEndings.hdl:"
 msgid "The file is not editable because of mixed line-endings."
 msgstr "改行コードが混合しているため、ファイルを編集できません。"
 
@@ -5483,15 +5483,15 @@ msgctxt "dlgSgIndexEditorSaveOrDiscard.btn:"
 msgid "Save"
 msgstr "保存"
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.fur"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.fur:"
 msgid "Your changes will be lost, if you don't save them now."
 msgstr "今すぐ保存しないと、変更内容が失われます。"
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.hdl"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.hdl:"
 msgid "Do you want to save your changes?"
 msgstr "変更内容を保存しますか？"
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.tle"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.tle:"
 msgid "Close"
 msgstr "閉じる"
 
@@ -5503,27 +5503,27 @@ msgctxt "dlgSgJournalDoubleClick.btn:"
 msgid "Open Log"
 msgstr "ログを開く"
 
-msgctxt "dlgSgJournalDoubleClick.fur"
+msgctxt "dlgSgJournalDoubleClick.fur:"
 msgid "Select either to check out '$1' or to open the Log for the selected commit."
 msgstr "'$1' をチェックアウトするか、選択したコミットのログを開くかを選択します。"
 
-msgctxt "dlgSgJournalDoubleClick.hdl"
+msgctxt "dlgSgJournalDoubleClick.hdl:"
 msgid "Do you want to check out '$1'?"
 msgstr "'$1' をチェックアウトしますか？"
 
-msgctxt "dlgSgJournalDoubleClick.tle"
+msgctxt "dlgSgJournalDoubleClick.tle:"
 msgid "Journal"
 msgstr "ジャーナル"
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.fur"
+msgctxt "dlgSgJournalFormCommitCantBeModified.fur:"
 msgid "Not part of your head's first-parent history"
 msgstr "HEAD の 親を辿った履歴に含まれていません。"
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.hdl"
+msgctxt "dlgSgJournalFormCommitCantBeModified.hdl:"
 msgid "At least one selected commit can't be modified."
 msgstr "少なくとも1つの選択されたコミットを変更できません。"
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.tle"
+msgctxt "dlgSgJournalFormCommitCantBeModified.tle:"
 msgid "Edit Author"
 msgstr "作者を編集"
 
@@ -5531,15 +5531,15 @@ msgctxt "dlgSgLfsInstallConfirm.btn:"
 msgid "Install"
 msgstr "インストール"
 
-msgctxt "dlgSgLfsInstallConfirm.fur"
+msgctxt "dlgSgLfsInstallConfirm.fur:"
 msgid "This will configure hooks and filters required for LFS."
 msgstr "LFSに必要なフックとフィルタを設定します。"
 
-msgctxt "dlgSgLfsInstallConfirm.hdl"
+msgctxt "dlgSgLfsInstallConfirm.hdl:"
 msgid "Would you like to initialize this repository for Large File Support \\(LFS\\)?"
 msgstr "このリポジトリをLFS \\(Large File Support\\) 用に初期化しますか？"
 
-msgctxt "dlgSgLfsInstallConfirm.tle"
+msgctxt "dlgSgLfsInstallConfirm.tle:"
 msgid "LFS Install"
 msgstr "LFS インストール"
 
@@ -5547,15 +5547,15 @@ msgctxt "dlgSgLfsPruneConfirm.btn:"
 msgid "Prune"
 msgstr ""
 
-msgctxt "dlgSgLfsPruneConfirm.fur"
+msgctxt "dlgSgLfsPruneConfirm.fur:"
 msgid "This will call the remote to ensure that any LFS files to be deleted have copies on the remote before actually deleting them."
 msgstr ""
 
-msgctxt "dlgSgLfsPruneConfirm.hdl"
+msgctxt "dlgSgLfsPruneConfirm.hdl:"
 msgid "Would you like to delete old LFS files from the local storage?"
 msgstr ""
 
-msgctxt "dlgSgLfsPruneConfirm.tle"
+msgctxt "dlgSgLfsPruneConfirm.tle:"
 msgid "LFS Prune"
 msgstr ""
 
@@ -5567,15 +5567,15 @@ msgctxt "dlgSgLfsTrack.err:"
 msgid "File '$1' does not match the specified pattern."
 msgstr "ファイル '$1' は、指定されたパターンと一致しません。"
 
-msgctxt "dlgSgLfsTrack.hdl"
+msgctxt "dlgSgLfsTrack.hdl:"
 msgid "Mark a file or pattern as tracked"
 msgstr "ファイルまたはパターンを追跡済みとしてマークする"
 
-msgctxt "dlgSgLfsTrack.inf"
+msgctxt "dlgSgLfsTrack.inf:"
 msgid "Specify the file name pattern that should be handled by Large File Support \\(LFS\\)."
 msgstr "Large File Support\\(LFS\\)で扱うファイル名のパターンを指定します。"
 
-msgctxt "dlgSgLfsTrack.tle"
+msgctxt "dlgSgLfsTrack.tle:"
 msgid "LFS Track"
 msgstr "LFSで追跡"
 
@@ -5583,27 +5583,27 @@ msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.btn:"
 msgid "Revert"
 msgstr "リバート"
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur:"
 msgid "You are about to apply lines from the Index to the working tree file '$1'. The modifications will be saved immediately."
 msgstr "インデックスの行を作業ツリーのファイル '$1' に適用しようとしています。変更はすぐに保存されます。"
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.hdl"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.hdl:"
 msgid "Do you really want to revert changes in the working tree file?"
 msgstr "作業ツリー ファイルの変更を本当に元に戻しますか?"
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.tle"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.tle:"
 msgid "Revert Working Tree File"
 msgstr "作業ツリーのファイルを元に戻す"
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.fur"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.fur:"
 msgid "It's not possible to perform the requested operation on an empty repository."
 msgstr "空のリポジトリに対して要求された操作を実行することはできません。"
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.hdl"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.hdl:"
 msgid "The repository is empty."
 msgstr "リポジトリが空です。"
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.tle"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.tle:"
 msgid "Save Stash"
 msgstr "スタッシュに保存"
 
@@ -5619,7 +5619,7 @@ msgctxt "dlgSgLogCheckoutFileAs.edt:"
 msgid "Target File"
 msgstr "ターゲットファイル"
 
-msgctxt "dlgSgLogCheckoutFileAs.hdl"
+msgctxt "dlgSgLogCheckoutFileAs.hdl:"
 msgid "Save the repository file"
 msgstr "リポジトリファイルの保存"
 
@@ -5631,11 +5631,11 @@ msgctxt "dlgSgLogCheckoutFileAs.inf:"
 msgid "Select whether to save the file state Before or After the selected commit."
 msgstr "選択したコミット後 又は コミット前のファイル状態を保存するかどうかを選択します。"
 
-msgctxt "dlgSgLogCheckoutFileAs.tle"
+msgctxt "dlgSgLogCheckoutFileAs.tle:"
 msgid "Save File As"
 msgstr "ファイルを別名で保存"
 
-msgctxt "dlgSgLogCommentDeleteConfirm.hdl"
+msgctxt "dlgSgLogCommentDeleteConfirm.hdl:"
 msgid "Do you really want to delete comment '$1'?"
 msgstr "本当にコメント'$1'を削除しますか？"
 
@@ -5643,15 +5643,15 @@ msgctxt "dlgSgLogComment(|s)DeleteConfirm.btn:"
 msgid "Delete Comment"
 msgstr "コミットを削除"
 
-msgctxt "dlgSgLogComment(|s)DeleteConfirm.fur"
+msgctxt "dlgSgLogComment(|s)DeleteConfirm.fur:"
 msgid "Comments can't be restored after deletion."
 msgstr "削除したコメントは元に戻せません。"
 
-msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle"
+msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle:"
 msgid "Delete Comment"
 msgstr "コミットを削除"
 
-msgctxt "dlgSgLogCommentsDeleteConfirm.hdl"
+msgctxt "dlgSgLogCommentsDeleteConfirm.hdl:"
 msgid "Do you really want to delete $1 comments?"
 msgstr "$1のコメントを本当に削除しますか？"
 
@@ -5663,15 +5663,15 @@ msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.btn:"
 msgid "Compare With Each Other"
 msgstr "ファイル同士の比較"
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.fur"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.fur:"
 msgid "You may compare the selected files against each other or open up two separate compares for each file against its previous state."
 msgstr "選択したファイル同士を比較することも、各ファイルの以前の状態と比較するために2つの別々の比較画面を開くこともできます。"
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.hdl"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.hdl:"
 msgid "Do you want to compare the selected files against each other?"
 msgstr "選択したファイル同士を比較しますか？"
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.tle"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.tle:"
 msgid "Compare"
 msgstr "比較"
 
@@ -5687,15 +5687,15 @@ msgctxt "dlgSgLogCompareWithWorkingTree.edt:"
 msgid "Working Tree File"
 msgstr "ワーキングツリーファイル"
 
-msgctxt "dlgSgLogCompareWithWorkingTree.hdl"
+msgctxt "dlgSgLogCompareWithWorkingTree.hdl:"
 msgid "Compare repository file with local file"
 msgstr "リポジトリファイルとローカルファイルの比較"
 
-msgctxt "dlgSgLogCompareWithWorkingTree.inf"
+msgctxt "dlgSgLogCompareWithWorkingTree.inf:"
 msgid "Select whether to compare with the repository file as it was Before or After the selected commit."
 msgstr "選択したコミットの前または後の状態のリポジトリファイルと比較するかどうかを選択します。"
 
-msgctxt "dlgSgLogCompareWithWorkingTree.tle"
+msgctxt "dlgSgLogCompareWithWorkingTree.tle:"
 msgid "Compare with Working Tree"
 msgstr "作業ツリーとの比較"
 
@@ -5703,11 +5703,11 @@ msgctxt "dlgSgLogGraphRootSwitch.chk:"
 msgid "Include tracked remote branches"
 msgstr "追跡されたリモート ブランチを含める"
 
-msgctxt "dlgSgLogGraphRootSwitch.hdl"
+msgctxt "dlgSgLogGraphRootSwitch.hdl:"
 msgid "Select shown branches"
 msgstr "表示されたブランチを選択"
 
-msgctxt "dlgSgLogGraphRootSwitch.inf"
+msgctxt "dlgSgLogGraphRootSwitch.inf:"
 msgid "Select the branches for which to show commits in the graph."
 msgstr "グラフにコミットを表示するブランチを選択します。"
 
@@ -5715,7 +5715,7 @@ msgctxt "dlgSgLogGraphRootSwitch.mni:"
 msgid "Toggle"
 msgstr "トグル"
 
-msgctxt "dlgSgLogGraphRootSwitch.tle"
+msgctxt "dlgSgLogGraphRootSwitch.tle:"
 msgid "Select Branches"
 msgstr "ブランチを選択"
 
@@ -5727,23 +5727,23 @@ msgctxt "dlgSgLogOpenFailedRepository.fur:"
 msgid "Is the repository still valid?"
 msgstr "リポジトリはまだ有効ですか?"
 
-msgctxt "dlgSgLogOpenFailedRepository.hdl"
+msgctxt "dlgSgLogOpenFailedRepository.hdl:"
 msgid "Repository could not be opened."
 msgstr "リポジトリを開くことができませんでした。"
 
-msgctxt "dlgSgLogOpenFailedRepository.tle"
+msgctxt "dlgSgLogOpenFailedRepository.tle:"
 msgid "Log"
 msgstr "ログ"
 
-msgctxt "dlgSgLogOpenFailedSubmodule.fur"
+msgctxt "dlgSgLogOpenFailedSubmodule.fur:"
 msgid "Is the repository still valid?"
 msgstr "リポジトリはまだ有効ですか?"
 
-msgctxt "dlgSgLogOpenFailedSubmodule.hdl"
+msgctxt "dlgSgLogOpenFailedSubmodule.hdl:"
 msgid "Submodule could not be opened."
 msgstr "サブモジュールを開くことができませんでした。"
 
-msgctxt "dlgSgLogOpenFailedSubmodule.tle"
+msgctxt "dlgSgLogOpenFailedSubmodule.tle:"
 msgid "Log"
 msgstr "ログ"
 
@@ -5755,15 +5755,15 @@ msgctxt "dlgSgLogOpenNewWindow.btn:"
 msgid "New Window"
 msgstr "新しいウィンドウ"
 
-msgctxt "dlgSgLogOpenNewWindow.fur"
+msgctxt "dlgSgLogOpenNewWindow.fur:"
 msgid "There is already an existing Log window which can be revealed."
 msgstr "すでに既存のログウィンドウがあり、それを表示することができます。"
 
-msgctxt "dlgSgLogOpenNewWindow.hdl"
+msgctxt "dlgSgLogOpenNewWindow.hdl:"
 msgid "Do you want to open a new Log window?"
 msgstr "新しいログウィンドウを開きますか?"
 
-msgctxt "dlgSgLogOpenNewWindow.tle"
+msgctxt "dlgSgLogOpenNewWindow.tle:"
 msgid "Log"
 msgstr "ログ"
 
@@ -5775,15 +5775,15 @@ msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.btn:"
 msgid "Submodule Log"
 msgstr "サブモジュールログ"
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.fur"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.fur:"
 msgid "The history of submodule updates will show changes to the submodule link \\('GITLINK'\\) from the parent repository's perspective. The Log for the submodule repository will show all commits which have occurred in the submodule repository itself."
 msgstr "サブモジュールの更新履歴には、親リポジトリから見たサブモジュールリンク ('GITLINK') の変更が表示されます。サブモジュールリポジトリのログには、サブモジュールリポジトリ自身で発生したすべてのコミットが表示されます。"
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.hdl"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.hdl:"
 msgid "Do you want to show the history of submodule updates or the Log for the submodule repository?"
 msgstr "サブモジュールの更新履歴またはサブモジュール リポジトリのログを表示しますか?"
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.tle"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.tle:"
 msgid "Open Log"
 msgstr "ログを開く"
 
@@ -5791,15 +5791,15 @@ msgctxt "dlgSgLogRefActionsDeleteConfirm.btn:"
 msgid "Delete Branch"
 msgstr "ブランチを削除"
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.fur"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr "プッシュされていない変更が失われたり、ブランチの復元が困難になる可能性があります。"
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl:"
 msgid "Do you really want to delete the local branch '$1'?"
 msgstr "本当にローカルブランチ'$1'を削除しますか？"
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.tle"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.tle:"
 msgid "Delete Local Branch"
 msgstr "ローカルブランチを削除"
 
@@ -5811,15 +5811,15 @@ msgctxt "dlgSgLogRefreshRepositoryInvalid.btn:"
 msgid "Remove Repository"
 msgstr "リポジトリを削除"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.fur"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.fur:"
 msgid "This could mean that the repository at\\n\\n$1was removed or renamed outside SmartGit."
 msgstr "下記のリポジトリが削除されたか、SmartGit の外部で名前が変更された可能性があります。\\n\\n$1"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl:"
 msgid "The opened repository '$1' became invalid."
 msgstr "開いていたリポジトリ'$1'が無効になりました。"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.tle"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.tle:"
 msgid "Refresh"
 msgstr "更新"
 
@@ -5839,11 +5839,11 @@ msgctxt "dlgSgMerge.btn:"
 msgid "Squash-Merge"
 msgstr "スカッシュマージ"
 
-msgctxt "dlgSgMerge.hdl"
+msgctxt "dlgSgMerge.hdl:"
 msgid "Merge"
 msgstr "マージ"
 
-msgctxt "dlgSgMerge.inf"
+msgctxt "dlgSgMerge.inf:"
 msgid "Select the branch or commit to merge and how they should be merged into the Working Tree."
 msgstr "マージするブランチやコミットを選択し、それらをどのように作業ツリーにマージするかを決定します。"
 
@@ -5859,7 +5859,7 @@ msgctxt "dlgSgMerge.mni:"
 msgid "Refresh"
 msgstr "更新"
 
-msgctxt "dlgSgMerge.tle"
+msgctxt "dlgSgMerge.tle:"
 msgid "Merge"
 msgstr "マージ"
 
@@ -5867,15 +5867,15 @@ msgctxt "dlgSgMergeConfirmNoCommit.btn:"
 msgid "Merge"
 msgstr "マージ"
 
-msgctxt "dlgSgMergeConfirmNoCommit.fur"
+msgctxt "dlgSgMergeConfirmNoCommit.fur:"
 msgid "The selected revisions\\(s\\) will be merged to the working tree.\\n\\nNote that merging directly to the GitFlow-master branch is not recommended. Instead, you should start a hotfix."
 msgstr "選択したリビジョンが作業ツリーにマージされます。\\n\\nGitFlow-master ブランチに直接マージすることは推奨されないことに注意してください。代わりに、hotfix を開始する必要があります。"
 
-msgctxt "dlgSgMergeConfirmNoCommit.hdl"
+msgctxt "dlgSgMergeConfirmNoCommit.hdl:"
 msgid "Do you want to perform the merge?"
 msgstr "マージを実行しますか?"
 
-msgctxt "dlgSgMergeConfirmNoCommit.tle"
+msgctxt "dlgSgMergeConfirmNoCommit.tle:"
 msgid "Merge"
 msgstr "マージ"
 
@@ -5895,7 +5895,7 @@ msgctxt "dlgSgMergeHowToMerge.btn:"
 msgid "Squash-Merge"
 msgstr "スカッシュマージ"
 
-msgctxt "dlgSgMergeHowToMerge.fur"
+msgctxt "dlgSgMergeHowToMerge.fur:"
 msgid "If there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
 msgstr "競合がない場合、Gitは自動的にマージコミットを作成します。代わりに、作業ツリーにマージすることもできます。\\n作業ツリーにマージ を選択すると、マージコミットが作成されますが、スカッシュマージ を選択すると通常のコミットが作成されます \\(マージされたコミットに関する情報は破棄されます\\)。どちらの場合も、後で手動でコミットする必要があります。"
 
@@ -5907,19 +5907,19 @@ msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from tag '$1'?"
 msgstr "タグ '$1' からどのようにマージしますか?"
 
-msgctxt "dlgSgMergeHowToMerge.tle"
+msgctxt "dlgSgMergeHowToMerge.tle:"
 msgid "Merge"
 msgstr "マージ"
 
-msgctxt "dlgSgMergeNoop.fur"
+msgctxt "dlgSgMergeNoop.fur:"
 msgid "Merging a commit's own history into itself is technically allowed by Git but it's a no-op and will not give a new commit nor any other meaningful changes."
 msgstr "コミットをそれ自身にマージすることは、技術的にはGitで認められていますが、ノーオペレーション命令であり、新しいコミットやその他の意味のある変更を与えるものではありません。"
 
-msgctxt "dlgSgMergeNoop.hdl"
+msgctxt "dlgSgMergeNoop.hdl:"
 msgid "There is nothing to merge."
 msgstr "マージするものはありません。"
 
-msgctxt "dlgSgMergeNoop.tle"
+msgctxt "dlgSgMergeNoop.tle:"
 msgid "Merge"
 msgstr "マージ"
 
@@ -5931,15 +5931,15 @@ msgctxt "dlgSgOpenRepository.err:"
 msgid "Please specify the root directory of a Git repository."
 msgstr "Git リポジトリのルートディレクトリを指定してください。"
 
-msgctxt "dlgSgOpenRepository.hdl"
+msgctxt "dlgSgOpenRepository.hdl:"
 msgid "Add existing or create new repository"
 msgstr "既存のリポジトリを追加、または新しいリポジトリを作成"
 
-msgctxt "dlgSgOpenRepository.inf"
+msgctxt "dlgSgOpenRepository.inf:"
 msgid "Specify the local Git repository to open. To create a new repository, specify an empty directory."
 msgstr "開くローカル Git リポジトリを指定します。新しいリポジトリを作成するには、空のディレクトリを指定します。"
 
-msgctxt "dlgSgOpenRepository.tle"
+msgctxt "dlgSgOpenRepository.tle:"
 msgid "Add or Create Repository"
 msgstr "リポジトリの追加又は作成"
 
@@ -5947,27 +5947,27 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.btn:"
 msgid "Initialize"
 msgstr "初期化"
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.fur"
+msgctxt "dlgSgOpenRepositoryInitializeGit.fur:"
 msgid "The specified directory does not appear to be a valid Git repository."
 msgstr "指定されたディレクトリは、有効な Git リポジトリではないようです。"
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.hdl"
+msgctxt "dlgSgOpenRepositoryInitializeGit.hdl:"
 msgid "Should '$1' be initialized as a new Git repository?"
 msgstr "'$1' を新しい Git リポジトリとして初期化しますか?"
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.tle"
+msgctxt "dlgSgOpenRepositoryInitializeGit.tle:"
 msgid "Add or Create Repository"
 msgstr "リポジトリの追加又は作成"
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur:"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr "SmartGit では不可能な既存の SVN 作業コピーを開こうとしています。代わりに、$1 を使用して、SVN リポジトリの Git クローン \\(つまり、SVN ではなく Git に基づく作業コピー\\) を作成してください。"
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.hdl"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.hdl:"
 msgid "Can't open SVN working copy, please re-clone with SmartGit."
 msgstr "SVN作業コピーを開くことができません。SmartGitで再クローンしてください。"
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.tle"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.tle:"
 msgid "Add or Create Repository"
 msgstr "リポジトリの追加又は作成"
 
@@ -6199,15 +6199,15 @@ msgctxt "dlgSgOutput.tle:"
 msgid "Output"
 msgstr "出力"
 
-msgctxt "dlgSgPingRepositoryFailed.fur"
+msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr "リポジトリURLを確認してください。\\n\\n$1"
 
-msgctxt "dlgSgPingRepositoryFailed.hdl"
+msgctxt "dlgSgPingRepositoryFailed.hdl:"
 msgid "Could not connect to the repository '$1'."
 msgstr "リポジトリ'$1'に接続できませんでした。"
 
-msgctxt "dlgSgPingRepositoryFailed.tle"
+msgctxt "dlgSgPingRepositoryFailed.tle:"
 msgid "Clone"
 msgstr "クローン"
 
@@ -7415,7 +7415,7 @@ msgctxt "dlgSgPreferences.tab:"
 msgid "User"
 msgstr "ユーザー"
 
-msgctxt "dlgSgPreferences.tle"
+msgctxt "dlgSgPreferences.tle:"
 msgid "Preferences"
 msgstr "環境設定"
 
@@ -7479,7 +7479,7 @@ msgctxt "dlgSgProcessKiller.lbl:"
 msgid "If you think the process is hanging, click the 'Kill Process' button, otherwise 'Wait'."
 msgstr "プロセスがハングしていると思われる場合は、[強制終了] ボタンをクリックします。それ以外の場合は [待機] ボタンをクリックします。"
 
-msgctxt "dlgSgProcessKiller.tle"
+msgctxt "dlgSgProcessKiller.tle:"
 msgid "Process Not Responding"
 msgstr "プロセスが応答していません"
 
@@ -7491,15 +7491,15 @@ msgctxt "dlgSgProviderCommentEdit.edt:"
 msgid "Text"
 msgstr "テキスト"
 
-msgctxt "dlgSgProviderCommentEdit.hdl"
+msgctxt "dlgSgProviderCommentEdit.hdl:"
 msgid "Edit GitHub comment"
 msgstr "GitHub のコメントを編集"
 
-msgctxt "dlgSgProviderCommentEdit.inf"
+msgctxt "dlgSgProviderCommentEdit.inf:"
 msgid "Enter the text of the comment."
 msgstr "コメントのテキストを入力します。"
 
-msgctxt "dlgSgProviderCommentEdit.tle"
+msgctxt "dlgSgProviderCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr "コメントを編集"
 
@@ -7511,7 +7511,7 @@ msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr "リンク"
 
-msgctxt "dlgSgProviderGenerateToken.inf"
+msgctxt "dlgSgProviderGenerateToken.inf:"
 msgid "Authenticate at GitLab and grant access to SmartGit."
 msgstr ""
 
@@ -7523,19 +7523,19 @@ msgctxt "dlgSgProviderGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at GitLab and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.tle"
+msgctxt "dlgSgProviderGenerateToken.tle:"
 msgid "Generate API Token"
 msgstr "API トークンを生成する"
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.fur"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.fur:"
 msgid "The repository is no GitHub-fork and there are no other remotes which are forks of this repository."
 msgstr "リポジトリはGitHubフォークではなく、このリポジトリのフォークである他のリモートはありません。"
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.hdl"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.hdl:"
 msgid "No target repositories found."
 msgstr "ターゲットリポジトリが見つかりません。"
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.tle"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.tle:"
 msgid "Create Pull Request"
 msgstr "プルリクエストを作成"
 
@@ -7547,15 +7547,15 @@ msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.btn:"
 msgid "Skip"
 msgstr "スキップ"
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.fur"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.fur:"
 msgid "You have local commits which are not yet present in the server-side Provider repository. Unless you push them now, these local commits will not be included in the merge request."
 msgstr "サーバー側のプロバイダーリポジトリにまだ存在していないローカル コミットがあります。今すぐプッシュしない限り、これらのローカル コミットはマージリクエストに含まれません。"
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.hdl"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.hdl:"
 msgid "Do you want to push your local commits first?"
 msgstr "最初にローカルのコミットをプッシュしますか?"
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.tle"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.tle:"
 msgid "Create Merge Request"
 msgstr "マージリクエストを作成"
 
@@ -7563,15 +7563,15 @@ msgctxt "dlgSgProviderPullRequestDropConfirmMr.btn:"
 msgid "Drop"
 msgstr "削除"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur:"
 msgid "The merge request itself will not be deleted on the server."
 msgstr "マージリクエスト自体はサーバー上で削除されません。"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl:"
 msgid "Do you really want to drop the local commits of merge request $1?"
 msgstr "本当にマージリクエスト$1のローカルコミットを削除しますか?"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.tle"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.tle:"
 msgid "Drop Merge Request"
 msgstr "マージ リクエストの削除"
 
@@ -7579,15 +7579,15 @@ msgctxt "dlgSgProviderPullRequestDropConfirmPr.btn:"
 msgid "Drop"
 msgstr "削除"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur:"
 msgid "The pull request itself will not be deleted on the server."
 msgstr "プルリクエスト自体はサーバー上で削除されることはありません。"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl:"
 msgid "Do you want to drop the local commits of pull request $1?"
 msgstr "プルリクエスト $1 のローカルコミットを本当に削除しますか?"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.tle"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.tle:"
 msgid "Drop Pull Request"
 msgstr "プルリクエストの削除"
 
@@ -7599,15 +7599,15 @@ msgctxt "dlgSgProviderPullRequestRetractMr.edt:"
 msgid "Comment"
 msgstr "コメント"
 
-msgctxt "dlgSgProviderPullRequestRetractMr.hdl"
+msgctxt "dlgSgProviderPullRequestRetractMr.hdl:"
 msgid "Retract Merge Request"
 msgstr "マージリクエストの取り消し"
 
-msgctxt "dlgSgProviderPullRequestRetractMr.inf"
+msgctxt "dlgSgProviderPullRequestRetractMr.inf:"
 msgid "Enter the comment which will be logged with the closed merge request."
 msgstr "クローズされたマージリクエストと共にログに記録されるコメントを入力します。"
 
-msgctxt "dlgSgProviderPullRequestRetractMr.tle"
+msgctxt "dlgSgProviderPullRequestRetractMr.tle:"
 msgid "Retract Merge Request"
 msgstr "マージリクエストの取り消し"
 
@@ -7619,15 +7619,15 @@ msgctxt "dlgSgProviderPullRequestRetractPr.edt:"
 msgid "Comment"
 msgstr "コメント"
 
-msgctxt "dlgSgProviderPullRequestRetractPr.hdl"
+msgctxt "dlgSgProviderPullRequestRetractPr.hdl:"
 msgid "Retract Pull Request"
 msgstr "プルリクエストの取り消し"
 
-msgctxt "dlgSgProviderPullRequestRetractPr.inf"
+msgctxt "dlgSgProviderPullRequestRetractPr.inf:"
 msgid "Enter the comment which will be logged with the closed pull request."
 msgstr "クローズされたプルリクエストと共にログに記録されるコメントを入力します。"
 
-msgctxt "dlgSgProviderPullRequestRetractPr.tle"
+msgctxt "dlgSgProviderPullRequestRetractPr.tle:"
 msgid "Retract Pull Request"
 msgstr "プルリクエストの取り消し"
 
@@ -7659,7 +7659,7 @@ msgctxt "dlgSgPull.edt:"
 msgid "Fetch From"
 msgstr "フェッチ元"
 
-msgctxt "dlgSgPull.hdl"
+msgctxt "dlgSgPull.hdl:"
 msgid "Pull commits from a remote repository"
 msgstr "リモートリポジトリからコミットをプル"
 
@@ -7671,7 +7671,7 @@ msgctxt "dlgSgPull.inf:"
 msgid "Select the remote repository to pull. In contrast to Fetch Only, Pull will also incorporate the fetched changes \\(expand the options below to configure\\)."
 msgstr "プルするリモート リポジトリを選択します。フェッチのみとは対照的に、プルはフェッチされた変更も取り込みます。 （以下のオプションを展開して設定します）"
 
-msgctxt "dlgSgPull.tle"
+msgctxt "dlgSgPull.tle:"
 msgid "Pull"
 msgstr "プル"
 
@@ -7683,11 +7683,11 @@ msgctxt "dlgSgPullConfiguration.chk:"
 msgid "Remember as default for other repositories"
 msgstr "他のリポジトリのデフォルトとして記憶させる"
 
-msgctxt "dlgSgPullConfiguration.hdl"
+msgctxt "dlgSgPullConfiguration.hdl:"
 msgid "Configure how to pull"
 msgstr "プル方法を設定する"
 
-msgctxt "dlgSgPullConfiguration.inf"
+msgctxt "dlgSgPullConfiguration.inf:"
 msgid "Specify whether to merge or rebase on Pull for the current repository."
 msgstr "現在のリポジトリでプルするとき、マージするかリベースするかを指定します。"
 
@@ -7707,7 +7707,7 @@ msgctxt "dlgSgPullConfiguration.rbt:"
 msgid "Rebase"
 msgstr "リベース"
 
-msgctxt "dlgSgPullConfiguration.tle"
+msgctxt "dlgSgPullConfiguration.tle:"
 msgid "Configure Pull"
 msgstr "プル設定"
 
@@ -7719,15 +7719,15 @@ msgctxt "dlgSgPullMergeInsteadOfRebase.btn:"
 msgid "Rebase"
 msgstr "リベース"
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.fur"
+msgctxt "dlgSgPullMergeInsteadOfRebase.fur:"
 msgid "Amongst the changes to rebase there is merge-commit $1. Rebasing merge-commits can easily cause troubles."
 msgstr "リベースの対象となる変更の中に、マージコミット $1 があります。マージコミットをリベースすると、簡単にトラブルが発生します。"
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.hdl"
+msgctxt "dlgSgPullMergeInsteadOfRebase.hdl:"
 msgid "Do you want to merge your local changes instead of rebasing?"
 msgstr "リベースの代わりにローカルの変更をマージしますか？"
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.tle"
+msgctxt "dlgSgPullMergeInsteadOfRebase.tle:"
 msgid "Pull"
 msgstr "プル"
 
@@ -7735,15 +7735,15 @@ msgctxt "dlgSgPullNoRemoteRepository.btn:"
 msgid "Add Remote"
 msgstr "リモートを追加"
 
-msgctxt "dlgSgPullNoRemoteRepository.fur"
+msgctxt "dlgSgPullNoRemoteRepository.fur:"
 msgid "You first need to add a remote repository to pull from."
 msgstr "プルするためのリモートリポジトリを追加する必要があります。"
 
-msgctxt "dlgSgPullNoRemoteRepository.hdl"
+msgctxt "dlgSgPullNoRemoteRepository.hdl:"
 msgid "No remote repository has been found."
 msgstr "リモート リポジトリが見つかりませんでした。"
 
-msgctxt "dlgSgPullNoRemoteRepository.tle"
+msgctxt "dlgSgPullNoRemoteRepository.tle:"
 msgid "Pull"
 msgstr "プル"
 
@@ -7763,15 +7763,15 @@ msgctxt "dlgSgPullOrJustFetch.chk:"
 msgid "Update existing and fetch new tags"
 msgstr "既存のタグの更新と新しいタグの取得"
 
-msgctxt "dlgSgPullOrJustFetch.fur"
+msgctxt "dlgSgPullOrJustFetch.fur:"
 msgid "You can change the Pull behavior in the Repository Settings."
 msgstr "プルの動作は、リポジトリ設定で変更することができます。"
 
-msgctxt "dlgSgPullOrJustFetch.hdl"
+msgctxt "dlgSgPullOrJustFetch.hdl:"
 msgid "Do you want to pull or just fetch $1 repositories?"
 msgstr "リポジトリ $1 をフェッチしますか?"
 
-msgctxt "dlgSgPullOrJustFetch.tle"
+msgctxt "dlgSgPullOrJustFetch.tle:"
 msgid "Pull"
 msgstr "プル"
 
@@ -7779,11 +7779,11 @@ msgctxt "dlgSgPullSubmoduleUpdate.btn:"
 msgid "Pull"
 msgstr "プル"
 
-msgctxt "dlgSgPullSubmoduleUpdate.fur"
+msgctxt "dlgSgPullSubmoduleUpdate.fur:"
 msgid "The git infrastructure for this submodule will be initialized and all commits will be pulled."
 msgstr "このサブモジュールのGit環境を初期化し、すべてのコミットを取得します。"
 
-msgctxt "dlgSgPullSubmoduleUpdate.tle"
+msgctxt "dlgSgPullSubmoduleUpdate.tle:"
 msgid "Pull Submodule"
 msgstr "サブモジュールをプル"
 
@@ -7791,19 +7791,19 @@ msgctxt "dlgSgPushConfirmSingleBranch.btn:"
 msgid "Push"
 msgstr "プッシュ"
 
-msgctxt "dlgSgPushConfirmSingleBranch.chk"
+msgctxt "dlgSgPushConfirmSingleBranch.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgPushConfirmSingleBranch.fur"
+msgctxt "dlgSgPushConfirmSingleBranch.fur:"
 msgid "1 branch will be pushed to '$1'."
 msgstr "1つのブランチが'$1'にプッシュされます。"
 
-msgctxt "dlgSgPushConfirmSingleBranch.hdl"
+msgctxt "dlgSgPushConfirmSingleBranch.hdl:"
 msgid "Do you want to push branch '$1'?"
 msgstr "ブランチ'$1'をプッシュしますか？"
 
-msgctxt "dlgSgPushConfirmSingleBranch.tle"
+msgctxt "dlgSgPushConfirmSingleBranch.tle:"
 msgid "Push"
 msgstr "プッシュ"
 
@@ -7811,11 +7811,11 @@ msgctxt "dlgSgPushConfirmSingleTag.btn:"
 msgid "Push"
 msgstr "プッシュ"
 
-msgctxt "dlgSgPushConfirmSingleTag.chk"
+msgctxt "dlgSgPushConfirmSingleTag.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgPushConfirmSingleTag.tle"
+msgctxt "dlgSgPushConfirmSingleTag.tle:"
 msgid "Push"
 msgstr "プッシュ"
 
@@ -7823,15 +7823,15 @@ msgctxt "dlgSgPushForced.btn:"
 msgid "Force Push"
 msgstr "強制プッシュ"
 
-msgctxt "dlgSgPushForced.fur"
+msgctxt "dlgSgPushForced.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr "リモートブランチへのプッシュは ファストフォワードできないので、強制的にプッシュする必要があります。リモートブランチでのコミットは失われます。"
 
-msgctxt "dlgSgPushForced.hdl"
+msgctxt "dlgSgPushForced.hdl:"
 msgid "Do you want to force-push \\(replace\\) the remote branch?"
 msgstr "リモートブランチを強制プッシュ（置き換え）しますか？"
 
-msgctxt "dlgSgPushForced.tle"
+msgctxt "dlgSgPushForced.tle:"
 msgid "Push"
 msgstr "プッシュ"
 
@@ -7839,15 +7839,15 @@ msgctxt "dlgSgPushForcedSvn.btn:"
 msgid "Force Push"
 msgstr "強制プッシュ"
 
-msgctxt "dlgSgPushForcedSvn.fur"
+msgctxt "dlgSgPushForcedSvn.fur:"
 msgid "You are about to replace the remote branch. Revisions of that branch might not be \\(easily\\) accessible anymore."
 msgstr "リモート ブランチを置き換えようとしています。そのブランチのリビジョンには \\(簡単には\\) アクセスできなくなる可能性があります。"
 
-msgctxt "dlgSgPushForcedSvn.hdl"
+msgctxt "dlgSgPushForcedSvn.hdl:"
 msgid "Do you want to force-push \\(replace\\) the remote branch?"
 msgstr "リモートブランチを強制プッシュ（置き換え）しますか？"
 
-msgctxt "dlgSgPushForcedSvn.tle"
+msgctxt "dlgSgPushForcedSvn.tle:"
 msgid "Push"
 msgstr "プッシュ"
 
@@ -7855,19 +7855,19 @@ msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.btn:"
 msgid "Push"
 msgstr "プッシュ"
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.chk"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.chk:"
 msgid "Overwrite remote changes"
 msgstr "リモートでの変更を上書きする"
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.fur"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.fur:"
 msgid "You are about to replace the remote branch, which contains commits that you haven't seen at all. Maybe you want to merge/rebase onto the remote changes before?"
 msgstr "未知のコミットを含むリモート ブランチを置き換えようとしています。プッシュする前にリモートの変更をマージ/リベースする必要はありませんか?"
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.hdl"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.hdl:"
 msgid "Do you really want to overwrite the remote branch?"
 msgstr "本当にリモートブランチを上書きしますか?"
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.tle"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.tle:"
 msgid "Push"
 msgstr "プッシュ"
 
@@ -7875,39 +7875,39 @@ msgctxt "dlgSgPushToAddRemote.btn:"
 msgid "Add Remote"
 msgstr "リモートを追加"
 
-msgctxt "dlgSgPushToAddRemote.fur"
+msgctxt "dlgSgPushToAddRemote.fur:"
 msgid "There is no remote repository configured yet. To push, you first need to configure that. After having added the remote, invoke Push again."
 msgstr "リモートリポジトリが設定されていません。プッシュを行うには、まずリモートリポジトリの設定が必要です。設定完了後、再度プッシュを実行してください。"
 
-msgctxt "dlgSgPushToAddRemote.hdl"
+msgctxt "dlgSgPushToAddRemote.hdl:"
 msgid "Do you want to add a remote?"
 msgstr "リモートを追加しますか？"
 
-msgctxt "dlgSgPushToAddRemote.tle"
+msgctxt "dlgSgPushToAddRemote.tle:"
 msgid "Push To"
 msgstr "プッシュ先"
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.fur"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.fur:"
 msgid "There is no other Git-remote to which branches of the selected remote could be pushed."
 msgstr "選択したリモートのブランチをプッシュできる他の Git リモートはありません。"
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.hdl"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.hdl:"
 msgid "No more Git remote found."
 msgstr "他のリモートリポジトリが見つかりません。"
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.tle"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.tle:"
 msgid "Push To"
 msgstr "プッシュ先"
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.fur"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.fur:"
 msgid "You can only push tags or local branches."
 msgstr "プッシュできるのはタグかローカルブランチのみです。"
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.hdl"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.hdl:"
 msgid "No tags or local branches to push."
 msgstr "プッシュするタグやローカル ブランチはありません。"
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.tle"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.tle:"
 msgid "Push To"
 msgstr "プッシュ先"
 
@@ -7951,7 +7951,7 @@ msgctxt "dlgSgPushToRef.hdl:"
 msgid "Push local commits to a remote repository"
 msgstr ""
 
-msgctxt "dlgSgPushToRef.inf"
+msgctxt "dlgSgPushToRef.inf:"
 msgid "Select the target repository where to push the ref\\(s\\)."
 msgstr "参照\\(Ref\\(s)\\)をプッシュするターゲット リポジトリを選択します。"
 
@@ -7963,7 +7963,7 @@ msgctxt "dlgSgPushToRef.rbt:"
 msgid "Tracked or matching branch"
 msgstr "追跡中または一致するブランチ"
 
-msgctxt "dlgSgPushToRef.tle"
+msgctxt "dlgSgPushToRef.tle:"
 msgid "Push To"
 msgstr "プッシュ先"
 
@@ -7983,15 +7983,15 @@ msgctxt "dlgSgPushToRemote.edt:"
 msgid "Target Repository"
 msgstr "ターゲットリポジトリ"
 
-msgctxt "dlgSgPushToRemote.hdl"
+msgctxt "dlgSgPushToRemote.hdl:"
 msgid "Push '$1' branches to another remote"
 msgstr "別のリモートに '$1' ブランチをプッシュする"
 
-msgctxt "dlgSgPushToRemote.inf"
+msgctxt "dlgSgPushToRemote.inf:"
 msgid "All branches of '$1' \\(as locally represented by the corresponding remote branches\\) will be pushed to the target repository."
 msgstr "'$1' のすべてのブランチがターゲットリポジトリにプッシュされます。\\r\\(リモートにローカルと対応するブランチが作成されます。\\)"
 
-msgctxt "dlgSgPushToRemote.tle"
+msgctxt "dlgSgPushToRemote.tle:"
 msgid "Push To"
 msgstr "プッシュ先"
 
@@ -7999,15 +7999,15 @@ msgctxt "dlgSgPushToRemoteRemoveTargetBranches.btn:"
 msgid "Remove"
 msgstr "除去"
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.fur"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.fur:"
 msgid "Removed branches and their commits in the target remote which will be lost afterwards."
 msgstr "ターゲットリモートのブランチとそのコミットを削除しました。これは後で失われます。"
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.hdl"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.hdl:"
 msgid "Do you really want to remove target remote branches?"
 msgstr "本当にターゲットのリモートブランチを削除しますか?"
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.tle"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.tle:"
 msgid "Push To"
 msgstr "プッシュ先"
 
@@ -8015,19 +8015,19 @@ msgctxt "dlgSgPushToRemoteResetTargetBranches.btn:"
 msgid "Force Push"
 msgstr "強制プッシュ"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.chk"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.fur"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.fur:"
 msgid "Forcing push will overwrite branches and their commits in the target remote which will be lost afterwards."
 msgstr "強制的にプッシュすると、ターゲットリモートのブランチとそのコミットが上書きされ、失われます。"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.hdl"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.hdl:"
 msgid "Do you really want to reset the target remote branches?"
 msgstr "本当に対象のリモートブランチをリセットしますか？"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.tle"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.tle:"
 msgid "Push To"
 msgstr "プッシュ先"
 
@@ -8039,15 +8039,15 @@ msgctxt "dlgSgPushTrackingConfigureSingle.btn:"
 msgid "Skip"
 msgstr "スキップ"
 
-msgctxt "dlgSgPushTrackingConfigureSingle.fur"
+msgctxt "dlgSgPushTrackingConfigureSingle.fur:"
 msgid "For your current branch tracking \\(its corresponding remote branch\\) has not been configured yet. Configuring tracking will keep your local branches in sync with the remote branches."
 msgstr "現在のブランチでは、トラッキング\\(対応するリモートブランチ\\)はまだ設定されていません。トラッキングを設定することで、ローカルブランチとリモートブランチの同期が保たれます。"
 
-msgctxt "dlgSgPushTrackingConfigureSingle.hdl"
+msgctxt "dlgSgPushTrackingConfigureSingle.hdl:"
 msgid "Do you want to configure tracking for '$1' branch?"
 msgstr "'$1' ブランチに対してトラッキングを設定しますか？"
 
-msgctxt "dlgSgPushTrackingConfigureSingle.tle"
+msgctxt "dlgSgPushTrackingConfigureSingle.tle:"
 msgid "Push"
 msgstr "プッシュ"
 
@@ -8059,15 +8059,15 @@ msgctxt "dlgSgRebase.btn:"
 msgid "Rebase HEAD to"
 msgstr "HEAD を 選択したコミットにリベース"
 
-msgctxt "dlgSgRebase.hdl"
+msgctxt "dlgSgRebase.hdl:"
 msgid "Rebase HEAD to"
 msgstr "HEAD を 選択したコミットにリベース"
 
-msgctxt "dlgSgRebase.inf"
+msgctxt "dlgSgRebase.inf:"
 msgid "Select the commit to which the HEAD commits should be rebased."
 msgstr "HEADコミットのリベース先となるコミットを選択します。"
 
-msgctxt "dlgSgRebase.tle"
+msgctxt "dlgSgRebase.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8075,15 +8075,15 @@ msgctxt "dlgSgRebaseConfirmUnreachable.btn:"
 msgid "Rebase"
 msgstr "リベース"
 
-msgctxt "dlgSgRebaseConfirmUnreachable.fur"
+msgctxt "dlgSgRebaseConfirmUnreachable.fur:"
 msgid "You only might be able to access this commit using the 'Recyclable Commits' option of the Branches view."
 msgstr "「ブランチ」 ビューの 「Recyclable Commits」 を選択することでのみ、このコミットにアクセスできる場合があります。"
 
-msgctxt "dlgSgRebaseConfirmUnreachable.hdl"
+msgctxt "dlgSgRebaseConfirmUnreachable.hdl:"
 msgid "The Commit $1 would become unreachable by refs."
 msgstr "コミット $1 は参照\\(refs\\)によって到達不能になります。"
 
-msgctxt "dlgSgRebaseConfirmUnreachable.tle"
+msgctxt "dlgSgRebaseConfirmUnreachable.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8091,19 +8091,19 @@ msgctxt "dlgSgRebaseContinueAfterSplittingCommit.btn:"
 msgid "Continue"
 msgstr "続ける"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur:"
 msgid "The splitting of commit $1 still is in progress and all changes of this commit have been applied."
 msgstr "コミット $1 の分割はまだ進行中で、このコミットのすべての変更が適用されています。"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.hdl"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.hdl:"
 msgid "Do you want to continue after splitting the commit?"
 msgstr "コミットを分割した後、続行しますか？"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.tle"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8111,31 +8111,31 @@ msgctxt "dlgSgRebaseContinueConfirm.btn:"
 msgid "Continue Rebase"
 msgstr "リベースを続ける"
 
-msgctxt "dlgSgRebaseContinueConfirm.chk"
+msgctxt "dlgSgRebaseContinueConfirm.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgRebaseContinueConfirm.fur"
+msgctxt "dlgSgRebaseContinueConfirm.fur:"
 msgid "Continue the rebase operation after having resolved all conflicts."
 msgstr "すべてのコンフリクトを解決した後、リベース操作を続行します。"
 
-msgctxt "dlgSgRebaseContinueConfirm.hdl"
+msgctxt "dlgSgRebaseContinueConfirm.hdl:"
 msgid "Do you want to continue the rebase?"
 msgstr "リベースを続行しますか?"
 
-msgctxt "dlgSgRebaseContinueConfirm.tle"
+msgctxt "dlgSgRebaseContinueConfirm.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
-msgctxt "dlgSgRebaseContinueConflicts.fur"
+msgctxt "dlgSgRebaseContinueConflicts.fur:"
 msgid "Please resolve all conflicts before continuing the rebase."
 msgstr "リベースを続行する前に、すべての競合を解決してください。"
 
-msgctxt "dlgSgRebaseContinueConflicts.hdl"
+msgctxt "dlgSgRebaseContinueConflicts.hdl:"
 msgid "Can't continue rebase with conflicts."
 msgstr "競合があるため、リベースを続行できません。"
 
-msgctxt "dlgSgRebaseContinueConflicts.tle"
+msgctxt "dlgSgRebaseContinueConflicts.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8143,19 +8143,19 @@ msgctxt "dlgSgRebaseContinueNothingToCommitContinue.btn:"
 msgid "Continue Rebase"
 msgstr "リベースを続行する"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.chk"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.fur:"
 msgid "The repository is in 'rebasing' state and there is nothing to commit, so you may just continue the Rebase."
 msgstr "リポジトリは「リベース中」の状態ですが、コミットするものがないため、リベースを続行できます。"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.hdl:"
 msgid "Do you want to continue the rebase?"
 msgstr "リベースを続行しますか?"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8163,15 +8163,15 @@ msgctxt "dlgSgRebaseContinueNothingToCommitSkip.btn:"
 msgid "Skip Commit"
 msgstr "コミットをスキップ"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.fur:"
 msgid "The repository is in 'rebasing' state, but there is nothing to commit, so you may just skip this rebased commit."
 msgstr "リポジトリは「リベース中」の状態ですが、コミットするものがないため、このリベース コミットをスキップできます。"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.hdl:"
 msgid "Do you want to skip this rebased commit?"
 msgstr "このリベースされたコミットをスキップしますか?"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8183,15 +8183,15 @@ msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.btn:"
 msgid "Preserve"
 msgstr "保持"
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.fur"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.fur:"
 msgid "Your working tree contains untracked files. You may either choose to preserve them in the working tree or include them for the rebased commit."
 msgstr "作業ツリーに追跡されていないファイルが含まれています。それらを作業ツリーに保持するか、リベース後のコミットに含めるかを選択することができます。"
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.hdl"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.hdl:"
 msgid "Do you want to preserve untracked files in your working tree?"
 msgstr "追跡されていないファイルを作業ツリーに保持しますか?"
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.tle"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8199,15 +8199,15 @@ msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.btn:"
 msgid "Continue"
 msgstr "続ける"
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.fur"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.fur:"
 msgid "Rebase Continue will store all working tree changes in the commit."
 msgstr "リベースの続行は、すべての作業ツリーの変更をコミットに保存します。"
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.hdl"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.hdl:"
 msgid "Do you want the working tree changes to be part of the new commit?"
 msgstr "作業ツリーの変更を新しいコミットの一部にしますか？"
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.tle"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8215,18 +8215,18 @@ msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.btn:"
 msgid "Continue"
 msgstr "続ける"
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.fur"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.fur:"
 msgid "Rebase Continue will store both, staged changes and the working tree changes, in the new commit!\\n\\nIf the staged changes should go to a seperate commit, first commit them, and then invoke Continue again."
 msgstr ""
 "リベース継続時に、ステージされた変更と作業ツリーの変更の両方が新しいコミットに保存されます！\n"
 "\n"
 "ステージされた変更を別のコミットにしたい場合は、先にそれらをコミットしてから、再度リベースを継続してください。"
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.hdl"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.hdl:"
 msgid "Do you want the working tree changes to be applied, too?"
 msgstr "作業ツリーの変更も適用しますか？"
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.tle"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8238,31 +8238,31 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.btn:"
 msgid "Put Changes into Index"
 msgstr "Indexに変更を反映"
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur:"
 msgid "The splitting of commit $1 still is in progress, but not all changes of this commit have been applied.\\n\\nIf this is intentional, you can continue. Otherwise, you should click 'Put Changes into Index' and review your changes."
 msgstr "コミット $1 の分割はまだ進行中ですが、このコミットのすべての変更が適用されているわけではありません。\\n\\nこれが意図的なものである場合は、続行できます。それ以外の場合は、「Indexに変更を反映」 をクリックして、変更内容を確認してください。"
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.hdl"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.hdl:"
 msgid "Do you want to continue splitting the commit without applying all changes?"
 msgstr "すべての変更を適用せずに、コミットの分割を続行しますか?"
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) onto the selected commit."
 msgstr "これにより、作業ツリーのブランチ '$1' \\(HEAD\\) からのすべてのコミットが、選択したコミットに適用されます。"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl:"
 msgid "Do you want to rebase '$1' onto the selected commit?"
 msgstr "'$1' を選択したコミットにリベースしますか？"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) to '$2'."
 msgstr "これは、作業ツリーのブランチ '$1' \\(HEAD\\) からのすべてのコミットを '$2' に適用します。"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl:"
 msgid "Do you want to rebase '$1' to '$2'?"
 msgstr "'$1' を '$2' にリベースしますか？"
 
@@ -8274,7 +8274,7 @@ msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).btn:"
 msgid "Rebase Interactively"
 msgstr "対話的なリベース"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).tle"
+msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).tle:"
 msgid "Rebase HEAD to Selected Commit"
 msgstr "HEAD を選択したコミットにリベースする"
 
@@ -8318,11 +8318,11 @@ msgctxt "dlgSgRebaseInteractive.col:"
 msgid "Message"
 msgstr "メッセージ"
 
-msgctxt "dlgSgRebaseInteractive.hdl"
+msgctxt "dlgSgRebaseInteractive.hdl:"
 msgid "Rewrite History"
 msgstr "履歴を書き換える"
 
-msgctxt "dlgSgRebaseInteractive.inf"
+msgctxt "dlgSgRebaseInteractive.inf:"
 msgid "Reorder or squash commits according to your needs."
 msgstr "必要に応じてコミットを並べ替えたり、スカッシュします。"
 
@@ -8338,19 +8338,19 @@ msgctxt "dlgSgRebaseInteractive.mni:"
 msgid "To Top Commit"
 msgstr "最上部のコミットへ"
 
-msgctxt "dlgSgRebaseInteractive.tle"
+msgctxt "dlgSgRebaseInteractive.tle:"
 msgid "Rebase Interactive"
 msgstr "対話的なリベース"
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.fur"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.fur:"
 msgid "You need to select the first commit in the current branch's history that should be modified. All commits between this commit and HEAD must have exactly one parent."
 msgstr "現在のブランチの履歴の中で、変更すべき最初のコミットを選択する必要があります。このコミットから HEAD までのすべてのコミットには、ちょうどひとつの親がなければなりません。"
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.hdl"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.hdl:"
 msgid "Changing the initial commit is not supported by the interactive rebase."
 msgstr "初期コミットの変更は、対話型リベースではサポートされていません。"
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.tle"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.tle:"
 msgid "Rebase Interactive"
 msgstr "対話的なリベース"
 
@@ -8362,15 +8362,15 @@ msgctxt "dlgSgRebaseInteractiveMessage.edt:"
 msgid "New Message"
 msgstr "新しいメッセージ"
 
-msgctxt "dlgSgRebaseInteractiveMessage.hdl"
+msgctxt "dlgSgRebaseInteractiveMessage.hdl:"
 msgid "Edit commit message"
 msgstr "コミットメッセージを編集"
 
-msgctxt "dlgSgRebaseInteractiveMessage.inf"
+msgctxt "dlgSgRebaseInteractiveMessage.inf:"
 msgid "Provide the new message for the commit."
 msgstr "コミット用の新しいメッセージを指定します。"
 
-msgctxt "dlgSgRebaseInteractiveMessage.tle"
+msgctxt "dlgSgRebaseInteractiveMessage.tle:"
 msgid "Edit Message"
 msgstr "メッセージの編集"
 
@@ -8378,39 +8378,39 @@ msgctxt "dlgSgRebaseInteractiveRemoveCommit.btn:"
 msgid "Remove"
 msgstr "除去"
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur:"
 msgid "It might become hard or impossible to recover the commit again."
 msgstr "コミットを再び回復することが困難または不可能になる可能性があります。"
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl:"
 msgid "Do you want to remove the selected commit $1?"
 msgstr "選択したコミット $1 を削除しますか?"
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.tle"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.tle:"
 msgid "Remove Commit"
 msgstr "コミットを削除"
 
-msgctxt "dlgSgRebaseNoop.fur"
+msgctxt "dlgSgRebaseNoop.fur:"
 msgid "Rebasing a commit onto itself is technically allowed by Git but it's a no-op and will not give a new commit nor any other meaningful changes."
 msgstr "コミットを自身にリベースすることはGitで技術的には可能ですが、実質的に無効な操作となり、新しいコミットや意味のある変更は一切発生しません。"
 
-msgctxt "dlgSgRebaseNoop.hdl"
+msgctxt "dlgSgRebaseNoop.hdl:"
 msgid "There is nothing to rebase."
 msgstr "リベースするものはありません。"
 
-msgctxt "dlgSgRebaseNoop.tle"
+msgctxt "dlgSgRebaseNoop.tle:"
 msgid "Merge"
 msgstr "マージ"
 
-msgctxt "dlgSgRebaseNoopSelf.fur"
+msgctxt "dlgSgRebaseNoopSelf.fur:"
 msgid "Rebasing a commit onto itself is allowed by Git but will not create a new commit or any meaningful changes."
 msgstr "コミットを自身にリベースすることはGitで可能ですが、新しいコミットや意味のある変更は一切発生しません。"
 
-msgctxt "dlgSgRebaseNoopSelf.hdl"
+msgctxt "dlgSgRebaseNoopSelf.hdl:"
 msgid "There is nothing to rebase."
 msgstr "リベースするものは何もありません。"
 
-msgctxt "dlgSgRebaseNoopSelf.tle"
+msgctxt "dlgSgRebaseNoopSelf.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8422,15 +8422,15 @@ msgctxt "dlgSgRebaseTagCommit.btn:"
 msgid "Skip Tag"
 msgstr "タグをスキップ"
 
-msgctxt "dlgSgRebaseTagCommit.fur"
+msgctxt "dlgSgRebaseTagCommit.fur:"
 msgid "After the rebase, the remaining commit won't be reachable anymore."
 msgstr "リベースの後、残りのコミットには到達できなくなります。"
 
-msgctxt "dlgSgRebaseTagCommit.hdl"
+msgctxt "dlgSgRebaseTagCommit.hdl:"
 msgid "Should commit $1 be tagged?"
 msgstr "コミット$1 にタグを付ける必要がありますか？"
 
-msgctxt "dlgSgRebaseTagCommit.tle"
+msgctxt "dlgSgRebaseTagCommit.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8438,15 +8438,15 @@ msgctxt "dlgSgRebasingAbortConfirm.btn:"
 msgid "Abort Rebase"
 msgstr "リベースを中止"
 
-msgctxt "dlgSgRebasingAbortConfirm.fur"
+msgctxt "dlgSgRebasingAbortConfirm.fur:"
 msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase HEAD To instead.\\n\\nAborting will clean any local modification \\(by invoking 'git reset --hard'\\)!"
 msgstr "作業ツリーは「リベース中」の状態です。リベースを中止できます。現在のパッチをスキップしたい場合は、代わりに\\[ブランチ\\]→\\[リベース\\]→\\[リベース HEAD to\\] を使用してください。\\n\\n中止すると、ローカルの変更を消去することができます。\\('git reset --hard' の実行\\）"
 
-msgctxt "dlgSgRebasingAbortConfirm.hdl"
+msgctxt "dlgSgRebasingAbortConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
 msgstr "リベースを中止しますか？"
 
-msgctxt "dlgSgRebasingAbortConfirm.tle"
+msgctxt "dlgSgRebasingAbortConfirm.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
@@ -8458,11 +8458,11 @@ msgctxt "dlgSgRecursiveStage.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgRecursiveStage.hdl"
+msgctxt "dlgSgRecursiveStage.hdl:"
 msgid "Save working tree changes in the Index for later commit"
 msgstr "作業ツリーの変更をインデックスに保存し、後でコミットできるようにする。"
 
-msgctxt "dlgSgRecursiveStage.inf"
+msgctxt "dlgSgRecursiveStage.inf:"
 msgid "Select the files to stage to the Index."
 msgstr "Indexにステージングするファイルを選択します。"
 
@@ -8478,7 +8478,7 @@ msgctxt "dlgSgRecursiveStage.mni:"
 msgid "Toggle"
 msgstr "トグル"
 
-msgctxt "dlgSgRecursiveStage.tle"
+msgctxt "dlgSgRecursiveStage.tle:"
 msgid "Stage"
 msgstr "ステージ"
 
@@ -8490,15 +8490,15 @@ msgctxt "dlgSgRecursiveUnstage.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgRecursiveUnstage.hdl"
+msgctxt "dlgSgRecursiveUnstage.hdl:"
 msgid "Revert staged changes from the Index to the working tree"
 msgstr "ステージングされた変更をIndexから作業ツリーに戻す"
 
-msgctxt "dlgSgRecursiveUnstage.inf"
+msgctxt "dlgSgRecursiveUnstage.inf:"
 msgid "Select the files to unstage from the Index."
 msgstr "アンステージするファイルをIndexから選択します。"
 
-msgctxt "dlgSgRecursiveUnstage.tle"
+msgctxt "dlgSgRecursiveUnstage.tle:"
 msgid "Unstage"
 msgstr "アンステージ"
 
@@ -8514,15 +8514,15 @@ msgctxt "dlgSgRemoteDeleteConfirm.btn:"
 msgid "Delete"
 msgstr "削除"
 
-msgctxt "dlgSgRemoteDeleteConfirm.fur"
+msgctxt "dlgSgRemoteDeleteConfirm.fur:"
 msgid "This will just delete the link to the remote repository."
 msgstr "これは、リモートリポジトリへのリンクを削除するだけです。"
 
-msgctxt "dlgSgRemoteDeleteConfirm.hdl"
+msgctxt "dlgSgRemoteDeleteConfirm.hdl:"
 msgid "Do you want to delete the remote repository '$1'?"
 msgstr "リモートリポジトリ'$1'を削除しますか？"
 
-msgctxt "dlgSgRemoteDeleteConfirm.tle"
+msgctxt "dlgSgRemoteDeleteConfirm.tle:"
 msgid "Delete Remote Repository"
 msgstr "リモートリポジトリを削除"
 
@@ -8534,27 +8534,27 @@ msgctxt "dlgSgRemoteFetchMore.col:"
 msgid "Branch"
 msgstr "ブランチ"
 
-msgctxt "dlgSgRemoteFetchMore.hdl"
+msgctxt "dlgSgRemoteFetchMore.hdl:"
 msgid "Fetch remote branches"
 msgstr "リモートブランチの取得"
 
-msgctxt "dlgSgRemoteFetchMore.inf"
+msgctxt "dlgSgRemoteFetchMore.inf:"
 msgid "Select the branches to fetch from the remote repository."
 msgstr "リモートリポジトリからフェッチするブランチを選択します。"
 
-msgctxt "dlgSgRemoteFetchMore.tle"
+msgctxt "dlgSgRemoteFetchMore.tle:"
 msgid "Fetch More"
 msgstr "追加のフェッチ"
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.fur"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.fur:"
 msgid "All branches which are present in the remote repository are already locally present as well."
 msgstr "リモートリポジトリに存在するすべてのブランチは、すでにローカルにも存在します。"
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.hdl"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.hdl:"
 msgid "There are no more remote branches to fetch."
 msgstr "取得するリモート ブランチはありません。"
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.tle"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.tle:"
 msgid "Fetch More"
 msgstr "追加のフェッチ"
 
@@ -8566,15 +8566,15 @@ msgctxt "dlgSgRemoteProperties.edt:"
 msgid "URL or Path"
 msgstr "URL or パス"
 
-msgctxt "dlgSgRemoteProperties.hdl"
+msgctxt "dlgSgRemoteProperties.hdl:"
 msgid "Configure remote properties"
 msgstr "リモートプロパティの設定"
 
-msgctxt "dlgSgRemoteProperties.inf"
+msgctxt "dlgSgRemoteProperties.inf:"
 msgid "Change the URL and other properties for the remote."
 msgstr "リモートのURLやその他のプロパティを変更します"
 
-msgctxt "dlgSgRemoteProperties.tle"
+msgctxt "dlgSgRemoteProperties.tle:"
 msgid "Remote Properties"
 msgstr "リモート プロパティ"
 
@@ -8582,15 +8582,15 @@ msgctxt "dlgSgRemoteSelect.edt:"
 msgid "Remote"
 msgstr "リモート"
 
-msgctxt "dlgSgRemoteSelect.hdl"
+msgctxt "dlgSgRemoteSelect.hdl:"
 msgid "Initialize remote review database"
 msgstr "リモート レビュー データベースの初期化"
 
-msgctxt "dlgSgRemoteSelect.inf"
+msgctxt "dlgSgRemoteSelect.inf:"
 msgid "Select the remote repository for which you want to initialize the review database."
 msgstr "レビュー データベースを初期化するリモート リポジトリを選択します。"
 
-msgctxt "dlgSgRemoteSelect.tle"
+msgctxt "dlgSgRemoteSelect.tle:"
 msgid "Initialize Remote"
 msgstr "リモートの初期化"
 
@@ -8606,15 +8606,15 @@ msgctxt "dlgSgRemoteSetDepth.err:"
 msgid "Please enter a valid commit count."
 msgstr "有効なコミット数を入力してください。"
 
-msgctxt "dlgSgRemoteSetDepth.hdl"
+msgctxt "dlgSgRemoteSetDepth.hdl:"
 msgid "Set repository depth"
 msgstr "リポジトリの深さを設定"
 
-msgctxt "dlgSgRemoteSetDepth.inf"
+msgctxt "dlgSgRemoteSetDepth.inf:"
 msgid "Use a large number \\(e.g. 100000\\) to set an unlimited depth."
 msgstr "深さを無制限に設定する場合は、大きな数値\\(例:100000\\)を使用します。"
 
-msgctxt "dlgSgRemoteSetDepth.tle"
+msgctxt "dlgSgRemoteSetDepth.tle:"
 msgid "Set Depth"
 msgstr "深さの設定"
 
@@ -8634,11 +8634,11 @@ msgctxt "dlgSgRemotesAdd.edt:"
 msgid "URL or Path"
 msgstr "URL or パス"
 
-msgctxt "dlgSgRemotesAdd.hdl"
+msgctxt "dlgSgRemotesAdd.hdl:"
 msgid "Add a remote repository"
 msgstr "リモートリポジトリの追加"
 
-msgctxt "dlgSgRemotesAdd.inf"
+msgctxt "dlgSgRemotesAdd.inf:"
 msgid "Enter the URL and a short name for the remote repository."
 msgstr "リモートリポジトリのURLと短い名前を入力します。"
 
@@ -8674,19 +8674,19 @@ msgctxt "dlgSgRemotesAdd.mni:"
 msgid "Select Local Repository"
 msgstr "ローカルリポジトリを選択"
 
-msgctxt "dlgSgRemotesAdd.tle"
+msgctxt "dlgSgRemotesAdd.tle:"
 msgid "Add Remote Repository"
 msgstr "リモートリポジトリを追加"
 
-msgctxt "dlgSgRemotesNoRemoteDetected.fur"
+msgctxt "dlgSgRemotesNoRemoteDetected.fur:"
 msgid "To perform the operation the repository configuration for $1 must contain one uniquely determined remote."
 msgstr "このこの操作を行うには、$1 のリポジトリ構成に、一意に決定された 1 つのリモートが含まれている必要があります。"
 
-msgctxt "dlgSgRemotesNoRemoteDetected.hdl"
+msgctxt "dlgSgRemotesNoRemoteDetected.hdl:"
 msgid "No remote detected."
 msgstr "リモートが検出されませんでした。"
 
-msgctxt "dlgSgRemotesNoRemoteDetected.tle"
+msgctxt "dlgSgRemotesNoRemoteDetected.tle:"
 msgid "Push Up To"
 msgstr "プッシュアップ"
 
@@ -8706,15 +8706,15 @@ msgctxt "dlgSgRemove.col:"
 msgid "Name"
 msgstr "名前"
 
-msgctxt "dlgSgRemove.hdl"
+msgctxt "dlgSgRemove.hdl:"
 msgid "Remove files from the repository"
 msgstr "リポジトリからをファイル削除"
 
-msgctxt "dlgSgRemove.inf"
+msgctxt "dlgSgRemove.inf:"
 msgid "Select the files you want to remove from the repository or working tree \\(stopped from tracking\\)."
 msgstr "リポジトリや作業ツリーから削除したい（追跡を停止したい）ファイルを選択します。"
 
-msgctxt "dlgSgRemove.tle"
+msgctxt "dlgSgRemove.tle:"
 msgid "Remove"
 msgstr "除去"
 
@@ -8726,15 +8726,15 @@ msgctxt "dlgSgRenameBranch.edt:"
 msgid "Name"
 msgstr "名前"
 
-msgctxt "dlgSgRenameBranch.hdl"
+msgctxt "dlgSgRenameBranch.hdl:"
 msgid "Rename branch"
 msgstr "ブランチの名前を変更する"
 
-msgctxt "dlgSgRenameBranch.inf"
+msgctxt "dlgSgRenameBranch.inf:"
 msgid "Enter the new name for the branch '$1'."
 msgstr "ブランチの新しい名前 '$1' を入力してください。"
 
-msgctxt "dlgSgRenameBranch.tle"
+msgctxt "dlgSgRenameBranch.tle:"
 msgid "Rename"
 msgstr "リネーム"
 
@@ -8746,15 +8746,15 @@ msgctxt "dlgSgRenameFile.edt:"
 msgid "Path"
 msgstr "パス"
 
-msgctxt "dlgSgRenameFile.hdl"
+msgctxt "dlgSgRenameFile.hdl:"
 msgid "Move or Rename the file"
 msgstr "移動またはファイル名を変更する"
 
-msgctxt "dlgSgRenameFile.inf"
+msgctxt "dlgSgRenameFile.inf:"
 msgid "Enter the new path and name of the file."
 msgstr "新しいパスとファイル名を入力してください。"
 
-msgctxt "dlgSgRenameFile.tle"
+msgctxt "dlgSgRenameFile.tle:"
 msgid "Move or Rename"
 msgstr "移動または名前を変更"
 
@@ -8766,15 +8766,15 @@ msgctxt "dlgSgRenameRemote.edt:"
 msgid "Name"
 msgstr "名前"
 
-msgctxt "dlgSgRenameRemote.hdl"
+msgctxt "dlgSgRenameRemote.hdl:"
 msgid "Change the name of an existing remote"
 msgstr "既存のリモートの名前を変更する"
 
-msgctxt "dlgSgRenameRemote.inf"
+msgctxt "dlgSgRenameRemote.inf:"
 msgid "Provide the new name of the selected remote."
 msgstr "選択したリモートの新しい名前を入力します。"
 
-msgctxt "dlgSgRenameRemote.tle"
+msgctxt "dlgSgRenameRemote.tle:"
 msgid "Rename Remote Repository"
 msgstr "リモートリポジトリの名前を変更する"
 
@@ -8786,15 +8786,15 @@ msgctxt "dlgSgRenameRepository.edt:"
 msgid "Name"
 msgstr "名前"
 
-msgctxt "dlgSgRenameRepository.hdl"
+msgctxt "dlgSgRenameRepository.hdl:"
 msgid "Rename repository"
 msgstr "リポジトリの名前を変更する"
 
-msgctxt "dlgSgRenameRepository.inf"
+msgctxt "dlgSgRenameRepository.inf:"
 msgid "Provide the new name for the repository. The repository directory will not be renamed."
 msgstr "リポジトリの新しい名前を指定します。リポジトリディレクトリの名前は変更されません。"
 
-msgctxt "dlgSgRenameRepository.tle"
+msgctxt "dlgSgRenameRepository.tle:"
 msgid "Rename"
 msgstr "リネーム"
 
@@ -8814,11 +8814,11 @@ msgctxt "dlgSgRepositoriesSearch.edt:"
 msgid "Search In"
 msgstr "検索対象"
 
-msgctxt "dlgSgRepositoriesSearch.hdl"
+msgctxt "dlgSgRepositoriesSearch.hdl:"
 msgid "Search existing local repositories"
 msgstr "既存のローカルリポジトリの検索"
 
-msgctxt "dlgSgRepositoriesSearch.inf"
+msgctxt "dlgSgRepositoriesSearch.inf:"
 msgid "Select a root directory where the search should start and click 'Start Search'."
 msgstr "検索対象のルートディレクトリを指定し、「検索」をクリックします。"
 
@@ -8854,7 +8854,7 @@ msgctxt "dlgSgRepositoriesSearch.mni:"
 msgid "Toggle"
 msgstr "トグル"
 
-msgctxt "dlgSgRepositoriesSearch.tle"
+msgctxt "dlgSgRepositoriesSearch.tle:"
 msgid "Search for Repositories"
 msgstr "リポジトリの検索"
 
@@ -8866,15 +8866,15 @@ msgctxt "dlgSgRepositoryAddGroup.edt:"
 msgid "Group Name"
 msgstr "グループ名"
 
-msgctxt "dlgSgRepositoryAddGroup.hdl"
+msgctxt "dlgSgRepositoryAddGroup.hdl:"
 msgid "Enter the group name"
 msgstr "グループ名を入力してください"
 
-msgctxt "dlgSgRepositoryAddGroup.inf"
+msgctxt "dlgSgRepositoryAddGroup.inf:"
 msgid "After having created the group, you can move repositories inside it."
 msgstr "グループ作成後は、その中でリポジトリを移動させることができます。"
 
-msgctxt "dlgSgRepositoryAddGroup.tle"
+msgctxt "dlgSgRepositoryAddGroup.tle:"
 msgid "Add Group"
 msgstr "グループを作成"
 
@@ -8886,15 +8886,15 @@ msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Close"
 msgstr "強制的に閉じる"
 
-msgctxt "dlgSgRepositoryClose.fur"
+msgctxt "dlgSgRepositoryClose.fur:"
 msgid "Note that currently running Git processes might not be interrupted."
 msgstr "現在実行中のGitプロセスは中止されない可能性があることに注意してください。"
 
-msgctxt "dlgSgRepositoryClose.hdl"
+msgctxt "dlgSgRepositoryClose.hdl:"
 msgid "Do you really want to close now?"
 msgstr "本当に今すぐ閉じますか？"
 
-msgctxt "dlgSgRepositoryClose.tle"
+msgctxt "dlgSgRepositoryClose.tle:"
 msgid "Close"
 msgstr "閉じる"
 
@@ -8902,19 +8902,19 @@ msgctxt "dlgSgRepositoryFrameCloseWithoutPush.btn:"
 msgid "Close Now"
 msgstr "今すぐ閉じる"
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.chk"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.fur"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.fur:"
 msgid "You have pushable commits. Maybe you want to push them before closing this window."
 msgstr "プッシュ可能なコミットがあります。このウィンドウを閉じる前にプッシュする必要はありませんか?"
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.hdl"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.hdl:"
 msgid "Do you want to close without having pushed commits?"
 msgstr "コミットをプッシュせずに終了しますか？"
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.tle"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.tle:"
 msgid "Close"
 msgstr "閉じる"
 
@@ -8922,91 +8922,91 @@ msgctxt "dlgSgRepositoryOpen.btn:"
 msgid "Remove"
 msgstr "除去"
 
-msgctxt "dlgSgRepositoryOpen.fur"
+msgctxt "dlgSgRepositoryOpen.fur:"
 msgid "If it is relocated, remove it and add its new location."
 msgstr "移動した場合は、削除して新しい場所を追加してください。"
 
-msgctxt "dlgSgRepositoryOpen.hdl"
+msgctxt "dlgSgRepositoryOpen.hdl:"
 msgid "Do you want to remove the missing repository '$1'?"
 msgstr "見つからないリポジトリ'$1'を削除しますか？"
 
-msgctxt "dlgSgRepositoryOpen.tle"
+msgctxt "dlgSgRepositoryOpen.tle:"
 msgid "Repository Opening"
 msgstr "リポジトリを開く"
 
-msgctxt "dlgSgRepositoryRemoveFailed1.fur"
+msgctxt "dlgSgRepositoryRemoveFailed1.fur:"
 msgid "This could happen if the repository is open in another window or currently commands are executed."
 msgstr "別のウィンドウでリポジトリが開かれている場合や、コマンドが実行中の場合に、このようなことが起こる可能性があります。"
 
-msgctxt "dlgSgRepositoryRemoveFailed1.hdl"
+msgctxt "dlgSgRepositoryRemoveFailed1.hdl:"
 msgid "The repository '$1' could not be removed."
 msgstr "リポジトリ '$1' を削除できませんでした。"
 
-msgctxt "dlgSgRepositoryRemoveFailed1.tle"
+msgctxt "dlgSgRepositoryRemoveFailed1.tle:"
 msgid "Remove"
 msgstr "除去"
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "削除されたグループ内のリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl:"
 msgid "Do you want to remove $1 groups?"
 msgstr "グループ'$1'を削除しますか？"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "これは、ディスク上のリポジトリを維持しつつ、SmartGitに忘れさせるだけです。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl:"
 msgid "Do you want to remove $1 repositories?"
 msgstr "リポジトリ'$1'を削除しますか？"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "これにより、ディスク上のリポジトリは維持されますが、SmartGitはそのことを忘れてしまいます。削除されたグループの中にあるリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl:"
 msgid "Do you want to remove $1 repositories and $2 groups?"
 msgstr "リポジトリ'$1'とグループ'$2'を削除しますか？"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "これにより、ディスク上のリポジトリは維持されますが、SmartGitはそのことを忘れてしまいます。削除されたグループの中にあるリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl:"
 msgid "Do you want to remove $1 repositories and the group \"$2\"?"
 msgstr "リポジトリ'$1'とグループ'$2'を削除しますか？"
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "削除されたグループ内のリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl:"
 msgid "Do you want to remove the group \"$1\"?"
 msgstr "グループ'$1'を削除しますか？"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "これは、ディスク上のリポジトリを維持しつつ、SmartGitに忘れさせるだけです。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl:"
 msgid "Do you want to remove the repository \"$1\"?"
 msgstr "リポジトリ '$1' を削除しますか?"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "これにより、ディスク上のリポジトリは維持されますが、SmartGitはそのことを忘れてしまいます。削除されたグループの中にあるリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl:"
 msgid "Do you want to remove the repository \"$1\" and $2 groups?"
 msgstr "リポジトリ '$1' および '$2' グループを削除しますか?"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "これにより、ディスク上のリポジトリは維持されますが、SmartGitはそのことを忘れてしまいます。削除されたグループの中にあるリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl:"
 msgid "Do you want to remove the repository \"$1\" and the group \"$2\"?"
 msgstr "リポジトリ '$1' とグループ '$2' を削除しますか?"
 
@@ -9082,11 +9082,11 @@ msgctxt "dlgSgRepositorySettings.err:"
 msgid "Please enter a valid, comma-separated list of regular expressions."
 msgstr "有効なカンマ区切りの正規表現のリストを入力してください。"
 
-msgctxt "dlgSgRepositorySettings.hdl"
+msgctxt "dlgSgRepositorySettings.hdl:"
 msgid "Edit the repository settings"
 msgstr "リポジトリの設定を編集する"
 
-msgctxt "dlgSgRepositorySettings.inf"
+msgctxt "dlgSgRepositorySettings.inf:"
 msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
 msgstr "ここでは、このリポジトリ用のGit設定を編集することができます。デフォルトの設定は「環境設定」にあります。"
 
@@ -9122,7 +9122,7 @@ msgctxt "dlgSgRepositorySettings.tab:"
 msgid "User"
 msgstr "ユーザー"
 
-msgctxt "dlgSgRepositorySettings.tle"
+msgctxt "dlgSgRepositorySettings.tle:"
 msgid "Repository Settings"
 msgstr "リポジトリの設定"
 
@@ -9166,7 +9166,7 @@ msgctxt "dlgSgResetAdv.chk:"
 msgid "Thoroughly fix line-endings according to .gitattributes"
 msgstr ".gitattributes に従って行末を徹底的に修正する"
 
-msgctxt "dlgSgResetAdv.hdl"
+msgctxt "dlgSgResetAdv.hdl:"
 msgid "Reset to commit $1"
 msgstr "コミット $1 にリセット"
 
@@ -9214,7 +9214,7 @@ msgctxt "dlgSgResetAdv.rbt:"
 msgid "Reset the Index but not the working tree - 'mixed'"
 msgstr "インデックスをリセットするが、作業ツリーはリセットしない - 'mixed'"
 
-msgctxt "dlgSgResetAdv.tle"
+msgctxt "dlgSgResetAdv.tle:"
 msgid "Reset"
 msgstr "リセット"
 
@@ -9222,15 +9222,15 @@ msgctxt "dlgSgResetConfirm.btn:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "dlgSgResetConfirm.fur"
+msgctxt "dlgSgResetConfirm.fur:"
 msgid "Current staged and local changes will be lost!"
 msgstr "現在のステージング領域とローカルの変更は失われます"
 
-msgctxt "dlgSgResetConfirm.hdl"
+msgctxt "dlgSgResetConfirm.hdl:"
 msgid "Do you want to reset the HEAD to commit $1?"
 msgstr "HEADを コミット'$1' にリセットしますか？"
 
-msgctxt "dlgSgResetConfirm.tle"
+msgctxt "dlgSgResetConfirm.tle:"
 msgid "Reset"
 msgstr "リセット"
 
@@ -9246,11 +9246,11 @@ msgctxt "dlgSgResolve.edt:"
 msgid "Content"
 msgstr "コンテンツ"
 
-msgctxt "dlgSgResolve.hdl"
+msgctxt "dlgSgResolve.hdl:"
 msgid "Resolve Conflict"
 msgstr "競合を解決する"
 
-msgctxt "dlgSgResolve.inf"
+msgctxt "dlgSgResolve.inf:"
 msgid "Select which content to use for the resolved file\\(s\\)."
 msgstr "解決されたファイルに使用するコンテンツを選択します。"
 
@@ -9262,23 +9262,23 @@ msgctxt "dlgSgResolve.rbt:"
 msgid "Open Conflict Solver"
 msgstr "競合解決ツールを開く"
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
 msgid "Set to $1 \\(\"ours\", $2\\)"
 msgstr "$1 に設定\\(\"ours\", $2\\)"
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
 msgid "Set to $1 \\(\"theirs\", $2\\)"
 msgstr "$1 に設定\\(\"theirs\", $2\\)"
 
-msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
 msgid "Set to rebase target \\(\"theirs\", $1\\)"
 msgstr "リベースターゲットに設定 \\(\"theirs\", $1\\)"
 
-msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
 msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
 msgstr "リベースされたブランチ\"$1\"に設定 \\(\"ours\", $2\\)"
 
-msgctxt "dlgSgResolve.tle"
+msgctxt "dlgSgResolve.tle:"
 msgid "Resolve"
 msgstr "解決"
 
@@ -9286,15 +9286,15 @@ msgctxt "dlgSgResolveManuallyModifiedSingle.btn:"
 msgid "Overwrite"
 msgstr "上書き"
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.fur"
+msgctxt "dlgSgResolveManuallyModifiedSingle.fur:"
 msgid "$1 seems to contain manual conflict resolutions. They will be lost when continuing."
 msgstr "$1では、手動でコンフリクトを解決しているようです。続行すると失われます。"
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.hdl"
+msgctxt "dlgSgResolveManuallyModifiedSingle.hdl:"
 msgid "Do you want to overwrite your manual conflict resolution?"
 msgstr "手動の競合解決状態を上書きしますか?"
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.tle"
+msgctxt "dlgSgResolveManuallyModifiedSingle.tle:"
 msgid "Resolve"
 msgstr "解決"
 
@@ -9302,11 +9302,11 @@ msgctxt "dlgSgResolveSubmodule.btn:"
 msgid "Resolve"
 msgstr "解決"
 
-msgctxt "dlgSgResolveSubmodule.hdl"
+msgctxt "dlgSgResolveSubmodule.hdl:"
 msgid "Resolve Conflict"
 msgstr "競合を解決する"
 
-msgctxt "dlgSgResolveSubmodule.inf"
+msgctxt "dlgSgResolveSubmodule.inf:"
 msgid "Select to which submodule commit you want to resolve."
 msgstr "解決するサブモジュールのコミットを選択します。"
 
@@ -9318,7 +9318,7 @@ msgctxt "dlgSgResolveSubmodule.rbt:"
 msgid "Leave submodule pointer as is"
 msgstr "サブモジュールのポインタをそのままにする"
 
-msgctxt "dlgSgResolveSubmodule.tle"
+msgctxt "dlgSgResolveSubmodule.tle:"
 msgid "Resolve"
 msgstr "解決"
 
@@ -9330,15 +9330,15 @@ msgctxt "dlgSgRevealCommitLocalOrTracked.btn:"
 msgid "Reveal Tracked"
 msgstr "追跡ブランチを表示"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.chk"
+msgctxt "dlgSgRevealCommitLocalOrTracked.chk:"
 msgid "Always reveal local branch"
 msgstr "常にローカルブランチを表示する"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.fur"
+msgctxt "dlgSgRevealCommitLocalOrTracked.fur:"
 msgid "Select whether to reveal '$1' or '$2'."
 msgstr "どちらを表示するかを選択してください。\\r'$1'\\r'$2'"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.hdl"
+msgctxt "dlgSgRevealCommitLocalOrTracked.hdl:"
 msgid "Do you want to reveal the local or the tracked branch?"
 msgstr "ローカルと追跡されたブランチのどちらを表示しますか？"
 
@@ -9358,15 +9358,15 @@ msgctxt "dlgSgRevertAndCommitConfirmSingle.btn:"
 msgid "Revert"
 msgstr "リバート"
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.fur"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.fur:"
 msgid "This will undo the changes introduced with the selected commit."
 msgstr "これにより、選択したコミットでの変更が取り消されます。"
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.hdl"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.hdl:"
 msgid "Do you want to revert the selected commit?"
 msgstr "選択したコミットを取り消しますか？"
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.tle"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.tle:"
 msgid "Revert"
 msgstr "リバート"
 
@@ -9374,7 +9374,7 @@ msgctxt "dlgSgRevertConfigurationFile.btn:"
 msgid "Revert"
 msgstr "リバート"
 
-msgctxt "dlgSgRevertConfigurationFile.fur"
+msgctxt "dlgSgRevertConfigurationFile.fur:"
 msgid "Only changes of these files will be reverted \\(without committing\\)."
 msgstr "これらのファイルの変更のみが\\(コミットせずに\\)元に戻されます。"
 
@@ -9382,35 +9382,35 @@ msgctxt "dlgSgRevertConfigurationFile.hdl:"
 msgid "Do you want to revert changes of '$1'?"
 msgstr "'$1' の変更を元に戻しますか?"
 
-msgctxt "dlgSgRevertConfigurationFile.tle"
+msgctxt "dlgSgRevertConfigurationFile.tle:"
 msgid "Revert"
 msgstr "リバート"
 
-msgctxt "dlgSgRevertInProgress.fur"
+msgctxt "dlgSgRevertInProgress.fur:"
 msgid "You have to finish the Revert before you can continue. To finish the Revert use Commit, to abort use Discard."
 msgstr "続行する前に、リバートを完了する必要があります。 リバートをを完了するには コミットを使用し、中止するには 破棄 を使用します。"
 
-msgctxt "dlgSgRevertInProgress.hdl"
+msgctxt "dlgSgRevertInProgress.hdl:"
 msgid "There is currently a Revert in progress."
 msgstr "現在、リバートが進行中です。"
 
-msgctxt "dlgSgRevertInProgress.tle"
+msgctxt "dlgSgRevertInProgress.tle:"
 msgid "Revert"
 msgstr "リバート"
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.chk"
+msgctxt "dlgSgRevertNotAllConflictsResolved.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.fur"
+msgctxt "dlgSgRevertNotAllConflictsResolved.fur:"
 msgid "You may need to resolve the conflicts before proceeding."
 msgstr "先に進む前に、コンフリクトを解消する必要があるかもしれません。"
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.hdl"
+msgctxt "dlgSgRevertNotAllConflictsResolved.hdl:"
 msgid "Reverting failed because of conflicts."
 msgstr "競合のため、リバートできませんでした。"
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.tle"
+msgctxt "dlgSgRevertNotAllConflictsResolved.tle:"
 msgid "Revert"
 msgstr "リバート"
 
@@ -9418,11 +9418,11 @@ msgctxt "dlgSgReviewCommentAdd.btn:"
 msgid "Add"
 msgstr "追加"
 
-msgctxt "dlgSgReviewCommentAdd.hdl"
+msgctxt "dlgSgReviewCommentAdd.hdl:"
 msgid "Add comment"
 msgstr "コメントの追加"
 
-msgctxt "dlgSgReviewCommentAdd.tle"
+msgctxt "dlgSgReviewCommentAdd.tle:"
 msgid "Add Comment"
 msgstr "コメントを追加"
 
@@ -9430,11 +9430,11 @@ msgctxt "dlgSgReviewCommentEdit.btn:"
 msgid "Edit"
 msgstr "編集"
 
-msgctxt "dlgSgReviewCommentEdit.hdl"
+msgctxt "dlgSgReviewCommentEdit.hdl:"
 msgid "Edit comment"
 msgstr "コメントを編集"
 
-msgctxt "dlgSgReviewCommentEdit.tle"
+msgctxt "dlgSgReviewCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr "コメントを編集"
 
@@ -9442,11 +9442,11 @@ msgctxt "dlgSgReviewCommentReply.btn:"
 msgid "Reply"
 msgstr "返信"
 
-msgctxt "dlgSgReviewCommentReply.hdl"
+msgctxt "dlgSgReviewCommentReply.hdl:"
 msgid "Reply to selected comment"
 msgstr "選択したコメントへの返信"
 
-msgctxt "dlgSgReviewCommentReply.tle"
+msgctxt "dlgSgReviewCommentReply.tle:"
 msgid "Reply To Comment"
 msgstr "コメントに返信"
 
@@ -9454,7 +9454,7 @@ msgctxt "dlgSgReviewComment(Add|Edit|Reply).edt:"
 msgid "Text"
 msgstr "テキスト"
 
-msgctxt "dlgSgReviewComment(Add|Edit|Reply).inf"
+msgctxt "dlgSgReviewComment(Add|Edit|Reply).inf:"
 msgid "Enter the text of the comment."
 msgstr "コメントのテキストを入力します。"
 
@@ -9462,15 +9462,15 @@ msgctxt "dlgSgReviewConfigureDisposeDatabase.btn:"
 msgid "Dispose"
 msgstr "廃棄する"
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.fur"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.fur:"
 msgid "This will disable the Reviewing system and unpushed local data will be lost."
 msgstr "これにより、レビュー システムが無効になり、プッシュされていないローカル データが失われます。"
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.hdl"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.hdl:"
 msgid "Do you really want to dispose all local review data?"
 msgstr "本当にローカルレビューのデータをすべて廃棄しますか？"
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.tle"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.tle:"
 msgid "Dispose Database"
 msgstr "データベースの廃棄"
 
@@ -9478,15 +9478,15 @@ msgctxt "dlgSgReviewConfigureForGitHub.btn:"
 msgid "Continue"
 msgstr "続ける"
 
-msgctxt "dlgSgReviewConfigureForGitHub.fur"
+msgctxt "dlgSgReviewConfigureForGitHub.fur:"
 msgid "This repository is connected to a GitHub server. GitHub comes with its own reviewing concepts, like commit comments and pull requests. Hence, you probably do not want to have SmartGit's review database in addition to GitHub's existing capabilities."
 msgstr "このリポジトリはGitHubサーバーに接続されています。\\nGitHubには、コミットコメントやプルリクエストなど、独自のレビューの概念があります。\\nそのため、GitHubの既存の機能に加えて、SmartGitのレビューデータベースは必要ないかもしれません。"
 
-msgctxt "dlgSgReviewConfigureForGitHub.hdl"
+msgctxt "dlgSgReviewConfigureForGitHub.hdl:"
 msgid "Do you really want to configure SmartGit's review database for your GitHub repository?"
 msgstr "GitHub リポジトリ用に SmartGit のレビュー データベースを本当に構成しますか?"
 
-msgctxt "dlgSgReviewConfigureForGitHub.tle"
+msgctxt "dlgSgReviewConfigureForGitHub.tle:"
 msgid "Configure Review System"
 msgstr "レビューシステムの設定"
 
@@ -9494,15 +9494,15 @@ msgctxt "dlgSgReviewConfigureIntializeNew.btn:"
 msgid "Initialize"
 msgstr "初期化"
 
-msgctxt "dlgSgReviewConfigureIntializeNew.fur"
+msgctxt "dlgSgReviewConfigureIntializeNew.fur:"
 msgid "This will create a new Review database in the current repository which may be pushed to other remotes later."
 msgstr "これにより、現在のリポジトリに新しい レビューデータベースが作成され、後で他のリモートにプッシュされる可能性があります。"
 
-msgctxt "dlgSgReviewConfigureIntializeNew.hdl"
+msgctxt "dlgSgReviewConfigureIntializeNew.hdl:"
 msgid "Do you want to initialize a new Review database?"
 msgstr "新しいレビューデータベースを初期化しますか？"
 
-msgctxt "dlgSgReviewConfigureIntializeNew.tle"
+msgctxt "dlgSgReviewConfigureIntializeNew.tle:"
 msgid "Configure Review System"
 msgstr "レビューシステムの設定"
 
@@ -9518,15 +9518,15 @@ msgctxt "dlgSgReviewConfigureWhat.btn:"
 msgid "Initialize a Remote"
 msgstr "リモートの初期化"
 
-msgctxt "dlgSgReviewConfigureWhat.fur"
+msgctxt "dlgSgReviewConfigureWhat.fur:"
 msgid "The user database allows to define aliases \\(e.g. @mike\\) that make addressing teammates easier in review comments."
 msgstr "ユーザーデータベースでは、エイリアス（@mikeなど）を定義することができ、レビューコメントの中でチームメイトに声をかけやすくなります。"
 
-msgctxt "dlgSgReviewConfigureWhat.hdl"
+msgctxt "dlgSgReviewConfigureWhat.hdl:"
 msgid "Select what you want to configure."
 msgstr "設定したい内容を選択してください。"
 
-msgctxt "dlgSgReviewConfigureWhat.tle"
+msgctxt "dlgSgReviewConfigureWhat.tle:"
 msgid "Configure Review Database"
 msgstr "レビューデータベースの設定"
 
@@ -9534,15 +9534,15 @@ msgctxt "dlgSgReviewPullRequestClose.edt:"
 msgid "Comment"
 msgstr "コメント"
 
-msgctxt "dlgSgReviewPullRequestClose.hdl"
+msgctxt "dlgSgReviewPullRequestClose.hdl:"
 msgid "Close Pull Request"
 msgstr "プルリクエストを閉じる"
 
-msgctxt "dlgSgReviewPullRequestClose.inf"
+msgctxt "dlgSgReviewPullRequestClose.inf:"
 msgid "Enter the comment which will be logged when closing the pull request."
 msgstr "プルリクエストをクローズする際にログに記録されるコメントを入力します。"
 
-msgctxt "dlgSgReviewPullRequestClose.tle"
+msgctxt "dlgSgReviewPullRequestClose.tle:"
 msgid "Close Pull Request"
 msgstr "プルリクエストを閉じる"
 
@@ -9562,11 +9562,11 @@ msgctxt "dlgSgReviewPullRequestCreate.err:"
 msgid "Unknown user '$1'."
 msgstr "不明なユーザー '$1'"
 
-msgctxt "dlgSgReviewPullRequestCreate.hdl"
+msgctxt "dlgSgReviewPullRequestCreate.hdl:"
 msgid "Create a Pull Request"
 msgstr "プルリクエストを作成"
 
-msgctxt "dlgSgReviewPullRequestCreate.inf"
+msgctxt "dlgSgReviewPullRequestCreate.inf:"
 msgid "A Pull Request suggests the integration of one branch into another."
 msgstr "プルリクエストは、あるブランチを別のブランチに統合することを提案するものです。"
 
@@ -9578,7 +9578,7 @@ msgctxt "dlgSgReviewPullRequestCreate.lbl:"
 msgid "The pull request will be highlighted to those users which are listed as assignees."
 msgstr "プルリクエストは、担当者としてリストされているユーザーに対してハイライト表示されます。"
 
-msgctxt "dlgSgReviewPullRequestCreate.tle"
+msgctxt "dlgSgReviewPullRequestCreate.tle:"
 msgid "Create Pull Request"
 msgstr "プルリクエストを作成"
 
@@ -9598,15 +9598,15 @@ msgctxt "dlgSgReviewPullRequestState.err:"
 msgid "Unknown user '$1'."
 msgstr "不明なユーザー '$1'"
 
-msgctxt "dlgSgReviewPullRequestState.hdl"
+msgctxt "dlgSgReviewPullRequestState.hdl:"
 msgid "Assign Pull Request"
 msgstr "プルリクエストの割り当て"
 
-msgctxt "dlgSgReviewPullRequestState.inf"
+msgctxt "dlgSgReviewPullRequestState.inf:"
 msgid "Enter the user\\(s\\) to which the Pull Request should be assigned to."
 msgstr "プルリクエストを割り当てるユーザーを入力してください。"
 
-msgctxt "dlgSgReviewPullRequestState.tle"
+msgctxt "dlgSgReviewPullRequestState.tle:"
 msgid "Assign"
 msgstr "割り当て"
 
@@ -9642,7 +9642,7 @@ msgctxt "dlgSgReviewUserAddEdit.hdl:"
 msgid "Edit User"
 msgstr "ユーザーの編集"
 
-msgctxt "dlgSgReviewUserAddEdit.inf"
+msgctxt "dlgSgReviewUserAddEdit.inf:"
 msgid "Enter the user's name and email address \\(as used for Git\\), one or more space- or comma-separated aliases and optional contact details."
 msgstr "ユーザーの名前とメールアドレス（Gitで使用されているもの）、スペースまたはカンマで区切られた1つ以上のエイリアス、およびオプションの連絡先情報を入力します。"
 
@@ -9698,7 +9698,7 @@ msgctxt "dlgSgReviewUsersEdit.hdl:"
 msgid "Edit review database users"
 msgstr "レビューデータベースのユーザーを編集する"
 
-msgctxt "dlgSgReviewUsersEdit.inf"
+msgctxt "dlgSgReviewUsersEdit.inf:"
 msgid "Users can have aliases which are used in comment texts and they have optional contact details."
 msgstr "ユーザーは、コメント文に使用されるエイリアスを持つことができ、オプションで連絡先情報を持つことができます。"
 
@@ -9718,15 +9718,15 @@ msgctxt "dlgSgRollbackToCommit.btn:"
 msgid "Rollback"
 msgstr "ロールバック"
 
-msgctxt "dlgSgRollbackToCommit.fur"
+msgctxt "dlgSgRollbackToCommit.fur:"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr "HEAD と選択したコミット間のすべての差分が作業ツリーにチェックアウトされ、オプションでステージングされます。"
 
-msgctxt "dlgSgRollbackToCommit.hdl"
+msgctxt "dlgSgRollbackToCommit.hdl:"
 msgid "Do you want to rollback the Index to the state of commit $1?"
 msgstr "インデックスをコミット $1 の状態にロールバックしますか？"
 
-msgctxt "dlgSgRollbackToCommit.tle"
+msgctxt "dlgSgRollbackToCommit.tle:"
 msgid "Rollback To"
 msgstr "ロールバック"
 
@@ -9738,7 +9738,7 @@ msgctxt "dlgSgRollbackToFiles.btn:"
 msgid "Rollback"
 msgstr "ロールバック"
 
-msgctxt "dlgSgRollbackToFiles.fur"
+msgctxt "dlgSgRollbackToFiles.fur:"
 msgid "All differences of the selected files between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr "選択したファイルの HEAD と選択したコミット間のすべての差分が作業ツリーにチェックアウトされ、オプションでステージングされます。"
 
@@ -9746,7 +9746,7 @@ msgctxt "dlgSgRollbackToFiles.hdl:"
 msgid "Do you want to rollback the selected files to the state of commit $1?"
 msgstr "選択したファイルをコミット $1 の状態にロールバックしますか？"
 
-msgctxt "dlgSgRollbackToFiles.tle"
+msgctxt "dlgSgRollbackToFiles.tle:"
 msgid "Rollback To"
 msgstr "ロールバック"
 
@@ -9770,7 +9770,7 @@ msgctxt "dlgSgSelectBranch.inf:"
 msgid "Select which auxiliary branch should be shown in addition to the current branch."
 msgstr "現在のブランチに加えて、どの補助ブランチを表示するかを選択します。"
 
-msgctxt "dlgSgSelectBranch.tle"
+msgctxt "dlgSgSelectBranch.tle:"
 msgid "Set Tracked Branch"
 msgstr "追跡ブランチの設定"
 
@@ -9966,15 +9966,15 @@ msgctxt "dlgSgSetupStdWnd.btn:"
 msgid "Use Standard Window"
 msgstr "スタンダードウィンドウを使用する"
 
-msgctxt "dlgSgSetupStdWnd.fur"
+msgctxt "dlgSgSetupStdWnd.fur:"
 msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 msgstr "初めてのGitユーザーまたは経験の浅い方には、スタンダードウィンドウをおすすめします。\\n\\n以前にSmartGitの古いバージョンを使用していた場合、スタンダードウィンドウが従来のものとは\\*異なる見た目\\*になっていることに驚かれるかもしれません。\\n以前のバージョンと同様の体験をしたい場合は、\\*ロググラフ\\* ウィンドウまたは \\*作業ツリー\\* ウィンドウを選択してみてください。"
 
-msgctxt "dlgSgSetupStdWnd.hdl"
+msgctxt "dlgSgSetupStdWnd.hdl:"
 msgid "Do you want to use the Standard Window?"
 msgstr "スタンダードウィンドウを使用しますか？"
 
-msgctxt "dlgSgSetupStdWnd.tle"
+msgctxt "dlgSgSetupStdWnd.tle:"
 msgid "Setup SmartGit $1"
 msgstr "SmartGit $1 のセットアップ"
 
@@ -9982,11 +9982,11 @@ msgctxt "dlgSgShowLocalChanges.btn:"
 msgid "Compare"
 msgstr "比較"
 
-msgctxt "dlgSgShowLocalChanges.hdl"
+msgctxt "dlgSgShowLocalChanges.hdl:"
 msgid "File $1 modified in Index and working tree"
 msgstr "インデックスと作業ツリーでファイル$1が変更されました。"
 
-msgctxt "dlgSgShowLocalChanges.inf"
+msgctxt "dlgSgShowLocalChanges.inf:"
 msgid "Select the file states to compare."
 msgstr "比較するファイルの状態を選択します。"
 
@@ -10002,7 +10002,7 @@ msgctxt "dlgSgShowLocalChanges.rbt:"
 msgid "Index vs. Working Tree"
 msgstr "インデックスと作業ツリー"
 
-msgctxt "dlgSgShowLocalChanges.tle"
+msgctxt "dlgSgShowLocalChanges.tle:"
 msgid "Show Changes"
 msgstr "比較する"
 
@@ -10026,27 +10026,27 @@ msgctxt "dlgSgSplitOffFiles.edt:"
 msgid "Commit Message"
 msgstr "コミットメッセージ"
 
-msgctxt "dlgSgSplitOffFiles.hdl"
+msgctxt "dlgSgSplitOffFiles.hdl:"
 msgid "Move files to a second commit"
 msgstr "ファイルを2番目のコミットに移動する"
 
-msgctxt "dlgSgSplitOffFiles.inf"
+msgctxt "dlgSgSplitOffFiles.inf:"
 msgid "Provide the message for the second commit that should contain the changes from the selected files."
 msgstr "選択したファイルからの変更を含める必要がある 2 番目のコミットのメッセージを入力します。"
 
-msgctxt "dlgSgSplitOffFiles.tle"
+msgctxt "dlgSgSplitOffFiles.tle:"
 msgid "Split Off Files"
 msgstr "ファイルを分割"
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.fur"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.fur:"
 msgid "By splitting off all files, the resulting commit would become empty."
 msgstr "すべてのファイルを分割すると、結果のコミットは空になります。"
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.hdl"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.hdl:"
 msgid "You can't split off all files from a commit"
 msgstr "コミットからすべてのファイルを分割することはできません"
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.tle"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.tle:"
 msgid "Commit"
 msgstr "コミット"
 
@@ -10078,11 +10078,11 @@ msgctxt "dlgSgSshCredentials.edt:"
 msgid "Private Key File"
 msgstr "秘密鍵ファイル"
 
-msgctxt "dlgSgSshCredentials.hdl"
+msgctxt "dlgSgSshCredentials.hdl:"
 msgid "SSH Credentials"
 msgstr "SSH 資格情報"
 
-msgctxt "dlgSgSshCredentials.inf"
+msgctxt "dlgSgSshCredentials.inf:"
 msgid "Provide the credentials for authenticating to the SSH server '$1' as user '$2'."
 msgstr "ユーザー '$2' として SSH サーバー '$1' に接続するための資格情報を入力してください。"
 
@@ -10098,7 +10098,7 @@ msgctxt "dlgSgSshCredentials.rbt:"
 msgid "Private Key"
 msgstr "秘密鍵"
 
-msgctxt "dlgSgSshCredentials.tle"
+msgctxt "dlgSgSshCredentials.tle:"
 msgid "SSH Authentication"
 msgstr "SSH認証"
 
@@ -10110,27 +10110,27 @@ msgctxt "dlgSgStageConflict.btn:"
 msgid "Stage Anyway"
 msgstr "とにかくステージ"
 
-msgctxt "dlgSgStageConflict.fur"
+msgctxt "dlgSgStageConflict.fur:"
 msgid "The file contains conflict markers which indicate that you have not resolved all conflicts."
 msgstr "このファイルには、すべての競合が解決されていないことを示す競合マーカーが含まれています。"
 
-msgctxt "dlgSgStageConflict.hdl"
+msgctxt "dlgSgStageConflict.hdl:"
 msgid "Should $1 really be staged?"
 msgstr "$1 は本当にステージングする必要がありますか?"
 
-msgctxt "dlgSgStageConflict.tle"
+msgctxt "dlgSgStageConflict.tle:"
 msgid "Stage"
 msgstr "ステージ"
 
-msgctxt "dlgSgStageNoFilesFound.fur"
+msgctxt "dlgSgStageNoFilesFound.fur:"
 msgid "Could not find files with modified working tree, untracked or missing files."
 msgstr "作業ツリーが変更されたファイル、追跡されていないファイル、または見つからないファイルが見つかりませんでした。"
 
-msgctxt "dlgSgStageNoFilesFound.hdl"
+msgctxt "dlgSgStageNoFilesFound.hdl:"
 msgid "No files found that could be staged."
 msgstr "ステージングできるファイルが見つかりませんでした。"
 
-msgctxt "dlgSgStageNoFilesFound.tle"
+msgctxt "dlgSgStageNoFilesFound.tle:"
 msgid "Stage"
 msgstr "ステージ"
 
@@ -10150,15 +10150,15 @@ msgctxt "dlgSgStartupExpired.btn:"
 msgid "Exit"
 msgstr "終了"
 
-msgctxt "dlgSgStartupExpired.fur"
+msgctxt "dlgSgStartupExpired.fur:"
 msgid "Please download and install a new one or a release version."
 msgstr "新しいバージョンまたはリリース バージョンをダウンロードしてインストールしてください。"
 
-msgctxt "dlgSgStartupExpired.hdl"
+msgctxt "dlgSgStartupExpired.hdl:"
 msgid "This beta version expired."
 msgstr "このベータ版は有効期限切れです。"
 
-msgctxt "dlgSgStartupExpired.tle"
+msgctxt "dlgSgStartupExpired.tle:"
 msgid "Beta Version Expired"
 msgstr "ベータ版終了のお知らせ"
 
@@ -10182,15 +10182,15 @@ msgctxt "dlgSgStashAll.edt:"
 msgid "Message"
 msgstr "メッセージ"
 
-msgctxt "dlgSgStashAll.hdl"
+msgctxt "dlgSgStashAll.hdl:"
 msgid "Stash Index and Working Tree changes"
 msgstr "インデックスとワーキングツリーの変更をスタッシュ"
 
-msgctxt "dlgSgStashAll.inf"
+msgctxt "dlgSgStashAll.inf:"
 msgid "The saved stash can be applied later. By default, Index and Working Tree are cleaned, but you may keep the Index or both."
 msgstr "保存されたスタッシュは後で適用することができます。デフォルトでは、インデックスとワーキングツリーがクリーンアップされますが、インデックスを残すか、両方を残すこともできます。"
 
-msgctxt "dlgSgStashAll.tle"
+msgctxt "dlgSgStashAll.tle:"
 msgid "Save Stash"
 msgstr "スタッシュに保存"
 
@@ -10214,11 +10214,11 @@ msgctxt "dlgSgStashApply.hdl:"
 msgid "Apply the latest saved stash"
 msgstr "最新の保存されたスタッシュを適用する"
 
-msgctxt "dlgSgStashApply.inf"
+msgctxt "dlgSgStashApply.inf:"
 msgid "Decide how to apply the stash to the Index or working tree."
 msgstr "インデックスやワーキングツリーにスタッシュをどのように適用するかを選択してください。"
 
-msgctxt "dlgSgStashApply.tle"
+msgctxt "dlgSgStashApply.tle:"
 msgid "Apply Stash"
 msgstr "スタッシュを適用"
 
@@ -10226,15 +10226,15 @@ msgctxt "dlgSgStashApplyWithoutRestoringIndex.btn:"
 msgid "Try Without Restoring Index"
 msgstr "インデックスを復元せずに試す"
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.fur"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.fur:"
 msgid "Restoring the index failed while applying the patch."
 msgstr "パッチの適用中にインデックスの復元に失敗しました。"
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.hdl"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.hdl:"
 msgid "Should the stash been applied without restoring the index?"
 msgstr "インデックスを復元せずにスタッシュを適用しますか?"
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.tle"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.tle:"
 msgid "Apply Stash"
 msgstr "スタッシュを適用"
 
@@ -10246,7 +10246,7 @@ msgctxt "dlgSgStashOnDemandConfirmation.btn:"
 msgid "Save Stash"
 msgstr "スタッシュに保存"
 
-msgctxt "dlgSgStashOnDemandConfirmation.chk"
+msgctxt "dlgSgStashOnDemandConfirmation.chk:"
 msgid "Automatically save stash"
 msgstr "自動的にスタッシュを保存"
 
@@ -10318,7 +10318,7 @@ msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "What to do with the working tree or Index changes?"
 msgstr "作業ツリーまたはインデックスの変更をどうしますか？"
 
-msgctxt "dlgSgStashOnDemandConfirmation.tle"
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Reset"
 msgstr "リセット"
 
@@ -10330,15 +10330,15 @@ msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
 msgstr "プル"
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
 msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
 msgstr "プルが完了したら、最新のスタッシュを手動で適用し、ローカルの変更を作業ツリーに戻す必要があります。"
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl:"
 msgid "Your local changes have been stashed away, but could not be reapplied."
 msgstr "ローカルの変更はスタッシュに退避されましたが、再適用できませんでした。"
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.tle"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.tle:"
 msgid "Pull"
 msgstr "プル"
 
@@ -10346,15 +10346,15 @@ msgctxt "dlgSgStashOnDemandProceedWithoutStashing.btn:"
 msgid "Proceed"
 msgstr "続行"
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.fur"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.fur:"
 msgid "Auto-stashing changes is not possible due to technical reasons. Changes will be discarded!"
 msgstr "技術的な理由により、変更を自動的にスタッシュすることはできません。変更は破棄されます。"
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.hdl"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.hdl:"
 msgid "Do you want to proceed without stashing changes?"
 msgstr "変更を保存せずに続行しますか?"
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.tle"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.tle:"
 msgid "Reset"
 msgstr "リセット"
 
@@ -10366,15 +10366,15 @@ msgctxt "dlgSgStashRename.edt:"
 msgid "Message"
 msgstr "メッセージ"
 
-msgctxt "dlgSgStashRename.hdl"
+msgctxt "dlgSgStashRename.hdl:"
 msgid "Rename Stash"
 msgstr "リネーム"
 
-msgctxt "dlgSgStashRename.inf"
+msgctxt "dlgSgStashRename.inf:"
 msgid "Enter the new message for the stash"
 msgstr "スタッシュの新しいメッセージを入力してください"
 
-msgctxt "dlgSgStashRename.tle"
+msgctxt "dlgSgStashRename.tle:"
 msgid "Rename"
 msgstr "リネーム"
 
@@ -10386,15 +10386,15 @@ msgctxt "dlgSgStashesDropConfirm.btn:"
 msgid "Drop Stashes"
 msgstr "スタッシュを削除"
 
-msgctxt "dlgSgStashesDropConfirm.fur"
+msgctxt "dlgSgStashesDropConfirm.fur:"
 msgid "The stashed changes will be lost."
 msgstr "スタッシュに保存された変更内容は失われます。"
 
-msgctxt "dlgSgStashesDropConfirm.hdl"
+msgctxt "dlgSgStashesDropConfirm.hdl:"
 msgid "Do you want to drop the selected stash?"
 msgstr "選択したスタッシュを削除しますか？"
 
-msgctxt "dlgSgStashesDropConfirm.tle"
+msgctxt "dlgSgStashesDropConfirm.tle:"
 msgid "Drop Stash"
 msgstr "スタッシュを削除"
 
@@ -10486,7 +10486,7 @@ msgctxt "dlgSgSubmoduleAdd.rbt:"
 msgid "Remote repository"
 msgstr "リモートリポジトリ"
 
-msgctxt "dlgSgSubmoduleAdd.tle"
+msgctxt "dlgSgSubmoduleAdd.tle:"
 msgid "Add Submodule"
 msgstr "サブモジュールを追加"
 
@@ -10494,19 +10494,19 @@ msgctxt "dlgSgSubmoduleDeinitConfirm.btn:"
 msgid "Deinit"
 msgstr "削除\\(Deinit\\)"
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.chk"
+msgctxt "dlgSgSubmoduleDeinitConfirm.chk:"
 msgid "Force \\(for modified submodules\\)"
 msgstr "強制 \\(変更されたサブモジュール用\\)"
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.fur"
+msgctxt "dlgSgSubmoduleDeinitConfirm.fur:"
 msgid "The submodule will be skipped from the working tree. To get rid from the \\(remote\\) repository, you have to use Unregister instead."
 msgstr "サブモジュールは作業ツリーからスキップされます。 \\(リモート\\) リポジトリから削除するには、代わりに 「登録を解除」 を使用する必要があります。"
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.hdl"
+msgctxt "dlgSgSubmoduleDeinitConfirm.hdl:"
 msgid "Do you want to deinit submodule '$1'?"
 msgstr "サブモジュール'$1'をdeinitしますか？"
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.tle"
+msgctxt "dlgSgSubmoduleDeinitConfirm.tle:"
 msgid "Deinit Submodule"
 msgstr "サブモジュールの削除"
 
@@ -10518,15 +10518,15 @@ msgctxt "dlgSgSubmoduleInitAll.chk:"
 msgid "Pull submodule repositories"
 msgstr "サブモジュール リポジトリをプル"
 
-msgctxt "dlgSgSubmoduleInitAll.hdl"
+msgctxt "dlgSgSubmoduleInitAll.hdl:"
 msgid "Initialize all submodules"
 msgstr "すべてのサブモジュールを初期化する"
 
-msgctxt "dlgSgSubmoduleInitAll.inf"
+msgctxt "dlgSgSubmoduleInitAll.inf:"
 msgid "Submodule entries will be added to .git/config. You may customize the URLs afterwards or pull immediately."
 msgstr "サブモジュールエントリが .git/config に追加されます。後で URL をカスタマイズするか、すぐにプルすることができます。"
 
-msgctxt "dlgSgSubmoduleInitAll.tle"
+msgctxt "dlgSgSubmoduleInitAll.tle:"
 msgid "Initialize Submodule"
 msgstr "サブモジュールを初期化"
 
@@ -10542,15 +10542,15 @@ msgctxt "dlgSgSubmoduleInitGit.edt:"
 msgid "URL"
 msgstr "URL"
 
-msgctxt "dlgSgSubmoduleInitGit.hdl"
+msgctxt "dlgSgSubmoduleInitGit.hdl:"
 msgid "Set submodule URL"
 msgstr "サブモジュールのURLを設定"
 
-msgctxt "dlgSgSubmoduleInitGit.inf"
+msgctxt "dlgSgSubmoduleInitGit.inf:"
 msgid "You can customize the submodule's clone URL used in .git/config for your local setup."
 msgstr ".git/config でローカル環境に合わせてサブモジュールのクローンURLをカスタマイズできます。"
 
-msgctxt "dlgSgSubmoduleInitGit.tle"
+msgctxt "dlgSgSubmoduleInitGit.tle:"
 msgid "Initialize Submodule"
 msgstr "サブモジュールの初期化"
 
@@ -10558,15 +10558,15 @@ msgctxt "dlgSgSubmoduleRegister.edt:"
 msgid "URL"
 msgstr "URL"
 
-msgctxt "dlgSgSubmoduleRegister.hdl"
+msgctxt "dlgSgSubmoduleRegister.hdl:"
 msgid "Register nested root as submodule"
 msgstr "ネストされたルートをサブモジュールとして登録する"
 
-msgctxt "dlgSgSubmoduleRegister.inf"
+msgctxt "dlgSgSubmoduleRegister.inf:"
 msgid "Select the URL for the submodule to register."
 msgstr "登録するサブモジュールの URL を選択します。"
 
-msgctxt "dlgSgSubmoduleRegister.tle"
+msgctxt "dlgSgSubmoduleRegister.tle:"
 msgid "Register Submodule"
 msgstr "サブモジュールを登録"
 
@@ -10574,15 +10574,15 @@ msgctxt "dlgSgSubmoduleResetConfirm.btn:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "dlgSgSubmoduleResetConfirm.fur"
+msgctxt "dlgSgSubmoduleResetConfirm.fur:"
 msgid "The corresponding commit will be checked out, so the submodule content will match the content of the registered commit."
 msgstr "対応するコミットがチェックアウトされるため、サブモジュールの内容は登録されたコミットの内容と一致します。"
 
-msgctxt "dlgSgSubmoduleResetConfirm.hdl"
+msgctxt "dlgSgSubmoduleResetConfirm.hdl:"
 msgid "Do you want to reset submodule '$1' to the commit registered in the repository?"
 msgstr "サブモジュール '$1' をリポジトリに登録されているコミットの状態にリセットしますか？"
 
-msgctxt "dlgSgSubmoduleResetConfirm.tle"
+msgctxt "dlgSgSubmoduleResetConfirm.tle:"
 msgid "Reset Submodule"
 msgstr "サブモジュールのリセット"
 
@@ -10590,15 +10590,15 @@ msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.btn:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.fur"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.fur:"
 msgid "The submodule HEAD is not reachable from any ref. After resetting, it will be hard to access this commit."
 msgstr "サブモジュールの HEAD はどのrefからも到達できません。リセットした後は、この コミットにアクセスするのが困難になります。"
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.hdl"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.hdl:"
 msgid "Do you want to perform the reset even though you will loose access to the current HEAD commit?"
 msgstr "現在のHEADコミットへのアクセスを失うことになりますが、それでもリセットを実行しますか？"
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.tle"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.tle:"
 msgid "Reset Submodule"
 msgstr "サブモジュールのリセット"
 
@@ -10614,27 +10614,27 @@ msgctxt "dlgSgSubmoduleSync.chk:"
 msgid "Pull submodule repository"
 msgstr "サブモジュールリポジトリをプル"
 
-msgctxt "dlgSgSubmoduleSync.hdl"
+msgctxt "dlgSgSubmoduleSync.hdl:"
 msgid "Synchronize all submodules"
 msgstr "すべてのサブモジュールを同期する"
 
-msgctxt "dlgSgSubmoduleSync.inf"
+msgctxt "dlgSgSubmoduleSync.inf:"
 msgid "Submodule entries will be updated in .git/config. You may customize the URLs afterwards or pull immediately."
 msgstr "サブモジュールのエントリは .git/config で更新されます。後で URL をカスタマイズするか、すぐにプルすることができます。"
 
-msgctxt "dlgSgSubmoduleSync.tle"
+msgctxt "dlgSgSubmoduleSync.tle:"
 msgid "Synchronize Submodules"
 msgstr "サブモジュールの同期"
 
-msgctxt "dlgSgSubmoduleSyncConfigured.fur"
+msgctxt "dlgSgSubmoduleSyncConfigured.fur:"
 msgid "You may now pull individual submodules or on the root directory to clone the configured repositories."
 msgstr "個々のサブモジュールをプルするか、ルートディレクトリで設定されたリポジトリをクローンすることができます。"
 
-msgctxt "dlgSgSubmoduleSyncConfigured.hdl"
+msgctxt "dlgSgSubmoduleSyncConfigured.hdl:"
 msgid "Submodules have been configured."
 msgstr "サブモジュールが設定されました。"
 
-msgctxt "dlgSgSubmoduleSyncConfigured.tle"
+msgctxt "dlgSgSubmoduleSyncConfigured.tle:"
 msgid "Synchronize Submodules"
 msgstr "サブモジュールの同期"
 
@@ -10642,11 +10642,11 @@ msgctxt "dlgSgSubmoduleUnregisterConfirm.btn:"
 msgid "Unregister"
 msgstr "登録を解除"
 
-msgctxt "dlgSgSubmoduleUnregisterConfirm.fur"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.fur:"
 msgid "All relevant files will be adjusted. Afterwards you will only need to perform a commit to finish the operation. To just skip the submodule from the working tree, use Deinit."
 msgstr "関連するすべてのファイルが調整されます。その後、操作を完了するにはコミットを実行するだけで済みます。作業ツリーからサブモジュールをスキップするには、Deinit を使用します。"
 
-msgctxt "dlgSgSubmoduleUnregisterConfirm.tle"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.tle:"
 msgid "Unregister Submodule"
 msgstr "サブモジュールの登録を解除"
 
@@ -10702,7 +10702,7 @@ msgctxt "dlgSgSubtreeAdd.rbt:"
 msgid "Remote repository"
 msgstr "リモートリポジトリ"
 
-msgctxt "dlgSgSubtreeAdd.tle"
+msgctxt "dlgSgSubtreeAdd.tle:"
 msgid "Add Subtree"
 msgstr "サブツリーを追加"
 
@@ -10722,19 +10722,19 @@ msgctxt "dlgSgSvnClientCertificate.edt:"
 msgid "Passphrase"
 msgstr "パスフレーズ"
 
-msgctxt "dlgSgSvnClientCertificate.hdl"
+msgctxt "dlgSgSvnClientCertificate.hdl:"
 msgid "Client Certificate"
 msgstr "クライアント証明書"
 
-msgctxt "dlgSgSvnClientCertificate.inf"
+msgctxt "dlgSgSvnClientCertificate.inf:"
 msgid "Provide the client certificate for authentication to the SVN repository '$1'."
 msgstr "SVNリポジトリ'$1'への認証用クライアント証明書を提供します。"
 
-msgctxt "dlgSgSvnClientCertificate.tle"
+msgctxt "dlgSgSvnClientCertificate.tle:"
 msgid "SVN Authentication"
 msgstr "SVN認証"
 
-msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\""
+msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
 msgid "Authentication to the SVN repository '$1' failed with error: $2'"
 msgstr "SVN リポジトリ '$1' への認証に失敗し、次のエラーが発生しました: '$2'"
 
@@ -10766,7 +10766,7 @@ msgctxt "dlgSgSvnSslFingerprintChanged.lbl:"
 msgid "This might indicate a security problem! When in doubt, contact your server administrator."
 msgstr "これは、セキュリティ上の問題を示している可能性があります。疑わしい場合は、サーバー管理者に連絡してください。"
 
-msgctxt "dlgSgSvnSslFingerprintChanged.tle"
+msgctxt "dlgSgSvnSslFingerprintChanged.tle:"
 msgid "SVN Authentication"
 msgstr "SVN認証"
 
@@ -10774,19 +10774,19 @@ msgctxt "dlgSgSyncConfirm.btn:"
 msgid "Synchronize"
 msgstr "同期"
 
-msgctxt "dlgSgSyncConfirm.chk"
+msgctxt "dlgSgSyncConfirm.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgSyncConfirm.fur"
+msgctxt "dlgSgSyncConfirm.fur:"
 msgid "First, local changes will be pushed, then possible remote changes pulled. The advantage over a normal push is that if it fails because of remote changes, they will be pulled automatically."
 msgstr "まず、ローカルの変更がプッシュされ、次に可能性のあるリモートの変更がプルされます。\\r通常のプッシュに比べて優れているのは、リモートの変更が原因で失敗した場合、それらが自動的にプルされることです。"
 
-msgctxt "dlgSgSyncConfirm.hdl"
+msgctxt "dlgSgSyncConfirm.hdl:"
 msgid "Do you want to proceed with sync?"
 msgstr "同期を実行しますか？"
 
-msgctxt "dlgSgSyncConfirm.tle"
+msgctxt "dlgSgSyncConfirm.tle:"
 msgid "Synchronize"
 msgstr "同期"
 
@@ -10814,15 +10814,15 @@ msgctxt "dlgSgTagAdd.err:"
 msgid "The name must not end with a slash or dot."
 msgstr "名前の末尾にスラッシュまたはドットを使用することはできません。"
 
-msgctxt "dlgSgTagAdd.hdl"
+msgctxt "dlgSgTagAdd.hdl:"
 msgid "Add tag to selected commit"
 msgstr "現在のHEADコミットにタグを追加"
 
-msgctxt "dlgSgTagAdd.inf"
+msgctxt "dlgSgTagAdd.inf:"
 msgid "Enter the name of the tag to create. If entering a message, an annotated tag is created."
 msgstr "作成するタグの名前を入力します。メッセージを入力した場合は、注釈付きタグが作成されます。"
 
-msgctxt "dlgSgTagAdd.tle"
+msgctxt "dlgSgTagAdd.tle:"
 msgid "Add Tag"
 msgstr "タグを追加"
 
@@ -10830,15 +10830,15 @@ msgctxt "dlgSgTagAddOverwrite.btn:"
 msgid "Overwrite"
 msgstr "上書き"
 
-msgctxt "dlgSgTagAddOverwrite.fur"
+msgctxt "dlgSgTagAddOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different tag name."
 msgstr "'キャンセル'をクリックすると、別のタグ名を選択できます。"
 
-msgctxt "dlgSgTagAddOverwrite.hdl"
+msgctxt "dlgSgTagAddOverwrite.hdl:"
 msgid "The tag '$1' already exists. Do you want to overwrite it?"
 msgstr "タグ '$1' はすでに存在しています。上書きしますか？"
 
-msgctxt "dlgSgTagAddOverwrite.tle"
+msgctxt "dlgSgTagAddOverwrite.tle:"
 msgid "Add Tag"
 msgstr "タグを追加"
 
@@ -10846,23 +10846,23 @@ msgctxt "dlgSgTagDeleteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "削除"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk:"
 msgid "Delete from all remotes"
 msgstr "すべてのリモートから削除"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
 msgstr "リモート '$1' から削除"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.fur"
+msgctxt "dlgSgTagDeleteConfirmSingle.fur:"
 msgid "You will not be able to restore it."
 msgstr "復元できなくなります。"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.hdl"
+msgctxt "dlgSgTagDeleteConfirmSingle.hdl:"
 msgid "Do you want to delete the tag '$1'?"
 msgstr "タグ'$1'を削除しますか？"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.tle"
+msgctxt "dlgSgTagDeleteConfirmSingle.tle:"
 msgid "Delete"
 msgstr "削除"
 
@@ -10886,11 +10886,11 @@ msgctxt "dlgSgToolAdd.err:"
 msgid "The options 'Can be used by the Open command' and 'Show output and wait until finished' cannot both be set."
 msgstr "「開くコマンドで使用可能」と「出力を表示して終了まで待つ」のオプションは、同時に設定することができません。"
 
-msgctxt "dlgSgToolAdd.hdl"
+msgctxt "dlgSgToolAdd.hdl:"
 msgid "Add external tool"
 msgstr "外部ツールの追加"
 
-msgctxt "dlgSgToolAdd.tle"
+msgctxt "dlgSgToolAdd.tle:"
 msgid "Add"
 msgstr "追加"
 
@@ -10902,11 +10902,11 @@ msgctxt "dlgSgToolEdit.err:"
 msgid "Please enter the name for this command."
 msgstr "このコマンドの名前を入力してください。"
 
-msgctxt "dlgSgToolEdit.hdl"
+msgctxt "dlgSgToolEdit.hdl:"
 msgid "Edit external tool"
 msgstr "外部ツールの編集"
 
-msgctxt "dlgSgToolEdit.tle"
+msgctxt "dlgSgToolEdit.tle:"
 msgid "Edit"
 msgstr "編集"
 
@@ -10950,7 +10950,7 @@ msgctxt "dlgSgTool(Add|Edit).edt:"
 msgid "Menu Item Name"
 msgstr "メニュー項目名"
 
-msgctxt "dlgSgTool(Add|Edit).inf"
+msgctxt "dlgSgTool(Add|Edit).inf:"
 msgid "Define the name of the tool menu item, the command which should be executed and configure its arguments. The used variables define on what selection the tool may be used."
 msgstr "ツールメニューの項目名、実行するコマンド、その引数を定義します。\\r引数は、そのツールをどの選択項目に対して使用するかを定義します。"
 
@@ -11054,23 +11054,23 @@ msgctxt "dlgSgUndoLastCommitConfirm.fur:"
 msgid "Undoing an already pushed commit might cause serious problems!\\n\\nMessage: $1"
 msgstr "既にプッシュされたコミットを元に戻すと、深刻な問題が発生する可能性があります！\\n\\nメッセージ: $1"
 
-msgctxt "dlgSgUndoLastCommitConfirm.hdl"
+msgctxt "dlgSgUndoLastCommitConfirm.hdl:"
 msgid "Do you want to undo the last local commit?"
 msgstr "最後のローカルコミットを元に戻しますか？"
 
-msgctxt "dlgSgUndoLastCommitConfirm.tle"
+msgctxt "dlgSgUndoLastCommitConfirm.tle:"
 msgid "Undo Last Commit"
 msgstr "直前のコミットを元に戻す"
 
-msgctxt "dlgSgUnstageNoFilesFound.fur"
+msgctxt "dlgSgUnstageNoFilesFound.fur:"
 msgid "Could not find files with staged changes."
 msgstr "ステージングされた変更を含むファイルが見つかりませんでした。"
 
-msgctxt "dlgSgUnstageNoFilesFound.hdl"
+msgctxt "dlgSgUnstageNoFilesFound.hdl:"
 msgid "No files found that could be unstaged."
 msgstr "アンステージできるファイルが見つかりませんでした。"
 
-msgctxt "dlgSgUnstageNoFilesFound.tle"
+msgctxt "dlgSgUnstageNoFilesFound.tle:"
 msgid "Unstage"
 msgstr "アンステージ"
 
@@ -11078,11 +11078,11 @@ msgctxt "dlgSgWelcome.chk:"
 msgid "Show this dialog if no repository was opened"
 msgstr "リポジトリが開かれていない場合にこのダイアログを表示する"
 
-msgctxt "dlgSgWelcome.hdl"
+msgctxt "dlgSgWelcome.hdl:"
 msgid "What do you want to do?"
 msgstr "何をしますか？"
 
-msgctxt "dlgSgWelcome.inf"
+msgctxt "dlgSgWelcome.inf:"
 msgid "Select whether to open a new, local repository, clone a \\(remote\\) repository or open an existing repository."
 msgstr "新規のローカルリポジトリを開くか、リモートリポジトリをクローンするか、既存のリポジトリを開くかを選択します。"
 
@@ -11098,7 +11098,7 @@ msgctxt "dlgSgWelcome.rbt:"
 msgid "Reopen previously used repository:"
 msgstr "以前使用していたリポジトリを開く"
 
-msgctxt "dlgSgWelcome.tle"
+msgctxt "dlgSgWelcome.tle:"
 msgid "Welcome to SmartGit"
 msgstr "SmartGitへようこそ"
 
@@ -11110,39 +11110,39 @@ msgctxt "dlgSgWorktreeAdd.edt:"
 msgid "Directory"
 msgstr "ディレクトリ"
 
-msgctxt "dlgSgWorktreeAdd.hdl"
+msgctxt "dlgSgWorktreeAdd.hdl:"
 msgid "Create another worktree from this repository"
 msgstr "このリポジトリから別のワークツリーを作成する"
 
-msgctxt "dlgSgWorktreeAdd.inf"
+msgctxt "dlgSgWorktreeAdd.inf:"
 msgid "Select the branch and directory to use for the new worktree."
 msgstr "新しいワークツリーで使用するブランチとディレクトリを選択します。"
 
-msgctxt "dlgSgWorktreeAdd.tle"
+msgctxt "dlgSgWorktreeAdd.tle:"
 msgid "Add Worktree"
 msgstr "ワークツリーを追加"
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.fur"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.fur:"
 msgid "You only can create worktrees for existing local branches that don't yet have an associated worktree."
 msgstr "ワークツリーが関連付けられていない既存のローカル ブランチに対してのみ、ワークツリーを作成できます。"
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.hdl"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.hdl:"
 msgid "No \\(more\\) local branches available."
 msgstr "\\(これ以上\\) ローカル ブランチはありません。"
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.tle"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.tle:"
 msgid "Add Worktree"
 msgstr "ワークツリーを追加"
 
-msgctxt "dlgSgWorktreePruneNoWorktree.fur"
+msgctxt "dlgSgWorktreePruneNoWorktree.fur:"
 msgid "All your worktrees are still available."
 msgstr "すべてのワークツリーは引き続き使用できます。"
 
-msgctxt "dlgSgWorktreePruneNoWorktree.hdl"
+msgctxt "dlgSgWorktreePruneNoWorktree.hdl:"
 msgid "No worktree to prune."
 msgstr "プルーニング\\(剪定\\)するワークツリーがありません。"
 
-msgctxt "dlgSgWorktreePruneNoWorktree.tle"
+msgctxt "dlgSgWorktreePruneNoWorktree.tle:"
 msgid "Prune Obsolete Worktrees"
 msgstr "廃止されたワークツリーを整理する"
 
@@ -11150,15 +11150,15 @@ msgctxt "dlgSgWorktreePruneWorktrees.btn:"
 msgid "Prune Worktrees"
 msgstr "ワークツリーを整理する"
 
-msgctxt "dlgSgWorktreePruneWorktrees.fur"
+msgctxt "dlgSgWorktreePruneWorktrees.fur:"
 msgid "Git reported following worktrees as obsolete:"
 msgstr "Git は次のワークツリーが廃止されたと報告しました:"
 
-msgctxt "dlgSgWorktreePruneWorktrees.hdl"
+msgctxt "dlgSgWorktreePruneWorktrees.hdl:"
 msgid "Do you want to prune following worktrees?"
 msgstr "以下の作業ツリーをプルーン\\(prune\\)しますか？"
 
-msgctxt "dlgSgWorktreePruneWorktrees.tle"
+msgctxt "dlgSgWorktreePruneWorktrees.tle:"
 msgid "Prune Obsolete Worktrees"
 msgstr "廃止されたワークツリーを整理する"
 
@@ -11178,15 +11178,15 @@ msgctxt "dlgShPushTrackingLocalSvnBranches.btn:"
 msgid "Push onto Existing"
 msgstr "既存のものにプッシュ"
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.fur"
+msgctxt "dlgShPushTrackingLocalSvnBranches.fur:"
 msgid "You are going to push local branches back to the SVN repository. These branches may either be pushed as new branches or onto their existing SVN counterparts \\(recommended in most cases\\)."
 msgstr "ローカル ブランチを SVN リポジトリにプッシュします。これらのブランチは、新しいブランチとしてプッシュするか、既存の SVN 対応するブランチにプッシュすることができます \\(ほとんどの場合に推奨\\)。"
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.hdl"
+msgctxt "dlgShPushTrackingLocalSvnBranches.hdl:"
 msgid "Do you want to push local branches as new SVN branches?"
 msgstr "ローカルブランチを新しいSVNブランチとしてプッシュしますか？"
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.tle"
+msgctxt "dlgShPushTrackingLocalSvnBranches.tle:"
 msgid "Push"
 msgstr "プッシュ"
 
@@ -11198,15 +11198,15 @@ msgctxt "dlgTxtEditor.fileModified.btn:"
 msgid "Reload"
 msgstr "再読込"
 
-msgctxt "dlgTxtEditor.fileModified.fur"
+msgctxt "dlgTxtEditor.fileModified.fur:"
 msgid "Unless you want to see the old file state, it is recommended to reload."
 msgstr "古いファイルの状態を見たいのでなければ、再読み込みすることをお勧めします。"
 
-msgctxt "dlgTxtEditor.fileModified.hdl"
+msgctxt "dlgTxtEditor.fileModified.hdl:"
 msgid "The file config was changed. Reload it?"
 msgstr "ファイル構成が変更されました。再読み込みしますか？"
 
-msgctxt "dlgTxtEditor.fileModified.tle"
+msgctxt "dlgTxtEditor.fileModified.tle:"
 msgid "Editor"
 msgstr "エディタ"
 
@@ -11270,11 +11270,11 @@ msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).btn:"
 msgid "Move to Trash"
 msgstr "ゴミ箱へ移動"
 
-msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).fur"
+msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).fur:"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr "「削除」をクリックすると、削除されたファイルを復元するためにファイル復元ツールが必要になる場合があります!"
 
-msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).tle"
+msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).tle:"
 msgid "Delete"
 msgstr "削除"
 
@@ -11282,11 +11282,11 @@ msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgReposito
 msgid "Remove"
 msgstr "除去"
 
-msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).chk"
+msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).tle"
+msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).tle:"
 msgid "Remove"
 msgstr "除去"
 
@@ -11667,7 +11667,7 @@ msgctxt "ttpBranches:"
 msgid "<b>Incoming</b> from repository <b>$1</b> branch <b>$2</b> to branch <b>$3</b>"
 msgstr "<b>受信中</b> リポジトリ <b>$1</b> のブランチ <b>$2</b> からブランチ <b>$3</b>"
 
-msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\""
+msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
 msgid "<b>Last Updated By: </b>$1"
 msgstr "<b>最終更新者: </b>$1"
 
@@ -11675,11 +11675,11 @@ msgctxt "ttpBranches:"
 msgid "<b>Local Branch:\\t</b>$1"
 msgstr "<b>ローカルブランチ:\\t</b>$1"
 
-msgctxt "ttpBranches\"<b>On:\\t</b>$1\""
+msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
 msgid "<b>On: </b>$1"
 msgstr "<b>On: </b>$1"
 
-msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\""
+msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
 msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
 msgstr "ブランチ <b>$1</b> からリポジトリ <b>$2</b> の<b>main</b>ブランチへ<b>送信</b>"
 
@@ -11971,83 +11971,83 @@ msgctxt "wndAnnotate.mni:"
 msgid "Show Changes"
 msgstr "比較する"
 
-msgctxt "wndAnnotate.mniCommit-first"
+msgctxt "wndAnnotate.mniCommit-first:"
 msgid "Go to First Commit"
 msgstr "最初のコミットに移動"
 
-msgctxt "wndAnnotate.mniCommit-last"
+msgctxt "wndAnnotate.mniCommit-last:"
 msgid "Go to Last Commit"
 msgstr "最後のコミットに移動"
 
-msgctxt "wndAnnotate.mniCommit-next"
+msgctxt "wndAnnotate.mniCommit-next:"
 msgid "Go to Next Commit"
 msgstr "次のコミットに移動"
 
-msgctxt "wndAnnotate.mniCommit-preceding-line"
+msgctxt "wndAnnotate.mniCommit-preceding-line:"
 msgid "Go to Preceding Commit"
 msgstr "前のコミットに移動"
 
-msgctxt "wndAnnotate.mniCommit-previous"
+msgctxt "wndAnnotate.mniCommit-previous:"
 msgid "Go to Previous Commit"
 msgstr "前のコミットに移動"
 
-msgctxt "wndAnnotate.mniCompare"
+msgctxt "wndAnnotate.mniCompare:"
 msgid "Show Changes"
 msgstr "比較する"
 
-msgctxt "wndAnnotate.mniCustomize"
+msgctxt "wndAnnotate.mniCustomize:"
 msgid "Customize"
 msgstr "カスタマイズ"
 
-msgctxt "wndAnnotate.mniEdit-copy"
+msgctxt "wndAnnotate.mniEdit-copy:"
 msgid "Copy"
 msgstr "コピー"
 
-msgctxt "wndAnnotate.mniFile-close"
+msgctxt "wndAnnotate.mniFile-close:"
 msgid "Close"
 msgstr "閉じる"
 
-msgctxt "wndAnnotate.mniGoto-line"
+msgctxt "wndAnnotate.mniGoto-line:"
 msgid "Go to Line"
 msgstr "指定の行へ移動"
 
-msgctxt "wndAnnotate.mniLog"
+msgctxt "wndAnnotate.mniLog:"
 msgid "Log"
 msgstr "ログ"
 
-msgctxt "wndAnnotate.mniSearch-find"
+msgctxt "wndAnnotate.mniSearch-find:"
 msgid "Find"
 msgstr "検索"
 
-msgctxt "wndAnnotate.mniSearch-next"
+msgctxt "wndAnnotate.mniSearch-next:"
 msgid "Find Next"
 msgstr "次を検索"
 
-msgctxt "wndAnnotate.mniSearch-previous"
+msgctxt "wndAnnotate.mniSearch-previous:"
 msgid "Find Previous"
 msgstr "前を検索"
 
-msgctxt "wndAnnotate.mniSet-syntax"
+msgctxt "wndAnnotate.mniSet-syntax:"
 msgid "Syntax Language"
 msgstr "シンタックスハイライトの言語選択"
 
-msgctxt "wndAnnotate.mniShowChanges"
+msgctxt "wndAnnotate.mniShowChanges:"
 msgid "Show Changes"
 msgstr "比較する"
 
-msgctxt "wndAnnotate.mniUndo-goto"
+msgctxt "wndAnnotate.mniUndo-goto:"
 msgid "Undo Go To"
 msgstr "移動前のコミットに戻る"
 
-msgctxt "wndAnnotate.mniView-settings"
+msgctxt "wndAnnotate.mniView-settings:"
 msgid "Settings"
 msgstr "設定"
 
-msgctxt "wndAnnotate.mniWindowHideView"
+msgctxt "wndAnnotate.mniWindowHideView:"
 msgid "Hide View"
 msgstr "ビューを隠す"
 
-msgctxt "wndAnnotate.mniWindowLineHistory"
+msgctxt "wndAnnotate.mniWindowLineHistory:"
 msgid "Line History"
 msgstr "行の履歴"
 
@@ -12123,43 +12123,43 @@ msgctxt "wndCompare.mni:"
 msgid "Apply Selection to Right"
 msgstr "選択範囲を右に適用"
 
-msgctxt "wndCompare.mniRefresh"
+msgctxt "wndCompare.mniRefresh:"
 msgid "Reload"
 msgstr "再読込"
 
-msgctxt "wndCompare.mniView-ignore-whitespaces"
+msgctxt "wndCompare.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr "空白を無視"
 
-msgctxt "wndCompare.mniView-layout-left-beside-right"
+msgctxt "wndCompare.mniView-layout-left-beside-right:"
 msgid "Left Beside Right"
 msgstr "左右に並べて表示"
 
-msgctxt "wndCompare.mniView-layout-left-over-right"
+msgctxt "wndCompare.mniView-layout-left-over-right:"
 msgid "Left Above Right"
 msgstr "上下に並べて表示\\(上にLeft,下にRight\\)"
 
-msgctxt "wndCompare.tbtEdit-take-left"
+msgctxt "wndCompare.tbtEdit-take-left:"
 msgid "Take the left block to the right. Depending on the left block, this will insert, replace or delete at the right."
 msgstr "左のブロックを右に持っていきます。左側のブロックに応じて、右側で挿入、置換、削除を行います。"
 
-msgctxt "wndCompare.tbtEdit-take-right"
+msgctxt "wndCompare.tbtEdit-take-right:"
 msgid "Take the right block to the left. Depending on the right block, this will insert, replace or delete at the left."
 msgstr "右のブロックを左に持っていきます。右側のブロックに応じて、左側で挿入、置換、削除を行います。"
 
-msgctxt "wndCompare.tbtFile-save"
+msgctxt "wndCompare.tbtFile-save:"
 msgid "Save file modifications."
 msgstr "ファイルの変更を保存します。"
 
-msgctxt "wndCompare.tbtGoto-next-diff"
+msgctxt "wndCompare.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "次の変更点に移動します。"
 
-msgctxt "wndCompare.tbtGoto-previous-diff"
+msgctxt "wndCompare.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "前の変更点に移動します。"
 
-msgctxt "wndCompare.tbtRefresh"
+msgctxt "wndCompare.tbtRefresh:"
 msgid "Reload content from file system and recompare."
 msgstr "ファイル システムからコンテンツを再読み込みし、再比較します。"
 
@@ -12179,23 +12179,23 @@ msgctxt "wndConflictSolver.mni:"
 msgid "Apply Selection to Working Tree"
 msgstr "選択範囲を作業ツリーに適用する"
 
-msgctxt "wndConflictSolver.mniView-ignore-whitespaces"
+msgctxt "wndConflictSolver.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr "空白を無視"
 
-msgctxt "wndConflictSolver.mniView-layout-all"
+msgctxt "wndConflictSolver.mniView-layout-all:"
 msgid "All"
 msgstr "全て"
 
-msgctxt "wndConflictSolver.mniView-layout-left-merge"
+msgctxt "wndConflictSolver.mniView-layout-left-merge:"
 msgid "Left and Merge"
 msgstr "左とマージ"
 
-msgctxt "wndConflictSolver.mniView-layout-left-right-above-merge"
+msgctxt "wndConflictSolver.mniView-layout-left-right-above-merge:"
 msgid "Left and Right Above Merge"
 msgstr "左と右,下にマージ"
 
-msgctxt "wndConflictSolver.mniView-layout-right-merge"
+msgctxt "wndConflictSolver.mniView-layout-right-merge:"
 msgid "Merge and Right"
 msgstr "マージと右"
 
@@ -12247,59 +12247,59 @@ msgctxt "wndConflictSolver.tbr:"
 msgid "Take Right, Left"
 msgstr "右、左の順に取込"
 
-msgctxt "wndConflictSolver.tbtEdit-take-left"
+msgctxt "wndConflictSolver.tbtEdit-take-left:"
 msgid "Take the left block to the merge result. Depending on the left block, this will insert, replace or delete at the merge result."
 msgstr "左のブロックをマージ結果に持っていきます。左のブロックに応じて、マージ結果で挿入、置換、削除を行います。"
 
-msgctxt "wndConflictSolver.tbtEdit-take-left-right"
+msgctxt "wndConflictSolver.tbtEdit-take-left-right:"
 msgid "Take the left block, then the right one."
 msgstr "左のブロックを取り込み、次に右のブロックを取り込みます。"
 
-msgctxt "wndConflictSolver.tbtEdit-take-right"
+msgctxt "wndConflictSolver.tbtEdit-take-right:"
 msgid "Take the right block to the merge result. Depending on the right block, this will insert, replace or delete at the merge result."
 msgstr "右のブロックをマージ結果に持っていきます。右のブロックに応じて、マージ結果で挿入、置換、削除を行います。"
 
-msgctxt "wndConflictSolver.tbtEdit-take-right-left"
+msgctxt "wndConflictSolver.tbtEdit-take-right-left:"
 msgid "Take the right block, then the left one."
 msgstr "右のブロックを取り込み、次に左のブロックを取り込みます。"
 
-msgctxt "wndConflictSolver.tbtFile-open-base"
+msgctxt "wndConflictSolver.tbtFile-open-base:"
 msgid "Open the left and right changes from the common base file."
 msgstr "共通のベースファイルから左右の変更点を開く。"
 
-msgctxt "wndConflictSolver.tbtFile-save"
+msgctxt "wndConflictSolver.tbtFile-save:"
 msgid "Save file modifications."
 msgstr "ファイルの変更を保存します。"
 
-msgctxt "wndConflictSolver.tbtGoto-next-conflict"
+msgctxt "wndConflictSolver.tbtGoto-next-conflict:"
 msgid "Go to next conflict."
 msgstr "次の競合に移動"
 
-msgctxt "wndConflictSolver.tbtGoto-next-diff"
+msgctxt "wndConflictSolver.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "次の変更点に移動します。"
 
-msgctxt "wndConflictSolver.tbtGoto-previous-conflict"
+msgctxt "wndConflictSolver.tbtGoto-previous-conflict:"
 msgid "Go to previous conflict."
 msgstr "前の競合に移動"
 
-msgctxt "wndConflictSolver.tbtGoto-previous-diff"
+msgctxt "wndConflictSolver.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "前の変更点に移動します。"
 
-msgctxt "wndConflictSolver.tbtView-layout-all"
+msgctxt "wndConflictSolver.tbtView-layout-all:"
 msgid "Show the left, merge and right file."
 msgstr "左のファイル、マージファイル、右のファイルを表示します。"
 
-msgctxt "wndConflictSolver.tbtView-layout-left-merge"
+msgctxt "wndConflictSolver.tbtView-layout-left-merge:"
 msgid "Show the left and merge file."
 msgstr "左のファイルとマージファイルを表示します。"
 
-msgctxt "wndConflictSolver.tbtView-layout-left-right-above-merge"
+msgctxt "wndConflictSolver.tbtView-layout-left-right-above-merge:"
 msgid "Show the left and right files above the merge file."
 msgstr "マージ ファイルの上に左右のファイルを表示します。"
 
-msgctxt "wndConflictSolver.tbtView-layout-right-merge"
+msgctxt "wndConflictSolver.tbtView-layout-right-merge:"
 msgid "Show the merge and right file."
 msgstr "マージファイルと右のファイルを表示します。"
 
@@ -12575,167 +12575,167 @@ msgctxt "wndDeepgit.mni:"
 msgid "Open Repository Log"
 msgstr "リポジトリログを開く"
 
-msgctxt "wndDeepgit.mniDbBack"
+msgctxt "wndDeepgit.mniDbBack:"
 msgid "Go Back"
 msgstr "戻る"
 
-msgctxt "wndDeepgit.mniDgAbout"
+msgctxt "wndDeepgit.mniDgAbout:"
 msgid "About DeepGit"
 msgstr "DeepGitについて"
 
-msgctxt "wndDeepgit.mniDgBack"
+msgctxt "wndDeepgit.mniDgBack:"
 msgid "Go Back"
 msgstr "戻る"
 
-msgctxt "wndDeepgit.mniDgConfigureRefGroups"
+msgctxt "wndDeepgit.mniDgConfigureRefGroups:"
 msgid "Tag-Grouping"
 msgstr "タグ-グルーピング"
 
-msgctxt "wndDeepgit.mniDgExtendLineToBlock"
+msgctxt "wndDeepgit.mniDgExtendLineToBlock:"
 msgid "Extend Lines to Blocks"
 msgstr "行をブロックに拡張する"
 
-msgctxt "wndDeepgit.mniDgFilterAddSelection"
+msgctxt "wndDeepgit.mniDgFilterAddSelection:"
 msgid "Add Selection to Filter"
 msgstr "選択フィルタを追加"
 
-msgctxt "wndDeepgit.mniDgFilterReset"
+msgctxt "wndDeepgit.mniDgFilterReset:"
 msgid "Reset Filter"
 msgstr "フィルターをリセット"
 
-msgctxt "wndDeepgit.mniDgFilterSetSelection"
+msgctxt "wndDeepgit.mniDgFilterSetSelection:"
 msgid "Set Selection as Filter"
 msgstr "選択範囲をフィルターとして設定"
 
-msgctxt "wndDeepgit.mniDgFollowRenames"
+msgctxt "wndDeepgit.mniDgFollowRenames:"
 msgid "Follow Renames"
 msgstr "リネームを追跡"
 
-msgctxt "wndDeepgit.mniDgForward"
+msgctxt "wndDeepgit.mniDgForward:"
 msgid "Go Forward"
 msgstr "進む"
 
-msgctxt "wndDeepgit.mniDgHighlightBlameChanges"
+msgctxt "wndDeepgit.mniDgHighlightBlameChanges:"
 msgid "Highlight Changes of Current Blame Commit"
 msgstr "現在のBlameコミットの変更をハイライト"
 
-msgctxt "wndDeepgit.mniDgHighlightOriginChanges"
+msgctxt "wndDeepgit.mniDgHighlightOriginChanges:"
 msgid "Highlight Changes of Current Origin Commit"
 msgstr "現在のOriginコミットの変更をハイライト"
 
-msgctxt "wndDeepgit.mniDgIgnoreWhitespaceOnlyChanges"
+msgctxt "wndDeepgit.mniDgIgnoreWhitespaceOnlyChanges:"
 msgid "Ignore Whitespace Changes"
 msgstr "空白の変更を無視"
 
-msgctxt "wndDeepgit.mniDgLicenseAgreement"
+msgctxt "wndDeepgit.mniDgLicenseAgreement:"
 msgid "License Agreement"
 msgstr "ライセンス規約"
 
-msgctxt "wndDeepgit.mniDgOptimizeCreationOrigins"
+msgctxt "wndDeepgit.mniDgOptimizeCreationOrigins:"
 msgid "Optimize 'Appeared Here' Origins"
 msgstr "Optimize 'Appeared Here' Origins"
 
-msgctxt "wndDeepgit.mniDgPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.mniDgPerspectiveBlameOrigin:"
 msgid "Blame+Origins Perspective"
 msgstr "ブレーム+Origins パースペクティブ"
 
-msgctxt "wndDeepgit.mniDgPerspectiveBlameSimple"
+msgctxt "wndDeepgit.mniDgPerspectiveBlameSimple:"
 msgid "Blame Perspective"
 msgstr "ブレームパースペクティブ"
 
-msgctxt "wndDeepgit.mniDgPerspectiveCommit"
+msgctxt "wndDeepgit.mniDgPerspectiveCommit:"
 msgid "Log Perspective"
 msgstr "ログパースペクティブ"
 
-msgctxt "wndDeepgit.mniDgPerspectiveHistory"
+msgctxt "wndDeepgit.mniDgPerspectiveHistory:"
 msgid "Diff Perspective"
 msgstr "差分パースペクティブ"
 
-msgctxt "wndDeepgit.mniDgPerspectiveOrigins"
+msgctxt "wndDeepgit.mniDgPerspectiveOrigins:"
 msgid "Origins Perspective"
 msgstr "Origins パースペクティブ"
 
-msgctxt "wndDeepgit.mniDgResetInlineHelp"
+msgctxt "wndDeepgit.mniDgResetInlineHelp:"
 msgid "Reshow All Inline Help"
 msgstr "すべてのインラインヘルプを再表示する"
 
-msgctxt "wndDeepgit.mniDgSetEncoding"
+msgctxt "wndDeepgit.mniDgSetEncoding:"
 msgid "Encoding"
 msgstr "エンコーディング"
 
-msgctxt "wndDeepgit.mniDgShowAtRefs"
+msgctxt "wndDeepgit.mniDgShowAtRefs:"
 msgid "Show At Refs"
 msgstr "Show At Refs"
 
-msgctxt "wndDeepgit.mniDgShowLinePrefixes"
+msgctxt "wndDeepgit.mniDgShowLinePrefixes:"
 msgid "Show Line Prefixes"
 msgstr "行頭に追加の情報を表示"
 
-msgctxt "wndDeepgit.mniDgShowOnRefs"
+msgctxt "wndDeepgit.mniDgShowOnRefs:"
 msgid "Show On Refs"
 msgstr "Show On Refs"
 
-msgctxt "wndDeepgit.mniDgToggleLineHistory"
+msgctxt "wndDeepgit.mniDgToggleLineHistory:"
 msgid "Line History"
 msgstr "行の履歴"
 
-msgctxt "wndDeepgit.mniDgViewToolbar"
+msgctxt "wndDeepgit.mniDgViewToolbar:"
 msgid "Show Toolbar"
 msgstr "ツールバーを表示"
 
-msgctxt "wndDeepgit.mniDgWindowHorizontalLayout"
+msgctxt "wndDeepgit.mniDgWindowHorizontalLayout:"
 msgid "Horizontal Blame + Origins Layout"
 msgstr "左右にブレームとOriginsを並べる"
 
-msgctxt "wndDeepgit.mniDgWindowVerticalLayout"
+msgctxt "wndDeepgit.mniDgWindowVerticalLayout:"
 msgid "Vertical Blame + Origins Layout"
 msgstr "上下にブレームとOriginsを並べる"
 
-msgctxt "wndDeepgit.mniEdit-copy"
+msgctxt "wndDeepgit.mniEdit-copy:"
 msgid "Copy"
 msgstr "コピー"
 
-msgctxt "wndDeepgit.mniFile-close"
+msgctxt "wndDeepgit.mniFile-close:"
 msgid "Close"
 msgstr "閉じる"
 
-msgctxt "wndDeepgit.mniGoto-line"
+msgctxt "wndDeepgit.mniGoto-line:"
 msgid "Go to Line"
 msgstr "指定の行へ移動"
 
-msgctxt "wndDeepgit.mniGoto-next-diff"
+msgctxt "wndDeepgit.mniGoto-next-diff:"
 msgid "Next Change"
 msgstr "次の変更"
 
-msgctxt "wndDeepgit.mniGoto-previous-diff"
+msgctxt "wndDeepgit.mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr "前の変更"
 
-msgctxt "wndDeepgit.mniNextChange"
+msgctxt "wndDeepgit.mniNextChange:"
 msgid "Next Change"
 msgstr "次の変更"
 
-msgctxt "wndDeepgit.mniOpenFileLog"
+msgctxt "wndDeepgit.mniOpenFileLog:"
 msgid "Open File Log"
 msgstr "ファイルログを開く"
 
-msgctxt "wndDeepgit.mniOpenRepositoryLog"
+msgctxt "wndDeepgit.mniOpenRepositoryLog:"
 msgid "Open Repository Log"
 msgstr "リポジトリログを開く"
 
-msgctxt "wndDeepgit.mniPreviousChange"
+msgctxt "wndDeepgit.mniPreviousChange:"
 msgid "Previous Change"
 msgstr "前の変更"
 
-msgctxt "wndDeepgit.mniSearch-find"
+msgctxt "wndDeepgit.mniSearch-find:"
 msgid "Find"
 msgstr "検索"
 
-msgctxt "wndDeepgit.mniSearch-next"
+msgctxt "wndDeepgit.mniSearch-next:"
 msgid "Find Next"
 msgstr "次を検索"
 
-msgctxt "wndDeepgit.mniSearch-previous"
+msgctxt "wndDeepgit.mniSearch-previous:"
 msgid "Find Previous"
 msgstr "前を検索"
 
@@ -12827,59 +12827,59 @@ msgctxt "wndDeepgit.tbt:"
 msgid "Go to previous change."
 msgstr "前の変更点に移動します。"
 
-msgctxt "wndDeepgit.tbtBack"
+msgctxt "wndDeepgit.tbtBack:"
 msgid "Go back to previous blame..."
 msgstr "前のブレームに戻る..."
 
-msgctxt "wndDeepgit.tbtDbBack"
+msgctxt "wndDeepgit.tbtDbBack:"
 msgid "Go back to previous blame..."
 msgstr "前のブレームに戻る..."
 
-msgctxt "wndDeepgit.tbtDgForward"
+msgctxt "wndDeepgit.tbtDgForward:"
 msgid "Go forward to next blame..."
 msgstr "次のブレームに進む..."
 
-msgctxt "wndDeepgit.tbtDgPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.tbtDgPerspectiveBlameOrigin:"
 msgid "Find where the line originates from in cases where you need to choose from one of possible Origins."
 msgstr "行のOriginを探すには、考えられる候補から一つを選ぶ必要があります。"
 
-msgctxt "wndDeepgit.tbtDgPerspectiveBlameSimple"
+msgctxt "wndDeepgit.tbtDgPerspectiveBlameSimple:"
 msgid "Find where the line originates from in simple cases when there are no alternative Origins."
 msgstr "他のOriginがない単純なケースでは、その行のOriginを見つけることができます。"
 
-msgctxt "wndDeepgit.tbtDgPerspectiveCommit"
+msgctxt "wndDeepgit.tbtDgPerspectiveCommit:"
 msgid "Investigate Log."
 msgstr "ログを調査します。"
 
-msgctxt "wndDeepgit.tbtDgPerspectiveHistory"
+msgctxt "wndDeepgit.tbtDgPerspectiveHistory:"
 msgid "Investigate Diff between file's revisions."
 msgstr "ファイルのリビジョン間の差分を調査します。"
 
-msgctxt "wndDeepgit.tbtDgPerspectiveOrigins"
+msgctxt "wndDeepgit.tbtDgPerspectiveOrigins:"
 msgid "Find out what else happened where the line originates from.\\n\\nIn order to inspect available Origins, they have to be evaluated first. First, select the file you want to investigate using File\\|Open and select a line in it. Then wait until the calculation of possible Origins has finished."
 msgstr "その行が発生した場所で他に何が起こったのかを調査します。\\n\\n候補となるOriginを調べるには、まずそれらを評価する必要があります。まず、\\[ファイル\\]→\\[開く\\] で調査対象のファイルを選択し、その中の行を選択します。そして、可能性のあるOriginの計算が完了するまで待ちます。"
 
-msgctxt "wndDeepgit.tbtForward"
+msgctxt "wndDeepgit.tbtForward:"
 msgid "Go forward to next blame..."
 msgstr "次のブレームに進む..."
 
-msgctxt "wndDeepgit.tbtPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.tbtPerspectiveBlameOrigin:"
 msgid "Find where the line originates from in cases where you need to choose from one of possible Origins."
 msgstr "行のOriginを探すには、考えられる候補から一つを選ぶ必要があります。"
 
-msgctxt "wndDeepgit.tbtPerspectiveBlameSimple"
+msgctxt "wndDeepgit.tbtPerspectiveBlameSimple:"
 msgid "Find where the line originates from in simple cases when there are no alternative Origins."
 msgstr "他のOriginがない単純なケースでは、その行のOriginを見つけることができます。"
 
-msgctxt "wndDeepgit.tbtPerspectiveCommit"
+msgctxt "wndDeepgit.tbtPerspectiveCommit:"
 msgid "Investigate Log."
 msgstr "ログを調査します。"
 
-msgctxt "wndDeepgit.tbtPerspectiveHistory"
+msgctxt "wndDeepgit.tbtPerspectiveHistory:"
 msgid "Investigate Diff between file's revisions."
 msgstr "ファイルのリビジョン間の差分を調査します。"
 
-msgctxt "wndDeepgit.tbtPerspectiveOrigins"
+msgctxt "wndDeepgit.tbtPerspectiveOrigins:"
 msgid "Find out what else happened where the line originates from.\\n\\nIn order to inspect available Origins, they have to be evaluated first. First, select the file you want to investigate using File\\|Open and select a line in it. Then wait until the calculation of possible Origins has finished."
 msgstr "その行が発生した場所で他に何が起こったのかを調査します。\\n\\n候補となるOriginを調べるには、まずそれらを評価する必要があります。まず、\\[ファイル\\]→\\[開く\\] で調査対象のファイルを選択し、その中の行を選択します。そして、可能性のあるOriginの計算が完了するまで待ちます。"
 
@@ -12903,31 +12903,31 @@ msgctxt "wndEditor.mni:"
 msgid "LF \\(Unix, macOS\\)"
 msgstr "LF \\(Unix, macOS\\)"
 
-msgctxt "wndEditor.mniEdit-undo"
+msgctxt "wndEditor.mniEdit-undo:"
 msgid "Undo"
 msgstr "元に戻す"
 
-msgctxt "wndEditor.mniEofEnforceLineEnding"
+msgctxt "wndEditor.mniEofEnforceLineEnding:"
 msgid "Enforce Line Ending on End of File"
 msgstr "ファイル終端での改行を強制する"
 
-msgctxt "wndEditor.mniReplaceTabsWithSpaces"
+msgctxt "wndEditor.mniReplaceTabsWithSpaces:"
 msgid "Replace Tabs With Spaces"
 msgstr "タブをスペースに置き換える"
 
-msgctxt "wndEditor.mniSaveAuto"
+msgctxt "wndEditor.mniSaveAuto:"
 msgid "Auto-Save"
 msgstr "自動保存"
 
-msgctxt "wndEditor.mniView-remember-as-default"
+msgctxt "wndEditor.mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr "デフォルトとして記憶する"
 
-msgctxt "wndEditor.mniView-settings"
+msgctxt "wndEditor.mniView-settings:"
 msgid "Settings"
 msgstr "設定"
 
-msgctxt "wndEditor.tbtFile-save"
+msgctxt "wndEditor.tbtFile-save:"
 msgid "Save file modifications."
 msgstr "ファイルの変更を保存します。"
 
@@ -12971,59 +12971,59 @@ msgctxt "wndGit.indexEditor.mni:"
 msgid "Unstage Selection"
 msgstr "選択範囲をアンステージ"
 
-msgctxt "wndGit.indexEditor.mniView-ignore-whitespaces"
+msgctxt "wndGit.indexEditor.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr "空白を無視"
 
-msgctxt "wndGit.indexEditor.mniView-layout-all"
+msgctxt "wndGit.indexEditor.mniView-layout-all:"
 msgid "All"
 msgstr "全て"
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-index"
+msgctxt "wndGit.indexEditor.mniView-layout-head-index:"
 msgid "HEAD and Index"
 msgstr "HEAD と Index"
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-index-wt"
+msgctxt "wndGit.indexEditor.mniView-layout-head-index-wt:"
 msgid "All"
 msgstr "全て"
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-wt-above-index"
+msgctxt "wndGit.indexEditor.mniView-layout-head-wt-above-index:"
 msgid "HEAD and Working Tree Above Index"
 msgstr "Indexの上にHEADと作業ツリー"
 
-msgctxt "wndGit.indexEditor.mniView-layout-index-wt"
+msgctxt "wndGit.indexEditor.mniView-layout-index-wt:"
 msgid "Index and Working Tree"
 msgstr "Index と Working Tree"
 
-msgctxt "wndGit.indexEditor.mniView-layout-left-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-left-merge:"
 msgid "HEAD and Index"
 msgstr "HEAD と Index"
 
-msgctxt "wndGit.indexEditor.mniView-layout-left-right-above-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-left-right-above-merge:"
 msgid "HEAD and Working Tree Above Index"
 msgstr "Indexの上にHEADと作業ツリー"
 
-msgctxt "wndGit.indexEditor.mniView-layout-right-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-right-merge:"
 msgid "Index and Working Tree"
 msgstr "Index と Working Tree"
 
-msgctxt "wndGit.indexEditor.tbtEdit-take-left"
+msgctxt "wndGit.indexEditor.tbtEdit-take-left:"
 msgid "Take the left block to the merge result. Depending on the left block, this will insert, replace or delete at the merge result."
 msgstr "左のブロックをマージ結果に持っていきます。左のブロックに応じて、マージ結果で挿入、置換、削除を行います。"
 
-msgctxt "wndGit.indexEditor.tbtEdit-take-right"
+msgctxt "wndGit.indexEditor.tbtEdit-take-right:"
 msgid "Take the right block to the merge result. Depending on the right block, this will insert, replace or delete at the merge result."
 msgstr "右のブロックをマージ結果に持っていきます。右のブロックに応じて、マージ結果で挿入、置換、削除を行います。"
 
-msgctxt "wndGit.indexEditor.tbtFile-save"
+msgctxt "wndGit.indexEditor.tbtFile-save:"
 msgid "Save file modifications."
 msgstr "ファイルの変更を保存します。"
 
-msgctxt "wndGit.indexEditor.tbtGoto-next-diff"
+msgctxt "wndGit.indexEditor.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "次の変更点に移動します。"
 
-msgctxt "wndGit.indexEditor.tbtGoto-previous-diff"
+msgctxt "wndGit.indexEditor.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "前の変更点に移動します。"
 
@@ -13035,7 +13035,7 @@ msgctxt "wndLog.hnt:"
 msgid "No graph roots selected."
 msgstr "グラフのルートが選択されていません。"
 
-msgctxt "wndLog.mniFixCaseChange"
+msgctxt "wndLog.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr "大文字小文字の修正"
 
@@ -13187,31 +13187,31 @@ msgctxt "wndStd.mni:"
 msgid "Sort by Path"
 msgstr "パスで並べ替え"
 
-msgctxt "wndStd.mniBisectTryCommit"
+msgctxt "wndStd.mniBisectTryCommit:"
 msgid "Try Commit"
 msgstr "コミットを試行"
 
-msgctxt "wndStd.mniFixCaseChange"
+msgctxt "wndStd.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr "大文字小文字の変更を修正"
 
-msgctxt "wndStd.mniIntegrateMain"
+msgctxt "wndStd.mniIntegrateMain:"
 msgid "Integrate Main"
 msgstr "メインを統合"
 
-msgctxt "wndStd.mniStdOpenSubmodule"
+msgctxt "wndStd.mniStdOpenSubmodule:"
 msgid "Open a Submodule"
 msgstr "サブモジュールを開く"
 
-msgctxt "wndStd.mniStdOpenSubmoduleFromFile"
+msgctxt "wndStd.mniStdOpenSubmoduleFromFile:"
 msgid "Open this Submodule"
 msgstr "このサブモジュールを開く"
 
-msgctxt "wndStd.mniStdSetModeHistory"
+msgctxt "wndStd.mniStdSetModeHistory:"
 msgid "Show History"
 msgstr "履歴を表示"
 
-msgctxt "wndStd.mniStdSetModeWt"
+msgctxt "wndStd.mniStdSetModeWt:"
 msgid "Show Local Changes"
 msgstr "ローカルの変更を表示"
 
@@ -13223,7 +13223,7 @@ msgctxt "wndStd.tbr:"
 msgid "Submodule"
 msgstr "サブモジュール"
 
-msgctxt "wndStd.tbtFlowFeatureStart"
+msgctxt "wndStd.tbtFlowFeatureStart:"
 msgid "Start a new feature branch."
 msgstr "新しいフィーチャーブランチを開始します。"
 
@@ -13231,19 +13231,19 @@ msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|
 msgid "Ready"
 msgstr "準備完了"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
 msgid "Full Screen"
 msgstr "フルスクリーン"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
 msgid "Maximize"
 msgstr "最大化"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore:"
 msgid "Restore"
 msgstr "最大化を解除する"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-minimize"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-minimize:"
 msgid "Minimize"
 msgstr "最小化"
 
@@ -13263,83 +13263,83 @@ msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|
 msgid "Window"
 msgstr "ウィンドウ"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left:"
 msgid "Take Left Block"
 msgstr "左ブロックを採用"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left-right"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left-right:"
 msgid "Take Left, then Right Block"
 msgstr "左ブロック、右ブロックの順に取り込む"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right:"
 msgid "Take Right Block"
 msgstr "右ブロックを採用"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right-left"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right-left:"
 msgid "Take Right, then Left Block"
 msgstr "右ブロック、左ブロックの順に取り込む"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-undo"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-undo:"
 msgid "Undo"
 msgstr "元に戻す"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-export-html"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-export-html:"
 msgid "Export as HTML-File"
 msgstr "HTMLファイルとしてエクスポート"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-open-base"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-open-base:"
 msgid "Open Base File Changes"
 msgstr "ベースファイルの変更を開く"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-conflict"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-conflict:"
 msgid "Next Conflict"
 msgstr "次の競合"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-diff"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-diff:"
 msgid "Next Change"
 msgstr "次の変更"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-conflict"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-conflict:"
 msgid "Previous Conflict"
 msgstr "前の競合"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-diff"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr "前の変更"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniShow-line-numbers"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniShow-line-numbers:"
 msgid "Show Line Numbers"
 msgstr "行番号の表示"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-all"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-all:"
 msgid "Ignore All Whitespaces for Line Comparison"
 msgstr "行比較で空白をすべて無視する"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-leading-trailing"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-leading-trailing:"
 msgid "Ignore Leading/Trailing Whitespaces for Line Comparison"
 msgstr "行比較で先頭と行末の空白を無視する"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-none"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-none:"
 msgid "Ignore No Whitespace for Line Comparison"
 msgstr "行比較で空白を無視しない"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-refresh"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-refresh:"
 msgid "Reload"
 msgstr "再読込"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-remember-as-default"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr "デフォルトとして記憶する"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-settings"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-settings:"
 msgid "Settings"
 msgstr "設定"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-show-current-line-control"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-show-current-line-control:"
 msgid "Show Long Current Lines"
 msgstr "現在の行を長いテキストボックスで表示"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-synchronize-scrolling"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-synchronize-scrolling:"
 msgid "Synchronize Scrolling"
 msgstr "スクロールを同期する"
 
@@ -13367,59 +13367,59 @@ msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mni:"
 msgid "Copy Selection"
 msgstr "選択範囲をコピー"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniCustomize"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniCustomize:"
 msgid "Customize"
 msgstr "カスタマイズ"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-copy"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-copy:"
 msgid "Copy"
 msgstr "コピー"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-cut"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-cut:"
 msgid "Cut"
 msgstr "切り取り"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-ignore-case-changes"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-ignore-case-changes:"
 msgid "Ignore Case Change for Line Comparison"
 msgstr "行比較で大文字小文字を区別しない"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-paste"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-paste:"
 msgid "Paste"
 msgstr "貼り付け"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-redo"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-redo:"
 msgid "Redo"
 msgstr "やり直し"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-close"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-close:"
 msgid "Close"
 msgstr "閉じる"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-save"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-save:"
 msgid "Save"
 msgstr "保存"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniGoto-line"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniGoto-line:"
 msgid "Go to Line"
 msgstr "指定の行へ移動"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-find"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-find:"
 msgid "Find"
 msgstr "検索"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-next"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-next:"
 msgid "Find Next"
 msgstr "次を検索"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-previous"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-previous:"
 msgid "Find Previous"
 msgstr "前を検索"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-replace"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-replace:"
 msgid "Find and Replace"
 msgstr "検索と置換"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSet-syntax"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSet-syntax:"
 msgid "Syntax Language"
 msgstr "シンタックスハイライトの言語選択"
 
@@ -13443,11 +13443,11 @@ msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).tbr:"
 msgid "Save"
 msgstr "保存"
 
-msgctxt "wnd(Log|Project|).tbtFlowFeatureFinish"
+msgctxt "wnd(Log|Project|).tbtFlowFeatureFinish:"
 msgid "Finish a Git-Flow feature."
 msgstr "Git-Flow feature を完了"
 
-msgctxt "wnd(Log|Project|).tbtFlowFeatureStart"
+msgctxt "wnd(Log|Project|).tbtFlowFeatureStart:"
 msgid "Start a new Git-Flow feature."
 msgstr "新しい Git-Flow の feature を開始します。"
 
@@ -13747,7 +13747,7 @@ msgctxt "wnd(Log|Project|Std|).lbl:"
 msgid "Files"
 msgstr "ファイル"
 
-msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\""
+msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
 msgid "Show Rewritten Behind Commits"
 msgstr "コミット後に書き換えられたものを表示"
 
@@ -14511,307 +14511,307 @@ msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Varying Coloring"
 msgstr "さまざまな色"
 
-msgctxt "wnd(Log|Project|Std|).mniAbout"
+msgctxt "wnd(Log|Project|Std|).mniAbout:"
 msgid "About SmartGit"
 msgstr "SmartGitについて"
 
-msgctxt "wnd(Log|Project|Std|).mniAdd"
+msgctxt "wnd(Log|Project|Std|).mniAdd:"
 msgid "Add"
 msgstr "追加"
 
-msgctxt "wnd(Log|Project|Std|).mniAnnotate"
+msgctxt "wnd(Log|Project|Std|).mniAnnotate:"
 msgid "Blame"
 msgstr "ブレーム"
 
-msgctxt "wnd(Log|Project|Std|).mniAssume-unchanged-toggle"
+msgctxt "wnd(Log|Project|Std|).mniAssume-unchanged-toggle:"
 msgid "Toggle 'Assume Unchanged'"
 msgstr "'Assume Unchanged' フラグを切り替え"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectBad"
+msgctxt "wnd(Log|Project|Std|).mniBisectBad:"
 msgid "Mark HEAD as Bad"
 msgstr "HEAD を Badとしてマークする"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectExit"
+msgctxt "wnd(Log|Project|Std|).mniBisectExit:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectGood"
+msgctxt "wnd(Log|Project|Std|).mniBisectGood:"
 msgid "Mark HEAD as Good"
 msgstr "HEAD を Good としてマークする"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectStart"
+msgctxt "wnd(Log|Project|Std|).mniBisectStart:"
 msgid "Start"
 msgstr "開始"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAbort"
+msgctxt "wnd(Log|Project|Std|).mniBranchAbort:"
 msgid "Abort"
 msgstr "中止"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAdd"
+msgctxt "wnd(Log|Project|Std|).mniBranchAdd:"
 msgid "Add Branch"
 msgstr "ブランチを追加"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAddTag"
+msgctxt "wnd(Log|Project|Std|).mniBranchAddTag:"
 msgid "Add Tag"
 msgstr "タグを追加"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchClose"
+msgctxt "wnd(Log|Project|Std|).mniBranchClose:"
 msgid "Close"
 msgstr "閉じる"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchContinue"
+msgctxt "wnd(Log|Project|Std|).mniBranchContinue:"
 msgid "Continue"
 msgstr "続ける"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchDelete"
+msgctxt "wnd(Log|Project|Std|).mniBranchDelete:"
 msgid "Delete"
 msgstr "削除"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchRename"
+msgctxt "wnd(Log|Project|Std|).mniBranchRename:"
 msgid "Rename"
 msgstr "リネーム"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchResetTracking"
+msgctxt "wnd(Log|Project|Std|).mniBranchResetTracking:"
 msgid "Stop Tracking"
 msgstr "追跡を停止"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSetTracking"
+msgctxt "wnd(Log|Project|Std|).mniBranchSetTracking:"
 msgid "Set Tracked Branch"
 msgstr "追跡ブランチの設定"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSplit"
+msgctxt "wnd(Log|Project|Std|).mniBranchSplit:"
 msgid "Modify or Split Commit"
 msgstr "コミットの変更または分割"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSplitFiles"
+msgctxt "wnd(Log|Project|Std|).mniBranchSplitFiles:"
 msgid "Split Off Files"
 msgstr "ファイルを分割"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowRemoteOnly"
+msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowRemoteOnly:"
 msgid "Show remote branches in their Git-Flow sections"
 msgstr "Git-Flow セクションにリモート ブランチを表示する"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowTracked"
+msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowTracked:"
 msgid "Show remote, tracked branches"
 msgstr "リモートの追跡されたブランチを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionize"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionize:"
 msgid "Group tags and branches by path-like name \\(foo/bar\\)"
 msgstr "タグやブランチをパスのような名前でグループ化 \\(foo/bar\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeAfterLastSlash"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeAfterLastSlash:"
 msgid "After last slash"
 msgstr "最後のスラッシュの後"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeCompact"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeCompact:"
 msgid "Except for single refs"
 msgstr "単一の参照を除く"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionsBeforeRefs"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionsBeforeRefs:"
 msgid "Show groups first"
 msgstr "グループを最初に表示する"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSelectObsolete"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSelectObsolete:"
 msgid "Select Obsolete Local Branches"
 msgstr "廃止されたローカルブランチを選択"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByName"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByName:"
 msgid "Sort Refs by Name"
 msgstr "名前でソート"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByNameReversed"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByNameReversed:"
 msgid "Sort Refs by Name \\(Numbers Reversed\\)"
 msgstr "名前でソート \\(番号は降順\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByTime"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByTime:"
 msgid "Sort Refs by Commit Time"
 msgstr "コミットされた時間で並べ替え"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.compact"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.compact:"
 msgid "Compact"
 msgstr "コンパクト"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.ignoreLineSeparators"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.ignoreLineSeparators:"
 msgid "Ignore Line-Ending Changes"
 msgstr "改行コードの変更を無視する"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.sideBySide"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.sideBySide:"
 msgid "Side by Side"
 msgstr "並べて表示"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.unified"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.unified:"
 msgid "Unified"
 msgstr "単独表示"
 
-msgctxt "wnd(Log|Project|Std|).mniCheckForLatestBuild"
+msgctxt "wnd(Log|Project|Std|).mniCheckForLatestBuild:"
 msgid "Check for Latest Build"
 msgstr "最新ビルドの確認"
 
-msgctxt "wnd(Log|Project|Std|).mniCheckForNewVersion"
+msgctxt "wnd(Log|Project|Std|).mniCheckForNewVersion:"
 msgid "Check for New Version"
 msgstr "新しいバージョンの確認"
 
-msgctxt "wnd(Log|Project|Std|).mniCheckout"
+msgctxt "wnd(Log|Project|Std|).mniCheckout:"
 msgid "Check Out"
 msgstr "チェックアウト"
 
-msgctxt "wnd(Log|Project|Std|).mniCherryPick"
+msgctxt "wnd(Log|Project|Std|).mniCherryPick:"
 msgid "Cherry-Pick"
 msgstr "チェリーピック"
 
-msgctxt "wnd(Log|Project|Std|).mniClean"
+msgctxt "wnd(Log|Project|Std|).mniClean:"
 msgid "Clean Working Tree"
 msgstr "作業ツリーのクリーンアップ"
 
-msgctxt "wnd(Log|Project|Std|).mniClearOutput"
+msgctxt "wnd(Log|Project|Std|).mniClearOutput:"
 msgid "Clear Output"
 msgstr "出力をクリア"
 
-msgctxt "wnd(Log|Project|Std|).mniCommit"
+msgctxt "wnd(Log|Project|Std|).mniCommit:"
 msgid "Commit"
 msgstr "コミット"
 
-msgctxt "wnd(Log|Project|Std|).mniCompact-display"
+msgctxt "wnd(Log|Project|Std|).mniCompact-display:"
 msgid "Compact Change Display"
 msgstr "コンパクトな変更表示"
 
-msgctxt "wnd(Log|Project|Std|).mniCompareWithWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniCompareWithWorkingTree:"
 msgid "Compare with Working Tree"
 msgstr "作業ツリーとの比較"
 
-msgctxt "wnd(Log|Project|Std|).mniConfigureTagGrouping"
+msgctxt "wnd(Log|Project|Std|).mniConfigureTagGrouping:"
 msgid "Tag-Grouping"
 msgstr "タグ-グルーピング"
 
-msgctxt "wnd(Log|Project|Std|).mniConfigureToolbar"
+msgctxt "wnd(Log|Project|Std|).mniConfigureToolbar:"
 msgid "Configure Toolbar"
 msgstr "ツールバーの設定"
 
-msgctxt "wnd(Log|Project|Std|).mniConflictSolver"
+msgctxt "wnd(Log|Project|Std|).mniConflictSolver:"
 msgid "Conflict Solver"
 msgstr "コンフリクトソルバー"
 
-msgctxt "wnd(Log|Project|Std|).mniContactSupport"
+msgctxt "wnd(Log|Project|Std|).mniContactSupport:"
 msgid "Contact Support"
 msgstr "サポートに連絡"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyCommitId"
+msgctxt "wnd(Log|Project|Std|).mniCopyCommitId:"
 msgid "Copy ID"
 msgstr "IDをコピー"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyCommitMessage"
+msgctxt "wnd(Log|Project|Std|).mniCopyCommitMessage:"
 msgid "Copy Message"
 msgstr "メッセージをコピー"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyName"
+msgctxt "wnd(Log|Project|Std|).mniCopyName:"
 msgid "Copy Name"
 msgstr "名前をコピー"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyPath"
+msgctxt "wnd(Log|Project|Std|).mniCopyPath:"
 msgid "Copy Path"
 msgstr "パスをコピー"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyRelativePath"
+msgctxt "wnd(Log|Project|Std|).mniCopyRelativePath:"
 msgid "Copy Relative Path"
 msgstr "相対パスをコピー"
 
-msgctxt "wnd(Log|Project|Std|).mniCustomize"
+msgctxt "wnd(Log|Project|Std|).mniCustomize:"
 msgid "Customize"
 msgstr "カスタマイズ"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugCreateHeapDump"
+msgctxt "wnd(Log|Project|Std|).mniDebugCreateHeapDump:"
 msgid "Create Heap Dump"
 msgstr "Create Heap Dump"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugCreateThreadDumps"
+msgctxt "wnd(Log|Project|Std|).mniDebugCreateThreadDumps:"
 msgid "Create Periodical Thread Dumps"
 msgstr "Create Periodical Thread Dumps"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugEnableRefreshTraceLogging"
+msgctxt "wnd(Log|Project|Std|).mniDebugEnableRefreshTraceLogging:"
 msgid "Starting Tracing Refreshing"
 msgstr "Starting Tracing Refreshing"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorEvents"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorEvents:"
 msgid "Log File Monitor Events"
 msgstr "Log File Monitor Events"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorState"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorState:"
 msgid "Log File Monitor State"
 msgstr "Log File Monitor State"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogOpenRepositories"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogOpenRepositories:"
 msgid "Log Open Repositories"
 msgstr "Log Open Repositories"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugRestart"
+msgctxt "wnd(Log|Project|Std|).mniDebugRestart:"
 msgid "Restart"
 msgstr "再起動"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugRunGc"
+msgctxt "wnd(Log|Project|Std|).mniDebugRunGc:"
 msgid "Run GC"
 msgstr "Run GC"
 
-msgctxt "wnd(Log|Project|Std|).mniDelete"
+msgctxt "wnd(Log|Project|Std|).mniDelete:"
 msgid "Delete"
 msgstr "削除"
 
-msgctxt "wnd(Log|Project|Std|).mniDiscard"
+msgctxt "wnd(Log|Project|Std|).mniDiscard:"
 msgid "Discard"
 msgstr "破棄"
 
-msgctxt "wnd(Log|Project|Std|).mniEdit-ignore-case-changes"
+msgctxt "wnd(Log|Project|Std|).mniEdit-ignore-case-changes:"
 msgid "Ignore Case Change for Line Comparison"
 msgstr "行比較で大文字小文字を区別しない"
 
-msgctxt "wnd(Log|Project|Std|).mniEditCommitAuthor"
+msgctxt "wnd(Log|Project|Std|).mniEditCommitAuthor:"
 msgid "Edit Author"
 msgstr "作者を編集"
 
-msgctxt "wnd(Log|Project|Std|).mniEditCommitMessage"
+msgctxt "wnd(Log|Project|Std|).mniEditCommitMessage:"
 msgid "Edit Message"
 msgstr "メッセージの編集"
 
-msgctxt "wnd(Log|Project|Std|).mniEditFile"
+msgctxt "wnd(Log|Project|Std|).mniEditFile:"
 msgid "Edit File"
 msgstr "ファイルを編集"
 
-msgctxt "wnd(Log|Project|Std|).mniExit"
+msgctxt "wnd(Log|Project|Std|).mniExit:"
 msgid "Exit"
 msgstr "終了"
 
-msgctxt "wnd(Log|Project|Std|).mniFastForward"
+msgctxt "wnd(Log|Project|Std|).mniFastForward:"
 msgid "Fast-Forward Merge"
 msgstr "ファストフォワードマージ"
 
-msgctxt "wnd(Log|Project|Std|).mniFetch"
+msgctxt "wnd(Log|Project|Std|).mniFetch:"
 msgid "Pull"
 msgstr "プル"
 
-msgctxt "wnd(Log|Project|Std|).mniFile-close"
+msgctxt "wnd(Log|Project|Std|).mniFile-close:"
 msgid "Close"
 msgstr "閉じる"
 
-msgctxt "wnd(Log|Project|Std|).mniFilterCommits"
+msgctxt "wnd(Log|Project|Std|).mniFilterCommits:"
 msgid "Filter Commits"
 msgstr "コミットフィルタ"
 
-msgctxt "wnd(Log|Project|Std|).mniFilterFiles"
+msgctxt "wnd(Log|Project|Std|).mniFilterFiles:"
 msgid "Filter Files"
 msgstr "ファイルフィルタ"
 
-msgctxt "wnd(Log|Project|Std|).mniFindAction"
+msgctxt "wnd(Log|Project|Std|).mniFindAction:"
 msgid "Find Command"
 msgstr "コマンドを検索"
 
-msgctxt "wnd(Log|Project|Std|).mniFindObject"
+msgctxt "wnd(Log|Project|Std|).mniFindObject:"
 msgid "Find Object"
 msgstr "オブジェクトを検索"
 
-msgctxt "wnd(Log|Project|Std|).mniFixup"
+msgctxt "wnd(Log|Project|Std|).mniFixup:"
 msgid "Use Message for Commit"
 msgstr "コミットにメッセージを使用"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowConfigure"
+msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure"
 msgstr "設定"
 
@@ -14823,183 +14823,183 @@ msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure"
 msgstr "設定"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowContext"
+msgctxt "wnd(Log|Project|Std|).mniFlowContext:"
 msgid "Git-Flow"
 msgstr "Git-Flow"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowFeatureFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowFeatureFinish:"
 msgid "Finish Feature"
 msgstr "Featureを完了"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowFeatureStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowFeatureStart:"
 msgid "Start Feature"
 msgstr "Featureを開始"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowHotfixFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowHotfixFinish:"
 msgid "Finish Hotfix"
 msgstr "Hotfixを完了"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowHotfixStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowHotfixStart:"
 msgid "Start Hotfix"
 msgstr "Hotfixの開始"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowIntegrateDevelop"
+msgctxt "wnd(Log|Project|Std|).mniFlowIntegrateDevelop:"
 msgid "Integrate Develop"
 msgstr "Develop を統合"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowReleaseFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowReleaseFinish:"
 msgid "Finish Release"
 msgstr "Releaseを完了"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowReleaseStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowReleaseStart:"
 msgid "Start Release"
 msgstr "Releaseを開始"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowSupportStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowSupportStart:"
 msgid "Start Support Branch"
 msgstr "Support ブランチを開始"
 
-msgctxt "wnd(Log|Project|Std|).mniForgetCommit"
+msgctxt "wnd(Log|Project|Std|).mniForgetCommit:"
 msgid "Forget Commit"
 msgstr "コミットを忘れる"
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-line"
+msgctxt "wnd(Log|Project|Std|).mniGoto-line:"
 msgid "Go to Line"
 msgstr "指定の行へ移動"
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-next-diff"
+msgctxt "wnd(Log|Project|Std|).mniGoto-next-diff:"
 msgid "Next Change"
 msgstr "次の変更"
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-previous-diff"
+msgctxt "wnd(Log|Project|Std|).mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr "前の変更"
 
-msgctxt "wnd(Log|Project|Std|).mniGotoChildrenCommit"
+msgctxt "wnd(Log|Project|Std|).mniGotoChildrenCommit:"
 msgid "Select Child Commit"
 msgstr "子コミットを選択"
 
-msgctxt "wnd(Log|Project|Std|).mniGotoParentsCommit"
+msgctxt "wnd(Log|Project|Std|).mniGotoParentsCommit:"
 msgid "Select Parent Commit"
 msgstr "親コミットを選択"
 
-msgctxt "wnd(Log|Project|Std|).mniIgnore"
+msgctxt "wnd(Log|Project|Std|).mniIgnore:"
 msgid "Ignore"
 msgstr "無視"
 
-msgctxt "wnd(Log|Project|Std|).mniIgnore-line-separators"
+msgctxt "wnd(Log|Project|Std|).mniIgnore-line-separators:"
 msgid "Ignore Line-Ending Changes"
 msgstr "改行コードの変更を無視する"
 
-msgctxt "wnd(Log|Project|Std|).mniIgnoreReveal"
+msgctxt "wnd(Log|Project|Std|).mniIgnoreReveal:"
 msgid "Edit Ignore File"
 msgstr "無視リストを編集"
 
-msgctxt "wnd(Log|Project|Std|).mniIncludeTrackedRemoteBranches"
+msgctxt "wnd(Log|Project|Std|).mniIncludeTrackedRemoteBranches:"
 msgid "Include Tracked Remote Branches"
 msgstr "追跡されたリモート ブランチを含める"
 
-msgctxt "wnd(Log|Project|Std|).mniIndexEditor"
+msgctxt "wnd(Log|Project|Std|).mniIndexEditor:"
 msgid "Index Editor"
 msgstr "indexエディタ"
 
-msgctxt "wnd(Log|Project|Std|).mniInvestigate"
+msgctxt "wnd(Log|Project|Std|).mniInvestigate:"
 msgid "Investigate"
 msgstr "Investigate"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsInstall"
+msgctxt "wnd(Log|Project|Std|).mniLfsInstall:"
 msgid "Install"
 msgstr "インストール"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsLock"
+msgctxt "wnd(Log|Project|Std|).mniLfsLock:"
 msgid "Lock"
 msgstr "ロック"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsPrune"
+msgctxt "wnd(Log|Project|Std|).mniLfsPrune:"
 msgid "Prune"
 msgstr "プルーン\\(Prune\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsTrack"
+msgctxt "wnd(Log|Project|Std|).mniLfsTrack:"
 msgid "Track"
 msgstr "追跡"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsUnlock"
+msgctxt "wnd(Log|Project|Std|).mniLfsUnlock:"
 msgid "Unlock"
 msgstr "アンロック"
 
-msgctxt "wnd(Log|Project|Std|).mniLicenseAgreement"
+msgctxt "wnd(Log|Project|Std|).mniLicenseAgreement:"
 msgid "License Agreement"
 msgstr "ライセンス規約"
 
-msgctxt "wnd(Log|Project|Std|).mniLocalGc"
+msgctxt "wnd(Log|Project|Std|).mniLocalGc:"
 msgid "Run Garbage Collector"
 msgstr "ガベージコレクタ"
 
-msgctxt "wnd(Log|Project|Std|).mniLog"
+msgctxt "wnd(Log|Project|Std|).mniLog:"
 msgid "Log"
 msgstr "ログ"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringBranch"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringBranch:"
 msgid "Branch Coloring"
 msgstr "ブランチカラーリング"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringDefault"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringDefault:"
 msgid "Default Coloring"
 msgstr "デフォルトカラーリング"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringLegacy"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringLegacy:"
 msgid "Varying Coloring"
 msgstr "さまざまな色"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringMerge"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringMerge:"
 msgid "Mergeable Coloring"
 msgstr "マージ可能なカラーリング"
 
-msgctxt "wnd(Log|Project|Std|).mniLogRepository"
+msgctxt "wnd(Log|Project|Std|).mniLogRepository:"
 msgid "Show Log Window"
 msgstr "ログウィンドウを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniLogShowAllParents"
+msgctxt "wnd(Log|Project|Std|).mniLogShowAllParents:"
 msgid "Follow All Parents"
 msgstr "すべての親をフォロー"
 
-msgctxt "wnd(Log|Project|Std|).mniLogShowOnlyFirstParents"
+msgctxt "wnd(Log|Project|Std|).mniLogShowOnlyFirstParents:"
 msgid "Follow Only First Parent"
 msgstr "最初の親のみを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniLogTopoFiltering"
+msgctxt "wnd(Log|Project|Std|).mniLogTopoFiltering:"
 msgid "Show Graph While Filtering"
 msgstr "フィルタリング中にグラフを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexOnDemand"
+msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexOnDemand:"
 msgid "Show Working Tree  Index On Demand"
 msgstr "作業ツリー インデックスをオンデマンドで表示"
 
-msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexPermanent"
+msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexPermanent:"
 msgid "Show Working Tree Permanently"
 msgstr "作業ツリーを常に表示する"
 
-msgctxt "wnd(Log|Project|Std|).mniMailingList"
+msgctxt "wnd(Log|Project|Std|).mniMailingList:"
 msgid "SmartGit Website"
 msgstr "SmartGitウェブサイト"
 
-msgctxt "wnd(Log|Project|Std|).mniMerge"
+msgctxt "wnd(Log|Project|Std|).mniMerge:"
 msgid "Merge"
 msgstr "マージ"
 
-msgctxt "wnd(Log|Project|Std|).mniModifyCommit"
+msgctxt "wnd(Log|Project|Std|).mniModifyCommit:"
 msgid "Modify"
 msgstr "変更"
 
-msgctxt "wnd(Log|Project|Std|).mniNewStandardWindow"
+msgctxt "wnd(Log|Project|Std|).mniNewStandardWindow:"
 msgid "Show Standard Window"
 msgstr "スタンダードウィンドウを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniNewWindow"
+msgctxt "wnd(Log|Project|Std|).mniNewWindow:"
 msgid "New Window"
 msgstr "新しいウィンドウ"
 
-msgctxt "wnd(Log|Project|Std|).mniOpen"
+msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open from Working Tree"
 msgstr "作業ツリーから開く"
 
@@ -15011,99 +15011,99 @@ msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open"
 msgstr "開く"
 
-msgctxt "wnd(Log|Project|Std|).mniOpenDocumentation"
+msgctxt "wnd(Log|Project|Std|).mniOpenDocumentation:"
 msgid "Online Documentation"
 msgstr "オンラインドキュメント"
 
-msgctxt "wnd(Log|Project|Std|).mniOpenRootLog"
+msgctxt "wnd(Log|Project|Std|).mniOpenRootLog:"
 msgid "Open Root Log"
 msgstr "ルートログを開く"
 
-msgctxt "wnd(Log|Project|Std|).mniOpenUserEcho"
+msgctxt "wnd(Log|Project|Std|).mniOpenUserEcho:"
 msgid "Feature Requests"
 msgstr "機能の要望を送る"
 
-msgctxt "wnd(Log|Project|Std|).mniOpenWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniOpenWorkingTree:"
 msgid "Open Working Tree"
 msgstr "作業ツリーを開く"
 
-msgctxt "wnd(Log|Project|Std|).mniPreferences"
+msgctxt "wnd(Log|Project|Std|).mniPreferences:"
 msgid "Preferences"
 msgstr "環境設定"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCommentNext"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCommentNext:"
 msgid "Next Comment"
 msgstr "次のコメント"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCommentPrevious"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCommentPrevious:"
 msgid "Previous Comment"
 msgstr "前のコメント"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareAutomatic"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareAutomatic:"
 msgid "Automatic"
 msgstr "自動"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareHeadVsIndex"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareHeadVsIndex:"
 msgid "HEAD vs. Index"
 msgstr "HEAD 対 Index"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareIndexVsWT"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareIndexVsWT:"
 msgid "Index vs. Working Tree"
 msgstr "インデックスと作業ツリー"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewRefresh"
+msgctxt "wnd(Log|Project|Std|).mniPreviewRefresh:"
 msgid "Reload"
 msgstr "再読込"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewShowCurrentLines"
+msgctxt "wnd(Log|Project|Std|).mniPreviewShowCurrentLines:"
 msgid "Show Long Current Lines"
 msgstr "現在の行を長いテキストボックスで表示"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewUndo"
+msgctxt "wnd(Log|Project|Std|).mniPreviewUndo:"
 msgid "Undo"
 msgstr "元に戻す"
 
-msgctxt "wnd(Log|Project|Std|).mniPush"
+msgctxt "wnd(Log|Project|Std|).mniPush:"
 msgid "Push"
 msgstr "プッシュ"
 
-msgctxt "wnd(Log|Project|Std|).mniPushCommits"
+msgctxt "wnd(Log|Project|Std|).mniPushCommits:"
 msgid "Push Up To"
 msgstr "プッシュアップ"
 
-msgctxt "wnd(Log|Project|Std|).mniPushTo"
+msgctxt "wnd(Log|Project|Std|).mniPushTo:"
 msgid "Push To"
 msgstr "プッシュ先"
 
-msgctxt "wnd(Log|Project|Std|).mniPushToGerrit"
+msgctxt "wnd(Log|Project|Std|).mniPushToGerrit:"
 msgid "Push to Gerrit"
 msgstr "Gerritにプッシュ"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseAbort"
+msgctxt "wnd(Log|Project|Std|).mniRebaseAbort:"
 msgid "Abort"
 msgstr "中止"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseContinue"
+msgctxt "wnd(Log|Project|Std|).mniRebaseContinue:"
 msgid "Continue"
 msgstr "続ける"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseHeadTo"
+msgctxt "wnd(Log|Project|Std|).mniRebaseHeadTo:"
 msgid "Rebase"
 msgstr "リベース"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseInteractive"
+msgctxt "wnd(Log|Project|Std|).mniRebaseInteractive:"
 msgid "Rebase Interactive From"
 msgstr "対話的なリベース"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseSkip"
+msgctxt "wnd(Log|Project|Std|).mniRebaseSkip:"
 msgid "Skip"
 msgstr "スキップ"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseStep"
+msgctxt "wnd(Log|Project|Std|).mniRebaseStep:"
 msgid "Step"
 msgstr "ステップ"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseToHead"
+msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD"
 msgstr "HEAD にリベース"
 
@@ -15115,75 +15115,75 @@ msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD"
 msgstr "HEAD にリベース"
 
-msgctxt "wnd(Log|Project|Std|).mniRefresh"
+msgctxt "wnd(Log|Project|Std|).mniRefresh:"
 msgid "Refresh"
 msgstr "更新"
 
-msgctxt "wnd(Log|Project|Std|).mniRegister"
+msgctxt "wnd(Log|Project|Std|).mniRegister:"
 msgid "Register"
 msgstr "登録"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteAdd"
+msgctxt "wnd(Log|Project|Std|).mniRemoteAdd:"
 msgid "Add"
 msgstr "追加"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteCopyUrl"
+msgctxt "wnd(Log|Project|Std|).mniRemoteCopyUrl:"
 msgid "Copy URL"
 msgstr "URL をコピー"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteDelete"
+msgctxt "wnd(Log|Project|Std|).mniRemoteDelete:"
 msgid "Delete"
 msgstr "削除"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetch"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetch:"
 msgid "Fetch"
 msgstr "フェッチ"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetchAll"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetchAll:"
 msgid "Fetch All"
 msgstr "全てフェッチ"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetchMore"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetchMore:"
 msgid "Fetch More"
 msgstr "追加のフェッチ"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteProperties"
+msgctxt "wnd(Log|Project|Std|).mniRemoteProperties:"
 msgid "Properties"
 msgstr "プロパティ"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteRename"
+msgctxt "wnd(Log|Project|Std|).mniRemoteRename:"
 msgid "Rename"
 msgstr "リネーム"
 
-msgctxt "wnd(Log|Project|Std|).mniRemove"
+msgctxt "wnd(Log|Project|Std|).mniRemove:"
 msgid "Remove"
 msgstr "除去"
 
-msgctxt "wnd(Log|Project|Std|).mniRename"
+msgctxt "wnd(Log|Project|Std|).mniRename:"
 msgid "Move or Rename"
 msgstr "移動または名前を変更"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryAdd"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryAdd:"
 msgid "Add or Create"
 msgstr "追加 or 作成"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryAddGroup"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryAddGroup:"
 msgid "Add Group"
 msgstr "グループを作成"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryClone"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryClone:"
 msgid "Clone"
 msgstr "クローン"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryClose"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryClose:"
 msgid "Close Repository"
 msgstr "リポジトリを閉じる"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfig"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfig:"
 msgid "Repository"
 msgstr "リポジトリ"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfigUser"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfigUser:"
 msgid "User"
 msgstr "ユーザー"
 
@@ -15199,95 +15199,95 @@ msgctxt "wnd(Log|Project|Std|).mniRepositoryFavorite:"
 msgid "Unmark as Favorite"
 msgstr "お気に入りのマークを外す"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryOpen"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryOpen:"
 msgid "Open Repository"
 msgstr "リポジトリを開く"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryOpenInNewWindow"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryOpenInNewWindow:"
 msgid "Open Repository in New Window"
 msgstr "リポジトリを新しいウィンドウで開く"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryRemove"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryRemove:"
 msgid "Remove"
 msgstr "除去"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryRename"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryRename:"
 msgid "Rename"
 msgstr "リネーム"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySearch"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySearch:"
 msgid "Search for Repositories"
 msgstr "リポジトリの検索"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySelectObsolete"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySelectObsolete:"
 msgid "Select Obsolete Repositories"
 msgstr "廃止されたリポジトリを選択する"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySettings"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySettings:"
 msgid "Settings"
 msgstr "設定"
 
-msgctxt "wnd(Log|Project|Std|).mniReset"
+msgctxt "wnd(Log|Project|Std|).mniReset:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "wnd(Log|Project|Std|).mniResetAdvanced"
+msgctxt "wnd(Log|Project|Std|).mniResetAdvanced:"
 msgid "Reset Advanced"
 msgstr "高度なリセット"
 
-msgctxt "wnd(Log|Project|Std|).mniResolve"
+msgctxt "wnd(Log|Project|Std|).mniResolve:"
 msgid "Resolve"
 msgstr "解決"
 
-msgctxt "wnd(Log|Project|Std|).mniResolveOurs"
+msgctxt "wnd(Log|Project|Std|).mniResolveOurs:"
 msgid "Take Ours"
 msgstr "Ours を採用"
 
-msgctxt "wnd(Log|Project|Std|).mniResolveRecreateConflict"
+msgctxt "wnd(Log|Project|Std|).mniResolveRecreateConflict:"
 msgid "Recreate Conflict"
 msgstr "競合した状態に戻す"
 
-msgctxt "wnd(Log|Project|Std|).mniResolveTheirs"
+msgctxt "wnd(Log|Project|Std|).mniResolveTheirs:"
 msgid "Take Theirs"
 msgstr "Theirs を採用"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommit"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommit:"
 msgid "Reveal Commit"
 msgstr "コミットを表示する"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommitExtend"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommitExtend:"
 msgid "Compare with Selected Commit"
 msgstr "選択されたコミットと比較"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommitWithHead"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommitWithHead:"
 msgid "Compare with HEAD"
 msgstr "HEAD と比較"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealPrevCommit"
+msgctxt "wnd(Log|Project|Std|).mniRevealPrevCommit:"
 msgid "Reveal Previous Commit"
 msgstr "前のコミットを表示する"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniRevealWorkingTree:"
 msgid "Reveal Working Tree"
 msgstr "作業ツリーを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniRevert"
+msgctxt "wnd(Log|Project|Std|).mniRevert:"
 msgid "Revert"
 msgstr "リバート"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewCommentCreate"
+msgctxt "wnd(Log|Project|Std|).mniReviewCommentCreate:"
 msgid "Add Comment"
 msgstr "コメントを追加"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewConfigure"
+msgctxt "wnd(Log|Project|Std|).mniReviewConfigure:"
 msgid "Configure"
 msgstr "設定"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase"
+msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase:"
 msgid "Dump Database"
 msgstr "データベースのダンプ"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate"
+msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Pull Request"
 msgstr "プルリクエストを作成"
 
@@ -15299,335 +15299,335 @@ msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Pull Request"
 msgstr "プルリクエストを作成"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewShowClosedPullRequests"
+msgctxt "wnd(Log|Project|Std|).mniReviewShowClosedPullRequests:"
 msgid "Show Closed Pull Requests"
 msgstr "終了したプルリクエストを表示する"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewSync"
+msgctxt "wnd(Log|Project|Std|).mniReviewSync:"
 msgid "Sync"
 msgstr "同期"
 
-msgctxt "wnd(Log|Project|Std|).mniRewriteTextFile"
+msgctxt "wnd(Log|Project|Std|).mniRewriteTextFile:"
 msgid "Fix Line-Endings"
 msgstr "改行コードを修正"
 
-msgctxt "wnd(Log|Project|Std|).mniRollbackTo"
+msgctxt "wnd(Log|Project|Std|).mniRollbackTo:"
 msgid "Rollback To"
 msgstr "ロールバック"
 
-msgctxt "wnd(Log|Project|Std|).mniSaveAs"
+msgctxt "wnd(Log|Project|Std|).mniSaveAs:"
 msgid "Save As"
 msgstr "名前を付けて保存"
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-find"
+msgctxt "wnd(Log|Project|Std|).mniSearch-find:"
 msgid "Find"
 msgstr "検索"
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-next"
+msgctxt "wnd(Log|Project|Std|).mniSearch-next:"
 msgid "Find Next"
 msgstr "次を検索"
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-previous"
+msgctxt "wnd(Log|Project|Std|).mniSearch-previous:"
 msgid "Find Previous"
 msgstr "前を検索"
 
-msgctxt "wnd(Log|Project|Std|).mniSelectCommittableFiles"
+msgctxt "wnd(Log|Project|Std|).mniSelectCommittableFiles:"
 msgid "Select Committable Files"
 msgstr "コミット可能なファイルを選択"
 
-msgctxt "wnd(Log|Project|Std|).mniSelectDirectory"
+msgctxt "wnd(Log|Project|Std|).mniSelectDirectory:"
 msgid "Select Directory"
 msgstr "ディレクトリを選択"
 
-msgctxt "wnd(Log|Project|Std|).mniSelectRoot"
+msgctxt "wnd(Log|Project|Std|).mniSelectRoot:"
 msgid "Select Repository Root"
 msgstr "リポジトリルートを選択"
 
-msgctxt "wnd(Log|Project|Std|).mniSet-syntax"
+msgctxt "wnd(Log|Project|Std|).mniSet-syntax:"
 msgid "Syntax Language"
 msgstr "シンタックスハイライトの言語選択"
 
-msgctxt "wnd(Log|Project|Std|).mniSetDepth"
+msgctxt "wnd(Log|Project|Std|).mniSetDepth:"
 msgid "Set Depth"
 msgstr "深さの設定"
 
-msgctxt "wnd(Log|Project|Std|).mniShow-line-numbers"
+msgctxt "wnd(Log|Project|Std|).mniShow-line-numbers:"
 msgid "Show Line Numbers"
 msgstr "行番号の表示"
 
-msgctxt "wnd(Log|Project|Std|).mniShowChanges"
+msgctxt "wnd(Log|Project|Std|).mniShowChanges:"
 msgid "Show Changes"
 msgstr "比較する"
 
-msgctxt "wnd(Log|Project|Std|).mniSkipWorkTree"
+msgctxt "wnd(Log|Project|Std|).mniSkipWorkTree:"
 msgid "Toggle 'Skip Worktree'"
 msgstr "'Skip Worktree' フラグを切り替え"
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsAsIs"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsAsIs:"
 msgid "Sort By Time"
 msgstr "時間順でソート"
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsFirstParentsBeforeMergeParents"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsFirstParentsBeforeMergeParents:"
 msgid "Sort First Parents before Merge Parents"
 msgstr "最初の親、マージの親の順にソートする"
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsMergeParentsBeforeFirstParents"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsMergeParentsBeforeFirstParents:"
 msgid "Sort Merge Parents before First Parents"
 msgstr "マージの親、最初の親の順にソートする"
 
-msgctxt "wnd(Log|Project|Std|).mniSplitCommit"
+msgctxt "wnd(Log|Project|Std|).mniSplitCommit:"
 msgid "Split"
 msgstr "分割"
 
-msgctxt "wnd(Log|Project|Std|).mniSquashCommits"
+msgctxt "wnd(Log|Project|Std|).mniSquashCommits:"
 msgid "Squash"
 msgstr "スカッシュ"
 
-msgctxt "wnd(Log|Project|Std|).mniStage"
+msgctxt "wnd(Log|Project|Std|).mniStage:"
 msgid "Stage"
 msgstr "ステージ"
 
-msgctxt "wnd(Log|Project|Std|).mniStashApply"
+msgctxt "wnd(Log|Project|Std|).mniStashApply:"
 msgid "Apply Stash"
 msgstr "スタッシュを適用"
 
-msgctxt "wnd(Log|Project|Std|).mniStashDrop"
+msgctxt "wnd(Log|Project|Std|).mniStashDrop:"
 msgid "Drop Stash"
 msgstr "スタッシュを削除"
 
-msgctxt "wnd(Log|Project|Std|).mniStashRename"
+msgctxt "wnd(Log|Project|Std|).mniStashRename:"
 msgid "Rename Stash"
 msgstr "リネーム"
 
-msgctxt "wnd(Log|Project|Std|).mniStashSave"
+msgctxt "wnd(Log|Project|Std|).mniStashSave:"
 msgid "Stash All"
 msgstr "すべての変更を隠す"
 
-msgctxt "wnd(Log|Project|Std|).mniStashSaveSelection"
+msgctxt "wnd(Log|Project|Std|).mniStashSaveSelection:"
 msgid "Stash Selection"
 msgstr "選択した変更を隠す"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeactivate"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeactivate:"
 msgid "Deactivate"
 msgstr "無効にする"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeinit"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeinit:"
 msgid "Deinit"
 msgstr "削除\\(Deinit\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleInit"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleInit:"
 msgid "Initialize"
 msgstr "初期化"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleRegister"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleRegister:"
 msgid "Add"
 msgstr "追加"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleReset"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleReset:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleSync"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleSync:"
 msgid "Synchronize"
 msgstr "同期"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleUnregister"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleUnregister:"
 msgid "Unregister"
 msgstr "登録を解除"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeAdd"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeAdd:"
 msgid "Add"
 msgstr "追加"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeMerge"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeMerge:"
 msgid "Merge"
 msgstr "マージ"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreePush"
+msgctxt "wnd(Log|Project|Std|).mniSubtreePush:"
 msgid "Push"
 msgstr "プッシュ"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeReset"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeReset:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeSplit"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeSplit:"
 msgid "Split"
 msgstr "分割"
 
-msgctxt "wnd(Log|Project|Std|).mniSync"
+msgctxt "wnd(Log|Project|Std|).mniSync:"
 msgid "Synchronize"
 msgstr "同期"
 
-msgctxt "wnd(Log|Project|Std|).mniUndoLastCommit"
+msgctxt "wnd(Log|Project|Std|).mniUndoLastCommit:"
 msgid "Undo Last Commit"
 msgstr "直前のコミットを元に戻す"
 
-msgctxt "wnd(Log|Project|Std|).mniUnstage"
+msgctxt "wnd(Log|Project|Std|).mniUnstage:"
 msgid "Unstage"
 msgstr "アンステージ"
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr "空白を無視"
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-all"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-all:"
 msgid "Ignore All Whitespaces for Line Comparison"
 msgstr "行比較で空白をすべて無視する"
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-leading-trailing"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-leading-trailing:"
 msgid "Ignore Leading/Trailing Whitespaces for Line Comparison"
 msgstr "行比較で先頭と行末の空白を無視する"
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-none"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-none:"
 msgid "Ignore No Whitespace for Line Comparison"
 msgstr "行比較で空白を無視しない"
 
-msgctxt "wnd(Log|Project|Std|).mniView-remember-as-default"
+msgctxt "wnd(Log|Project|Std|).mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr "デフォルトとして記憶する"
 
-msgctxt "wnd(Log|Project|Std|).mniView-settings"
+msgctxt "wnd(Log|Project|Std|).mniView-settings:"
 msgid "Settings"
 msgstr "設定"
 
-msgctxt "wnd(Log|Project|Std|).mniView-show-current-line-control"
+msgctxt "wnd(Log|Project|Std|).mniView-show-current-line-control:"
 msgid "Show Long Current Lines"
 msgstr "現在の行を長いテキストボックスで表示"
 
-msgctxt "wnd(Log|Project|Std|).mniViewFromSubmodules"
+msgctxt "wnd(Log|Project|Std|).mniViewFromSubmodules:"
 msgid "Show Files From Submodules"
 msgstr "サブモジュールのファイルを表示する"
 
-msgctxt "wnd(Log|Project|Std|).mniViewIgnored"
+msgctxt "wnd(Log|Project|Std|).mniViewIgnored:"
 msgid "Show Ignored Files"
 msgstr "無視されたファイルを表示する"
 
-msgctxt "wnd(Log|Project|Std|).mniViewRecursive"
+msgctxt "wnd(Log|Project|Std|).mniViewRecursive:"
 msgid "Files from Subdirectories"
 msgstr "サブディレクトリのファイル"
 
-msgctxt "wnd(Log|Project|Std|).mniViewRenameSource"
+msgctxt "wnd(Log|Project|Std|).mniViewRenameSource:"
 msgid "Show Rename Source Files"
 msgstr "名前変更元のファイルを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniViewSeparateWtAndIndex"
+msgctxt "wnd(Log|Project|Std|).mniViewSeparateWtAndIndex:"
 msgid "Separate Working Tree and Index"
 msgstr "作業ツリーとインデックスを分離"
 
-msgctxt "wnd(Log|Project|Std|).mniViewSetAnchorCommit"
+msgctxt "wnd(Log|Project|Std|).mniViewSetAnchorCommit:"
 msgid "Set Anchor Commit"
 msgstr "アンカーコミットを設定"
 
-msgctxt "wnd(Log|Project|Std|).mniViewSkipped"
+msgctxt "wnd(Log|Project|Std|).mniViewSkipped:"
 msgid "Show Skipped Files"
 msgstr "スキップされたファイルを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniViewStaged"
+msgctxt "wnd(Log|Project|Std|).mniViewStaged:"
 msgid "Show Staged Files"
 msgstr "ステージングされたファイルを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleIndex"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleIndex:"
 msgid "Only Index"
 msgstr "Indexのみ"
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleMixed"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleMixed:"
 msgid "Mixed"
 msgstr "Mixed"
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleWorkingTree:"
 msgid "Only Working Tree"
 msgstr "作業ツリーのみ"
 
-msgctxt "wnd(Log|Project|Std|).mniViewToolBar"
+msgctxt "wnd(Log|Project|Std|).mniViewToolBar:"
 msgid "Show Toolbar"
 msgstr "ツールバーを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnchanged"
+msgctxt "wnd(Log|Project|Std|).mniViewUnchanged:"
 msgid "Show Unchanged Files"
 msgstr "未変更ファイルの表示"
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnchangedAssumed"
+msgctxt "wnd(Log|Project|Std|).mniViewUnchangedAssumed:"
 msgid "Show Assume-Unchanged Files"
 msgstr "変更すべきでない\\(assume-unchanged\\)ファイルを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnversioned"
+msgctxt "wnd(Log|Project|Std|).mniViewUnversioned:"
 msgid "Show Unversioned Files"
 msgstr "バージョン管理されていないファイルを表示"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowBranches"
+msgctxt "wnd(Log|Project|Std|).mniWindowBranches:"
 msgid "Branches"
 msgstr "ブランチ"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowChanges"
+msgctxt "wnd(Log|Project|Std|).mniWindowChanges:"
 msgid "Changes"
 msgstr "変更点"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowClose"
+msgctxt "wnd(Log|Project|Std|).mniWindowClose:"
 msgid "Close"
 msgstr "閉じる"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowComments"
+msgctxt "wnd(Log|Project|Std|).mniWindowComments:"
 msgid "Comments"
 msgstr "コメント"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowCommit"
+msgctxt "wnd(Log|Project|Std|).mniWindowCommit:"
 msgid "Commit"
 msgstr "コミット"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowDebugLog"
+msgctxt "wnd(Log|Project|Std|).mniWindowDebugLog:"
 msgid "Debug Log"
 msgstr "デバッグログ"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowDirectories"
+msgctxt "wnd(Log|Project|Std|).mniWindowDirectories:"
 msgid "Repositories"
 msgstr "リポジトリ"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowFiles"
+msgctxt "wnd(Log|Project|Std|).mniWindowFiles:"
 msgid "Files"
 msgstr "ファイル"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowGraph"
+msgctxt "wnd(Log|Project|Std|).mniWindowGraph:"
 msgid "Graph"
 msgstr "グラフ"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowHideView"
+msgctxt "wnd(Log|Project|Std|).mniWindowHideView:"
 msgid "Hide View"
 msgstr "ビューを隠す"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowJournal"
+msgctxt "wnd(Log|Project|Std|).mniWindowJournal:"
 msgid "Journal"
 msgstr "ジャーナル"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutReset"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutReset:"
 msgid "Reset Perspective"
 msgstr "作業環境のリセット"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetMain"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetMain:"
 msgid "Main Perspective"
 msgstr "メインの作業環境"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetReview"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetReview:"
 msgid "Review Perspective"
 msgstr "レビュー用の作業環境"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowOutput"
+msgctxt "wnd(Log|Project|Std|).mniWindowOutput:"
 msgid "Output"
 msgstr "出力"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniWindowWorkingTree:"
 msgid "Show Working Tree Window"
 msgstr "ワーキングツリーウィンドウを表示する"
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreeAdd"
+msgctxt "wnd(Log|Project|Std|).mniWorktreeAdd:"
 msgid "Add Worktree"
 msgstr "ワークツリーを追加"
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreePrune"
+msgctxt "wnd(Log|Project|Std|).mniWorktreePrune:"
 msgid "Prune Obsolete Worktrees"
 msgstr "廃止されたワークツリーを整理する"
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreeRemove"
+msgctxt "wnd(Log|Project|Std|).mniWorktreeRemove:"
 msgid "Remove Worktree"
 msgstr "ワークツリーを削除する"
 
@@ -15823,7 +15823,7 @@ msgctxt "wnd(Log|Project|Std|).tab:"
 msgid "Repositories"
 msgstr "リポジトリ"
 
-msgctxt "wnd(Log|Project|Std|).tbr\"  History  \""
+msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
 msgid "History"
 msgstr "履歴"
 
@@ -16087,119 +16087,119 @@ msgctxt "wnd(Log|Project|Std|).tbt:"
 msgid "Show directories tree"
 msgstr "ディレクトリツリーを表示"
 
-msgctxt "wnd(Log|Project|Std|).tbtAnnotate"
+msgctxt "wnd(Log|Project|Std|).tbtAnnotate:"
 msgid "Show a blame \\(annotated\\) view of the selected file."
 msgstr "選択したファイルのブレーム \\(注釈付き\\) ビューを表示します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtBranchAdd"
+msgctxt "wnd(Log|Project|Std|).tbtBranchAdd:"
 msgid "Add a new branch for the current commit."
 msgstr "現在のコミットに対して新しいブランチを追加します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtBranchAddTag"
+msgctxt "wnd(Log|Project|Std|).tbtBranchAddTag:"
 msgid "Add a new tag for the current commit."
 msgstr "現在のコミットに対して新しいタグを追加します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtCheckout"
+msgctxt "wnd(Log|Project|Std|).tbtCheckout:"
 msgid "Check out an existing commit."
 msgstr "既存のコミットをチェックアウトします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtCherryPick"
+msgctxt "wnd(Log|Project|Std|).tbtCherryPick:"
 msgid "Cherry-pick commits from other branches."
 msgstr "他のブランチからコミットをチェリーピックします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtClearOutput"
+msgctxt "wnd(Log|Project|Std|).tbtClearOutput:"
 msgid "Clear output pane."
 msgstr "「出力」ペーンをクリアします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtCommit"
+msgctxt "wnd(Log|Project|Std|).tbtCommit:"
 msgid "Commit local changes."
 msgstr "ローカルの変更をコミットします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtConflictSolver"
+msgctxt "wnd(Log|Project|Std|).tbtConflictSolver:"
 msgid "Open the Conflict Solver \\(or configured external merge tool\\) to resolve conflicts."
 msgstr "競合解決ツール\\(または設定された外部のマージツール\\)を開き、競合を解決します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtDelete"
+msgctxt "wnd(Log|Project|Std|).tbtDelete:"
 msgid "Delete the selected local files or directory."
 msgstr "選択したローカルファイルまたはディレクトリを削除します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtDiscard"
+msgctxt "wnd(Log|Project|Std|).tbtDiscard:"
 msgid "Discard local changes."
 msgstr "ローカルの変更を破棄します"
 
-msgctxt "wnd(Log|Project|Std|).tbtFetch"
+msgctxt "wnd(Log|Project|Std|).tbtFetch:"
 msgid "Fetch commits from a remote repository and \\(optionally\\) integrate them with possible local commits."
 msgstr "リモートリポジトリからコミットを取得し、（オプションで）ローカルの可能なコミットと統合します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowContext"
+msgctxt "wnd(Log|Project|Std|).tbtFlowContext:"
 msgid "Finish a Git-Flow feature."
 msgstr "Git-Flow feature を完了"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixFinish"
+msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixFinish:"
 msgid "Finish a Git-Flow hotfix."
 msgstr "Git-Flow hotfix を完了"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixStart"
+msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixStart:"
 msgid "Start a new Git-Flow hotfix."
 msgstr "新しい Git-Flow の hotfix を開始します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowIntegrateDevelop"
+msgctxt "wnd(Log|Project|Std|).tbtFlowIntegrateDevelop:"
 msgid "Integrate new base commits into a Git-Flow feature."
 msgstr "新しいベースコミットをGit-Flowのfeatureに統合する。"
 
-msgctxt "wnd(Log|Project|Std|).tbtGoto-next-diff"
+msgctxt "wnd(Log|Project|Std|).tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "次の変更点に移動します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtGoto-previous-diff"
+msgctxt "wnd(Log|Project|Std|).tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "前の変更点に移動します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtIgnore"
+msgctxt "wnd(Log|Project|Std|).tbtIgnore:"
 msgid "Mark unversioned local files/directories to be ignored."
 msgstr "バージョン管理されていないローカル ファイル/ディレクトリを無視するようにマークします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtIndexEditor"
+msgctxt "wnd(Log|Project|Std|).tbtIndexEditor:"
 msgid "Edit the Index state of the selected file, e.g. to decide which lines should be staged."
 msgstr "行単位のステージングなど、選択したファイルのインデックスの状態を編集することができます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtInvestigate"
+msgctxt "wnd(Log|Project|Std|).tbtInvestigate:"
 msgid "Investigate history line-wise with DeepGit."
 msgstr "DeepGit を使用して行ごとに履歴を調査します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtLog"
+msgctxt "wnd(Log|Project|Std|).tbtLog:"
 msgid "Show the history for selected file or directory."
 msgstr "選択したファイルやディレクトリの履歴を表示します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtLogRepository"
+msgctxt "wnd(Log|Project|Std|).tbtLogRepository:"
 msgid "Show the history for the whole repository."
 msgstr "リポジトリ全体の履歴を表示します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtMerge"
+msgctxt "wnd(Log|Project|Std|).tbtMerge:"
 msgid "Merge changes from other branches."
 msgstr "他のブランチからの変更をマージします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtPreviewRefresh"
+msgctxt "wnd(Log|Project|Std|).tbtPreviewRefresh:"
 msgid "Reload the previewed file contents."
 msgstr "プレビューしたファイルの内容を再読み込みします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtPush"
+msgctxt "wnd(Log|Project|Std|).tbtPush:"
 msgid "Push local commits to the remote origin repository."
 msgstr "ローカルのコミットをリモートの origin リポジトリにプッシュします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtPushTo"
+msgctxt "wnd(Log|Project|Std|).tbtPushTo:"
 msgid "Push local commits to a remote repository, allowing to choose the target repository."
 msgstr "ローカルコミットをリモートリポジトリにプッシュし、ターゲットリポジトリを選択できるようにします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRebaseHeadTo"
+msgctxt "wnd(Log|Project|Std|).tbtRebaseHeadTo:"
 msgid "Apply commits from your current branch to the selected commit."
 msgstr "現在のブランチのコミットを選択したコミットに適用します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRefresh"
+msgctxt "wnd(Log|Project|Std|).tbtRefresh:"
 msgid "Refresh the log view."
 msgstr "ログ ビューを更新します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch"
+msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from current remote repository."
 msgstr "現在のリモートリポジトリからコミットをフェッチします。"
 
@@ -16211,123 +16211,123 @@ msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from current remote repository."
 msgstr "現在のリモートリポジトリからコミットを取得します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRemove"
+msgctxt "wnd(Log|Project|Std|).tbtRemove:"
 msgid "Remove selected files or directories from repository."
 msgstr "選択したファイルやディレクトリをリポジトリから削除します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositoryAdd"
+msgctxt "wnd(Log|Project|Std|).tbtRepositoryAdd:"
 msgid "Add or create a new repository."
 msgstr "リポジトリを追加または新規作成します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositoryClone"
+msgctxt "wnd(Log|Project|Std|).tbtRepositoryClone:"
 msgid "Clone a new repository."
 msgstr "新しいリポジトリのクローンを作成します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositorySearch"
+msgctxt "wnd(Log|Project|Std|).tbtRepositorySearch:"
 msgid "Search for existing repositories."
 msgstr "既存のリポジトリを検索します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtReset"
+msgctxt "wnd(Log|Project|Std|).tbtReset:"
 msgid "Reset current HEAD to another commit."
 msgstr "現在のHEADを別のコミットにリセットします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtResetAdvanced"
+msgctxt "wnd(Log|Project|Std|).tbtResetAdvanced:"
 msgid "Reset current HEAD to another commit and keep the difference in Index or Working Tree."
 msgstr "現在の HEAD を別のコミットにリセットし、差分を Index または 作業ツリーに保持します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealHomeCommit"
+msgctxt "wnd(Log|Project|Std|).tbtRevealHomeCommit:"
 msgid "Reveal HEAD/working tree in graph."
 msgstr "HEAD/作業ツリーをグラフで表示します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealPrevCommit"
+msgctxt "wnd(Log|Project|Std|).tbtRevealPrevCommit:"
 msgid "Reveal selected commits before invoking Reveal Working Tree."
 msgstr "作業ツリーの表示を呼び出す前に、選択したコミットを表示します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealWorkingTree"
+msgctxt "wnd(Log|Project|Std|).tbtRevealWorkingTree:"
 msgid "Reveal working tree node in graph."
 msgstr "作業ツリーノードをグラフに表示します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRevert"
+msgctxt "wnd(Log|Project|Std|).tbtRevert:"
 msgid "Undo the changes of an existing commit by \"reverse\" merging it."
 msgstr "既存のコミットの変更を\"リバース\"マージして元に戻します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtShowChanges"
+msgctxt "wnd(Log|Project|Std|).tbtShowChanges:"
 msgid "Open the file compare for the selected file."
 msgstr "選択したファイルのファイル比較を開きます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStage"
+msgctxt "wnd(Log|Project|Std|).tbtStage:"
 msgid "Store working tree files in the index to prepare the next commit."
 msgstr "作業中のツリーファイルをインデックスに格納し、次のコミットに備えます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStashApply"
+msgctxt "wnd(Log|Project|Std|).tbtStashApply:"
 msgid "Reapply local changes from a stash."
 msgstr "スタッシュからローカルに変更を再適用します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStashDrop"
+msgctxt "wnd(Log|Project|Std|).tbtStashDrop:"
 msgid "Drop one or more stashes from the repository."
 msgstr "リポジトリから1つまたは複数のスタッシュを削除します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStashSave"
+msgctxt "wnd(Log|Project|Std|).tbtStashSave:"
 msgid "Stash current local changes."
 msgstr "現在のローカルの変更をスタッシュに退避します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStdSetModeHistory"
+msgctxt "wnd(Log|Project|Std|).tbtStdSetModeHistory:"
 msgid "Show the history view."
 msgstr "ヒストリービューを表示する。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStdSetModeWt"
+msgctxt "wnd(Log|Project|Std|).tbtStdSetModeWt:"
 msgid "Show the local files of the repository \\(Working Tree\\)."
 msgstr "リポジトリのローカルファイル（作業ツリー）を表示します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtSync"
+msgctxt "wnd(Log|Project|Std|).tbtSync:"
 msgid "Push local commits of the current branch and pull remote changes."
 msgstr "現在のブランチのローカルコミットをプッシュし、リモートの変更をプルします。"
 
-msgctxt "wnd(Log|Project|Std|).tbtUnstage"
+msgctxt "wnd(Log|Project|Std|).tbtUnstage:"
 msgid "Remove staged changes from index."
 msgstr "インデックスからステージングされた変更を削除します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtView-ignore-whitespaces"
+msgctxt "wnd(Log|Project|Std|).tbtView-ignore-whitespaces:"
 msgid "Ignore irrelevant whitespace"
 msgstr "無関係な空白を無視する"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewFromSubmodules"
+msgctxt "wnd(Log|Project|Std|).tbtViewFromSubmodules:"
 msgid "If selected, files from submodules will be shown."
 msgstr "サブモジュールのファイルが表示されます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewIgnored"
+msgctxt "wnd(Log|Project|Std|).tbtViewIgnored:"
 msgid "If selected, ignored files will be shown."
 msgstr "無視されたファイルが表示されます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewRenameSource"
+msgctxt "wnd(Log|Project|Std|).tbtViewRenameSource:"
 msgid "If selected, removed/missing source files of detected renames will be shown."
 msgstr "名前の変更として認識されたファイルの削除/紛失を表示します。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewSkipped"
+msgctxt "wnd(Log|Project|Std|).tbtViewSkipped:"
 msgid "If selected, skipped files will be shown."
 msgstr "スキップされたファイルが表示されます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewStaged"
+msgctxt "wnd(Log|Project|Std|).tbtViewStaged:"
 msgid "If selected, files with staged \\(Index\\) changes and without working tree changes will be shown."
 msgstr "選択すると、ステージングされた（インデックス）変更があるファイルと、作業ツリーの変更がないファイルが表示されます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnchanged"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnchanged:"
 msgid "If selected, unchanged files will be shown."
 msgstr "選択すると、変更されていないファイルが表示されます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnchangedAssumed"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnchangedAssumed:"
 msgid "If selected, files having the 'assume-unchanged' flag will be shown."
 msgstr "変更すべきでない\\(assume-unchanged\\)フラグが設定されたファイルが表示されます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnversioned"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnversioned:"
 msgid "If selected, not yet version controlled files will be shown."
 msgstr "選択すると、まだバージョン管理されていないファイルが表示されます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetMain"
+msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetMain:"
 msgid "Switch to the Main perspective."
 msgstr "メイン の表示に切り替えます。"
 
-msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetReview"
+msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetReview:"
 msgid "Switch to the Review perspective."
 msgstr "レビュー向けの表示に切り替えます。"
 

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -2013,10 +2013,6 @@ msgctxt "dlgSgAbortRebasingConfirm.tle:"
 msgid "Abort"
 msgstr "中止"
 
-msgctxt "dlgSgAbortRebasingConfirm.tle:"
-msgid "Abort"
-msgstr "中止"
-
 msgctxt "dlgSgAbortRevertingConfirm.btn:"
 msgid "Abort Revert"
 msgstr "リバートを中止"
@@ -2373,10 +2369,6 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr "$1個のローカルブランチを削除しますか？"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
-msgid "Do you want to delete $1 local branches?"
-msgstr "$1 件のローカル ブランチを削除しますか?"
-
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle:"
 msgid "Delete"
 msgstr "削除"
@@ -2413,10 +2405,6 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "ローカルブランチ'$1'を削除しますか？"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
-msgid "Do you want to delete the local branch '$1'?"
-msgstr "ローカル ブランチ '$1' を削除しますか?"
-
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle:"
 msgid "Delete"
 msgstr "削除"
@@ -2434,10 +2422,6 @@ msgid "Delete"
 msgstr "削除"
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
-msgid "Delete from remote repository '$1'"
-msgstr "リモートリポジトリ '$1' から削除する"
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
 msgstr "リモート '$1' から削除"
 
@@ -2448,10 +2432,6 @@ msgstr "リモートリポジトリ'$1'から削除"
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur:"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
 msgstr "ローカルにあるリモートブランチリストからブランチを削除するだけで、次のフェッチでブランチが復活する可能性があります。"
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
-msgid "Do you want to delete the branch '$1'?"
-msgstr "ブランチ '$1' を削除しますか？"
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the branch '$1'?"
@@ -3761,12 +3741,6 @@ msgctxt "dlgSgDiscardRevertTo(Head|Index).tle:"
 msgid "Discard"
 msgstr "破棄"
 
-# Needs review: Check whether the URL needs to be made variable
-#, fuzzy
-msgctxt "dlgSgErrorUtilsClientException.fur:"
-msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-msgstr "サーバーが URL: https://gitlab.com/oauth/token に対して HTTP 応答コード: 400 を返しました"
-
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Commit '$1' was not found in repository."
 msgstr "コミット '$1' がリポジトリ内に見つかりませんでした。"
@@ -3782,6 +3756,12 @@ msgstr "'$1' にあるリポジトリの GIT_DIR が存在しません。"
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Repository '$1' is not valid."
 msgstr "リポジトリ '$1' は無効です。"
+
+# Needs review: Check whether the URL needs to be made variable
+#, fuzzy
+msgctxt "dlgSgErrorUtilsClientException.fur:"
+msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
+msgstr "サーバーが URL: https://gitlab.com/oauth/token に対して HTTP 応答コード: 400 を返しました"
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "svn: $1"
@@ -10319,16 +10299,16 @@ msgid "What to do with the working tree or Index changes?"
 msgstr "作業ツリーまたはインデックスの変更をどうしますか？"
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
-msgid "Reset"
-msgstr "リセット"
-
-msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Checkout"
 msgstr "チェックアウト"
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
 msgstr "プル"
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Reset"
+msgstr "リセット"
 
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
 msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
@@ -14812,10 +14792,6 @@ msgid "Use Message for Commit"
 msgstr "コミットにメッセージを使用"
 
 msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
-msgid "Configure"
-msgstr "設定"
-
-msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure Features"
 msgstr "Feature の設定"
 
@@ -15004,10 +14980,6 @@ msgid "Open from Working Tree"
 msgstr "作業ツリーから開く"
 
 msgctxt "wnd(Log|Project|Std|).mniOpen:"
-msgid "Open from Working Tree"
-msgstr "作業ツリーから開く"
-
-msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open"
 msgstr "開く"
 
@@ -15102,10 +15074,6 @@ msgstr "スキップ"
 msgctxt "wnd(Log|Project|Std|).mniRebaseStep:"
 msgid "Step"
 msgstr "ステップ"
-
-msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
-msgid "Rebase to HEAD"
-msgstr "HEAD にリベース"
 
 msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD \\($1\\)"
@@ -15286,10 +15254,6 @@ msgstr "設定"
 msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase:"
 msgid "Dump Database"
 msgstr "データベースのダンプ"
-
-msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
-msgid "Create Pull Request"
-msgstr "プルリクエストを作成"
 
 msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Merge Request"
@@ -16200,16 +16164,12 @@ msgid "Refresh the log view."
 msgstr "ログ ビューを更新します。"
 
 msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
-msgid "Fetch commits from current remote repository."
-msgstr "現在のリモートリポジトリからコミットをフェッチします。"
-
-msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from all remote repositories."
 msgstr "すべてのリモートリポジトリからコミットを取得します。"
 
 msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from current remote repository."
-msgstr "現在のリモートリポジトリからコミットを取得します。"
+msgstr "現在のリモートリポジトリからコミットをフェッチします。"
 
 msgctxt "wnd(Log|Project|Std|).tbtRemove:"
 msgid "Remove selected files or directories from repository."

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -125,7 +125,7 @@ msgctxt "dlgCommitGitHubConfirmEmail.fur"
 msgid "If this repository is open-source, you might want to hide your email address, as \\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\], and use instead <username>@users.noreply.github.com."
 msgstr "このリポジトリがオープンソースである場合、GitHubが提案する\\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\]のようにメールアドレスを非表示にし、代わりに <username>@users.noreply.github.com  を使用することをお勧めします。"
 
-msgctxt "dlgCommitGitHubConfirmEmail.hdl%1"
+msgctxt "dlgCommitGitHubConfirmEmail.hdl"
 msgid "Commit with default email address $1?"
 msgstr "デフォルトの電子メールアドレス $1 でコミットしますか？"
 
@@ -325,11 +325,11 @@ msgctxt "dlgProgress.tle:"
 msgid "Verifying executables"
 msgstr "実行ファイルを確認中"
 
-msgctxt "dlgQBugFileSendingFailed.fur%1"
+msgctxt "dlgQBugFileSendingFailed.fur"
 msgid "Maybe you need to configure a proxy or our server is temporarily down.\\nDetails: $1"
 msgstr "プロキシの設定が必要なのか、サーバーが一時的にダウンしているのかもしれません。'$1'"
 
-msgctxt "dlgQBugFileSendingFailed.hdl%1"
+msgctxt "dlgQBugFileSendingFailed.hdl"
 msgid "Could not send the crash logs to $1"
 msgstr "クラッシュ・ログを$1に送信できませんでした"
 
@@ -401,7 +401,7 @@ msgctxt "dlgQDockManagerClosedView.fur"
 msgid "To reopen it again, use the corresponding menu item from the Window menu."
 msgstr "再び開くには、「ウィンドウ」メニューから対応するメニューを使用します。"
 
-msgctxt "dlgQDockManagerClosedView.hdl%1"
+msgctxt "dlgQDockManagerClosedView.hdl"
 msgid "You've closed the view '$1'."
 msgstr "ビュー'$1'を閉じました。"
 
@@ -417,7 +417,7 @@ msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur"
 msgid "To save to a different file, click 'Cancel'."
 msgstr "別のファイルに保存する場合は、「キャンセル」をクリックします。"
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl%1"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl"
 msgid "The file $1 already exists. Do you want to overwrite it?"
 msgstr "$1 は既に存在します。上書きしますか？"
 
@@ -449,11 +449,11 @@ msgctxt "dlgQFrameManagerExit.tle"
 msgid "Exit"
 msgstr "終了"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.fur%2"
+msgctxt "dlgQIntegerInputProviderInvalidValue.fur"
 msgid "Port must be in the range from $1 to $2."
 msgstr "Portは'$1'から'$2'の範囲でなければなりません。"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.hdl%1"
+msgctxt "dlgQIntegerInputProviderInvalidValue.hdl"
 msgid "The text in field '$1' is not valid."
 msgstr "フィールド '$1' のテキストは有効ではありません。"
 
@@ -513,7 +513,7 @@ msgctxt "dlgQProxyConnectionFailed.fur"
 msgid "Details: syntevo.com"
 msgstr "詳細: syntevo.com"
 
-msgctxt "dlgQProxyConnectionFailed.hdl%1"
+msgctxt "dlgQProxyConnectionFailed.hdl"
 msgid "Could not connect to $1."
 msgstr "$1 に接続できませんでした。"
 
@@ -549,7 +549,7 @@ msgctxt "dlgQUpdateCheckForNewVersion.tle"
 msgid "Check for New Version"
 msgstr "新しいバージョンの確認"
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.fur%1"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.fur"
 msgid "Details: Failed to connect to '$1'."
 msgstr "詳細: '$1'への接続に失敗しました。"
 
@@ -577,7 +577,7 @@ msgctxt "dlgQUpdateCheckLatestBuild.tle"
 msgid "Check for Latest Build"
 msgstr "最新ビルドの確認"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur%1"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur"
 msgid "Details: $1"
 msgstr "詳細: $1"
 
@@ -673,7 +673,7 @@ msgctxt "dlgScAboutUpdateInstallation.fur"
 msgid "This will take a few moments and has to restart SmartGit."
 msgstr "これには少し時間がかかり、SmartGitを再起動する必要があります。"
 
-msgctxt "dlgScAboutUpdateInstallation.hdl%1"
+msgctxt "dlgScAboutUpdateInstallation.hdl"
 msgid "Do you want to upgrade the installation directory to version $1?"
 msgstr "インストールディレクトリをバージョン$1にアップグレードしますか？"
 
@@ -729,11 +729,11 @@ msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl"
 msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr "ファイルには、混在した \\(一貫性のない\\) 改行文字が含まれています。"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%1"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - コンフリクトソルバー"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%2"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 msgid "\\[$1\\] - $2"
 msgstr ""
 
@@ -925,7 +925,7 @@ msgctxt "dlgScDevOpsCredentials.edt:"
 msgid "User Name"
 msgstr "ユーザ名"
 
-msgctxt "dlgScDevOpsCredentials.hdl%1"
+msgctxt "dlgScDevOpsCredentials.hdl"
 msgid "Login to '$1'"
 msgstr "'$1' にログイン"
 
@@ -957,7 +957,7 @@ msgctxt "dlgScDevOpsSslClientCertificate.edt:"
 msgid "Passphrase"
 msgstr "パスフレーズ"
 
-msgctxt "dlgScDevOpsSslClientCertificate.hdl%1"
+msgctxt "dlgScDevOpsSslClientCertificate.hdl"
 msgid "Select the client certificate for $1"
 msgstr "$1 用クライアント証明書を選択する"
 
@@ -1049,7 +1049,7 @@ msgctxt "dlgScDialogAssertionHandlerOutOfMemory.btn:"
 msgid "Force Exit"
 msgstr "強制終了"
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur%1"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur"
 msgid "It is strongly recommended to restart SmartGit.\\n\\nTo increase the maximum memory limit edit $1, increase the value of the -Xmx option, for example to -Xmx1024m \\(or add it if not yet existing\\) and restart SmartGit."
 msgstr "SmartGit を再起動することを強くお勧めします。\\n\\n最大メモリ制限を増やすには、$1 を編集し、-Xmx オプションの値を増やします。例えば、-Xmx1024m を設定し（まだ存在していない場合は追加し）、SmartGit を再起動してください。"
 
@@ -1069,11 +1069,11 @@ msgctxt "dlgScEvaluationReminderContinue.btn:"
 msgid "Register"
 msgstr "登録"
 
-msgctxt "dlgScEvaluationReminderContinue.fur%2"
+msgctxt "dlgScEvaluationReminderContinue.fur"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
 msgstr "商用環境で SmartGit を使用するには、\\[$1 ライセンスを購入\\]する必要があります。\\n\\n \\[$2 特定の用途\\] については、無料のライセンスを付与します。"
 
-msgctxt "dlgScEvaluationReminderContinue.hdl%1"
+msgctxt "dlgScEvaluationReminderContinue.hdl"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr "SmartGit の評価期間は $1 日後に終了します。"
 
@@ -1081,11 +1081,11 @@ msgctxt "dlgScEvaluationReminderContinue.tle"
 msgid "Evaluation"
 msgstr "評価"
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl%2"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl"
 msgid "Cannot run program \"$1\": $2"
 msgstr "プログラム「\"$1\": $2」を実行できません"
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle%1"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - コンフリクトソルバー"
 
@@ -1249,7 +1249,7 @@ msgctxt "dlgScFilePatternsEdit.edt:"
 msgid "File Pattern"
 msgstr "ファイルパターン"
 
-msgctxt "dlgScFilePatternsEdit.hdl%1"
+msgctxt "dlgScFilePatternsEdit.hdl"
 msgid "Language: $1"
 msgstr "言語: $1"
 
@@ -1381,7 +1381,7 @@ msgctxt "dlgScJiraResolveIssue.edt:"
 msgid "Summary"
 msgstr "概要"
 
-msgctxt "dlgScJiraResolveIssue.hdl%1"
+msgctxt "dlgScJiraResolveIssue.hdl"
 msgid "Resolve issue $1"
 msgstr "課題 $1 を解決"
 
@@ -1513,7 +1513,7 @@ msgctxt "dlgScPropertiesReset.fur"
 msgid "The new values will be active after restarting SmartGit."
 msgstr "新しい値は、SmartGitを再起動すると有効になります。"
 
-msgctxt "dlgScPropertiesReset.hdl%1"
+msgctxt "dlgScPropertiesReset.hdl"
 msgid "Do you want to reset $1 system properties to their defaults?"
 msgstr "$1 システムのプロパティをデフォルトにリセットしますか？"
 
@@ -1529,7 +1529,7 @@ msgctxt "dlgScPropertyEdit.hdl"
 msgid "Edit low-level property value"
 msgstr "ローレベルのプロパティ値を編集する"
 
-msgctxt "dlgScPropertyEdit.inf%1"
+msgctxt "dlgScPropertyEdit.inf"
 msgid "Set the value for property '$1'"
 msgstr "プロパティ '$1' の値を設定します。"
 
@@ -1901,7 +1901,7 @@ msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle"
 msgid "SmartGit Installation Update"
 msgstr "SmartGit インストールの更新"
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur%1"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur"
 msgid "Please get rid of '$1' manually and retry the upgrade."
 msgstr "'$1' を手動で削除して、アップグレードを再試行してください。"
 
@@ -1917,7 +1917,7 @@ msgctxt "dlgScUpdateInstallationUpgrade.btn:"
 msgid "Upgrade Now"
 msgstr "今すぐアップグレード"
 
-msgctxt "dlgScUpdateInstallationUpgrade.fur%1"
+msgctxt "dlgScUpdateInstallationUpgrade.fur"
 msgid "The new version $1 has been downloaded which needs to be installed."
 msgstr "インストールが必要な新しいバージョン $1 がダウンロードされました。"
 
@@ -2113,7 +2113,7 @@ msgctxt "dlgSgAbout.tle"
 msgid "About SmartGit"
 msgstr "SmartGitについて"
 
-msgctxt "dlgSgApplicationAlreadyRunning.fur%1"
+msgctxt "dlgSgApplicationAlreadyRunning.fur"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
 msgstr "別々のインスタンスを実行する代わりに、SmartGit で複数のプロジェクト ウィンドウを開くことができます。\\n\\n SmartGit のインスタンスがもう実行されていないことが確実な場合は、ロック ファイルを削除する必要があります。\\n $1"
 
@@ -2157,7 +2157,7 @@ msgctxt "dlgSgAuthenticationShowPassword.edt:"
 msgid "Password"
 msgstr "パスワード"
 
-msgctxt "dlgSgAuthenticationShowPassword.tle%1"
+msgctxt "dlgSgAuthenticationShowPassword.tle"
 msgid "Password for $1"
 msgstr "$1 のパスワード"
 
@@ -2201,7 +2201,7 @@ msgctxt "dlgSgBisectResult.btn:"
 msgid "Leave Bisect"
 msgstr "問題箇所の特定をやめる"
 
-msgctxt "dlgSgBisectResult.fur%1"
+msgctxt "dlgSgBisectResult.fur"
 msgid "$1"
 msgstr "$1"
 
@@ -2325,7 +2325,7 @@ msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr "「キャンセル」をクリックすると、別のブランチ名を選択することができます。"
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl%1"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr "ブランチ '$1' はすでに存在しています。上書きしますか？"
 
@@ -2377,7 +2377,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr "$1 件のローカル ブランチを削除しますか?"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl%1"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl"
 msgid "Do you want to delete $1 local branches?"
 msgstr "$1個のローカルブランチを削除しますか？"
 
@@ -2417,7 +2417,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "ローカル ブランチ '$1' を削除しますか?"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl%1"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "ローカルブランチ'$1'を削除しますか？"
 
@@ -2445,7 +2445,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr "リモートリポジトリ'$1'から削除"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk%1"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
 msgid "Delete from remote repository '$1'"
 msgstr "リモートリポジトリ '$1' から削除する"
 
@@ -2461,7 +2461,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr "リモートブランチ'$1'を削除しますか？"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl%1"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
 msgid "Do you want to delete the branch '$1'?"
 msgstr "ブランチ '$1' を削除しますか？"
 
@@ -2477,7 +2477,7 @@ msgctxt "dlgSgBranchTrackingResetConfirm.fur"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "必要な設定は .git/config ファイルで行います。"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.hdl%2"
+msgctxt "dlgSgBranchTrackingResetConfirm.hdl"
 msgid "Should branch '$1' stop tracking '$2'?"
 msgstr "ブランチ'$1'は'$2'の追跡を停止しますか?"
 
@@ -2493,7 +2493,7 @@ msgctxt "dlgSgBranchTrackingSetConfirm.fur"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "必要な設定は .git/config ファイルで行います。"
 
-msgctxt "dlgSgBranchTrackingSetConfirm.hdl%2"
+msgctxt "dlgSgBranchTrackingSetConfirm.hdl"
 msgid "Do you want to configure '$1' to track '$2'?"
 msgstr "$1'を'$2'に追従させるように設定しますか？"
 
@@ -2569,7 +2569,7 @@ msgctxt "dlgSgCheckoutFastForwardMerge.fur"
 msgid "Fast-forward-merging automatically moves the branch forward to the tracked remote branch."
 msgstr "ファストフォワードマージは、ブランチを追跡対象のリモート ブランチに自動的に移動します。"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.hdl%1"
+msgctxt "dlgSgCheckoutFastForwardMerge.hdl"
 msgid "Do you want to fast-forward-merge remote changes after checking out '$1'?"
 msgstr "$1'をチェックアウトした後、リモートの変更を ファストフォワードマージしますか？"
 
@@ -2585,11 +2585,11 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.chk"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.fur%1"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.fur"
 msgid "This will make '$1' your current branch."
 msgstr "この操作により '$1' が現在のブランチになります。"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl%1"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl"
 msgid "Do you want to checkout the branch '$1'?"
 msgstr "ブランチ '$1' をチェックアウトしますか？"
 
@@ -2677,7 +2677,7 @@ msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr "「キャンセル」をクリックすると、別のブランチ名を選択することができます。"
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl%1"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr "ブランチ '$1' はすでに存在しています。上書きしますか？"
 
@@ -3505,7 +3505,7 @@ msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr "右側のファイルは、改行コードが混在しているため編集できません。"
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle%3"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
 msgid "\\[$1\\] - \\[$2\\] - $3"
 msgstr ""
 
@@ -3641,7 +3641,7 @@ msgctxt "dlgSgDeleteDirTrash.fur"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr "「削除」をクリックすると、削除されたファイルを復元するためにファイル復旧ツールが必要になる可能性があります!"
 
-msgctxt "dlgSgDeleteDirTrash.hdl%1"
+msgctxt "dlgSgDeleteDirTrash.hdl"
 msgid "Do you want to delete '$1' recursively?"
 msgstr "'$1' を再帰的に削除しますか？"
 
@@ -3649,11 +3649,11 @@ msgctxt "dlgSgDeleteDirTrash.tle"
 msgid "Delete"
 msgstr "削除"
 
-msgctxt "dlgSgDeleteFileTrash.hdl%1"
+msgctxt "dlgSgDeleteFileTrash.hdl"
 msgid "Do you want to delete '$1'?"
 msgstr "'$1'を削除しますか？"
 
-msgctxt "dlgSgDeleteFilesTrash.hdl%1"
+msgctxt "dlgSgDeleteFilesTrash.hdl"
 msgid "Do you want to delete the $1 selected files?"
 msgstr "選択した$1個のファイルを削除しますか？"
 
@@ -3749,11 +3749,11 @@ msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle"
 msgid "Discard"
 msgstr "破棄"
 
-msgctxt "dlgSgDiscardRevertToHead.hdl%1"
+msgctxt "dlgSgDiscardRevertToHead.hdl"
 msgid "Do you want to reset $1 files back to their HEAD state?"
 msgstr "$1 個のファイルを HEAD の状態に戻しますか?"
 
-msgctxt "dlgSgDiscardRevertToIndex.hdl%1"
+msgctxt "dlgSgDiscardRevertToIndex.hdl"
 msgid "Do you want to reset $1 files back to their Index state?"
 msgstr "$1 個のファイルをインデックスの状態に戻しますか?"
 
@@ -3827,7 +3827,7 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.btn:"
 msgid "Force Opening"
 msgstr "強制的に開く"
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl%1"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl"
 msgid "Could not open Conflict Solver for '$1', because it seems to be no text file."
 msgstr "'$1'はテキスト ファイルではないようなので、コンフリクトソルバーを開くことができませんでした。"
 
@@ -3835,7 +3835,7 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle"
 msgid "Conflict Solver"
 msgstr "コンフリクトソルバー"
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.hdl%1"
+msgctxt "dlgSgFileCompareInvokerFailedIO.hdl"
 msgid "'$1' could not be invoked."
 msgstr "'$1' を呼び出すことができませんでした。"
 
@@ -3875,11 +3875,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.btn:"
 msgid "Fast-Forward"
 msgstr "ファストフォワード"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur%3"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur"
 msgid "The local branch '$1' is behind its tracked branch '$2'. You may fast-forward now or do it manually later, e.g. by checking out the branch '$3'."
 msgstr "ローカル ブランチ '$1' は、追跡されているブランチ '$2' の後ろにあります。ここでファストフォワードすることも、後で手動で行うこともできます。\\nたとえば、ブランチ '$3' をチェックアウトするなど、手動で行っても良いでしょう。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl"
 msgid "Should branch '$1' be fast-forwarded to '$2'?"
 msgstr "ブランチ '$1' を '$2' にファストフォワードする必要がありますか?"
 
@@ -3891,11 +3891,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.btn:"
 msgid "Replace"
 msgstr "置換"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur"
 msgid "The local branch '$1' seems to contain more recent but rewritten commits of remote branch '$2'.\\n\\nIf you are not sure whether the local branch is actually more recent than the remote branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr "ローカルブランチ '$1' には、リモートブランチ '$2' の書き換えられたコミットよりも新しいものが含まれているようです。\\n\\nローカルブランチがリモートブランチよりも実際に新しいかどうかわからない場合は、この操作をキャンセルしてローカルおよびリモートでの変更をより詳細に調査することをお勧めします。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl"
 msgid "Should branch '$1' replace remote branch '$2'?"
 msgstr "リモートブランチ'$2'をブランチ'$1'に置き換えますか?"
 
@@ -3907,11 +3907,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.btn:"
 msgid "Reset"
 msgstr "リセット"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur"
 msgid "The remote branch '$1' seems to contain more recent but rewritten commits of local branch '$2'.\\n\\nIf you are not sure whether the remote branch is actually more recent than the local branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr "リモート ブランチ '$1' には、ローカル ブランチ '$2' の最近の書き換えられたコミットが含まれているようです。\\n\\nリモート ブランチが実際にローカル ブランチよりも新しいかどうかわからない場合は、この操作をキャンセルして、ローカルおよびリモートの変更をより詳細に調査することをお勧めします。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl"
 msgid "Should branch '$1' be reset to remote branch '$2'?"
 msgstr "ブランチ '$1' をリモート ブランチ '$2' にリセットする必要がありますか?"
 
@@ -4095,7 +4095,7 @@ msgctxt "dlgSgFlowFeatureStart.hdl"
 msgid "Start a new feature"
 msgstr "新しい feature を開始する"
 
-msgctxt "dlgSgFlowFeatureStart.inf%1"
+msgctxt "dlgSgFlowFeatureStart.inf"
 msgid "Enter the name of the new feature branch. This operation will fork a new branch from the '$1' branch."
 msgstr "新しいFeatureブランチの名前を入力します。この操作により、'$1' ブランチから新しいブランチがフォークされます。"
 
@@ -4199,7 +4199,7 @@ msgctxt "dlgSgFlowHotfixStart.hdl"
 msgid "Start a new hotfix"
 msgstr "新しい hotfix を開始する"
 
-msgctxt "dlgSgFlowHotfixStart.inf%1"
+msgctxt "dlgSgFlowHotfixStart.inf"
 msgid "Enter the name of the new hotfix branch. This operation will fork a new branch from the '$1' branch."
 msgstr "新しいHotfixブランチの名前を入力します。この操作により、'$1'ブランチから新しいブランチがフォークされます。"
 
@@ -4219,7 +4219,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.chk:"
 msgid "Fetch latest '$1' commits from remote repository"
 msgstr "リモートリポジトリから最新の '$1' コミットを取得する"
 
-msgctxt "dlgSgFlowIntegrateDevelop.hdl%1"
+msgctxt "dlgSgFlowIntegrateDevelop.hdl"
 msgid "Integrate commits from '$1'"
 msgstr "'$1' からコミットを統合"
 
@@ -4331,7 +4331,7 @@ msgctxt "dlgSgFlowReleaseStart.hdl"
 msgid "Start a new release"
 msgstr "新しい release を開始する"
 
-msgctxt "dlgSgFlowReleaseStart.inf%1"
+msgctxt "dlgSgFlowReleaseStart.inf"
 msgid "Enter the name of the new release branch. This operation will fork a new branch from the '$1' branch."
 msgstr "新しいReleaseブランチの名前を入力してください。この操作により、'$1' ブランチから新しいブランチがフォークされます。"
 
@@ -4367,7 +4367,7 @@ msgctxt "dlgSgFlowSupportStart.hdl"
 msgid "Start a new support"
 msgstr "サポートを開始"
 
-msgctxt "dlgSgFlowSupportStart.inf%1"
+msgctxt "dlgSgFlowSupportStart.inf"
 msgid "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 msgstr "新しいサポート ブランチの名前を入力します。この操作により、'$1' ブランチから新しいブランチがフォークされます。"
 
@@ -4793,7 +4793,7 @@ msgctxt "dlgSgHistoryModifySplitConfirm.fur"
 msgid "'Modify' will stop after the commit.\\n\\n'Split' will put the changes into the Index. You may discard some changes that should go into the second commit.\\n\\nAfter you've done the changes, process the remaining commits by continuing the rebase."
 msgstr "「変更」はコミット後に停止します。\\n\\n 「分割」は、変更をインデックスに格納します。 2 番目のコミットに入れる必要があるいくつかの変更を破棄することができます。\\n\\n変更を行った後、リベースを続行して残りのコミットを処理します。"
 
-msgctxt "dlgSgHistoryModifySplitConfirm.hdl%1"
+msgctxt "dlgSgHistoryModifySplitConfirm.hdl"
 msgid "Do you want to modify or split commit $1?"
 msgstr "コミットした $1 を修正又は分割しますか?"
 
@@ -4809,7 +4809,7 @@ msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr "リモートブランチへのプッシュは ファストフォワードできないので、強制的にプッシュする必要があります。リモートブランチでのコミットは失われます。"
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl%1"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl"
 msgid "Do you want to replace the remote branch by commit $1?"
 msgstr "リモートブランチをコミット $1 で置き換えますか？"
 
@@ -4825,7 +4825,7 @@ msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur"
 msgid "All commits up to the selected commit will be pushed to the remote repository."
 msgstr "選択したコミットまでのすべてのコミットが、リモートリポジトリにプッシュされます。"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl%1"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl"
 msgid "Do you want to push changes up to commit $1?"
 msgstr "コミット$1まで変更をプッシュしますか？"
 
@@ -5191,11 +5191,11 @@ msgctxt "dlgSgHostingProviderEdit.err:"
 msgid "The provided SSL client certificate path is invalid."
 msgstr "指定されたSSLクライアント証明書のパスが無効です。"
 
-msgctxt "dlgSgHostingProviderEdit.hdl%1"
+msgctxt "dlgSgHostingProviderEdit.hdl"
 msgid "Configure $1 account"
 msgstr "$1 アカウントの設定"
 
-msgctxt "dlgSgHostingProviderEdit.inf%1"
+msgctxt "dlgSgHostingProviderEdit.inf"
 msgid "Please specify your credentials to connect to $1."
 msgstr "$1 に接続するための認証情報を指定してください。"
 
@@ -5307,11 +5307,11 @@ msgctxt "dlgSgHostingProvider(Add|Edit).lbl:"
 msgid "Optional SSL configuration"
 msgstr "オプションのSSL設定"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur%3"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur"
 msgid "The OAuth-access token could not be requested. Most likely your $1 configuration has changed and SmartGit's stored OAuth credentials are invalid.\\n\\nTo resolve, recreate the $2 hosting provider in the Preferences.\\n\\nDetails:\\n\\n$3"
 msgstr "OAuth アクセス トークンを要求できませんでした。 ほとんどの場合 $1 の設定が変更され、SmartGit に保存されている OAuth 資格情報が無効になっています。\\n\\n解決するには、環境設定で $2 ホスティング プロバイダーを再作成します。\\n\\n詳細：\\n\\n $3"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl%1"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl"
 msgid "$1 OAuth-authentication failed"
 msgstr "$1 OAuth認証に失敗しました"
 
@@ -5335,7 +5335,7 @@ msgctxt "dlgSgHttpPasswordCredentials.edt:"
 msgid "User Name"
 msgstr "ユーザ名"
 
-msgctxt "dlgSgHttpPasswordCredentials.hdl%1"
+msgctxt "dlgSgHttpPasswordCredentials.hdl"
 msgid "Login to '$1'"
 msgstr "'$1' にログインする"
 
@@ -5387,7 +5387,7 @@ msgctxt "dlgSgIgnoreDirectoryConfirm.fur"
 msgid "The directory name will be added to the ignore file. If the ignore file does not exist, it will be created."
 msgstr "このディレクトリ名は、.ignore ファイルに追加されます。 .ignore ファイルが存在しない場合は、作成されます。"
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.hdl%1"
+msgctxt "dlgSgIgnoreDirectoryConfirm.hdl"
 msgid "Do you want to ignore directory '$1'?"
 msgstr "ディレクトリ'$1'を無視しますか？"
 
@@ -5511,11 +5511,11 @@ msgctxt "dlgSgJournalDoubleClick.btn:"
 msgid "Open Log"
 msgstr "ログを開く"
 
-msgctxt "dlgSgJournalDoubleClick.fur%1"
+msgctxt "dlgSgJournalDoubleClick.fur"
 msgid "Select either to check out '$1' or to open the Log for the selected commit."
 msgstr "'$1' をチェックアウトするか、選択したコミットのログを開くかを選択します。"
 
-msgctxt "dlgSgJournalDoubleClick.hdl%1"
+msgctxt "dlgSgJournalDoubleClick.hdl"
 msgid "Do you want to check out '$1'?"
 msgstr "'$1' をチェックアウトしますか？"
 
@@ -5591,7 +5591,7 @@ msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.btn:"
 msgid "Revert"
 msgstr "リバート"
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur%1"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur"
 msgid "You are about to apply lines from the Index to the working tree file '$1'. The modifications will be saved immediately."
 msgstr "インデックスの行を作業ツリーのファイル '$1' に適用しようとしています。変更はすぐに保存されます。"
 
@@ -5643,7 +5643,7 @@ msgctxt "dlgSgLogCheckoutFileAs.tle"
 msgid "Save File As"
 msgstr "ファイルを別名で保存"
 
-msgctxt "dlgSgLogCommentDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogCommentDeleteConfirm.hdl"
 msgid "Do you really want to delete comment '$1'?"
 msgstr "本当にコメント'$1'を削除しますか？"
 
@@ -5659,7 +5659,7 @@ msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle"
 msgid "Delete Comment"
 msgstr "コミットを削除"
 
-msgctxt "dlgSgLogCommentsDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogCommentsDeleteConfirm.hdl"
 msgid "Do you really want to delete $1 comments?"
 msgstr "$1のコメントを本当に削除しますか？"
 
@@ -5803,7 +5803,7 @@ msgctxt "dlgSgLogRefActionsDeleteConfirm.fur"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr "プッシュされていない変更が失われたり、ブランチの復元が困難になる可能性があります。"
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl"
 msgid "Do you really want to delete the local branch '$1'?"
 msgstr "本当にローカルブランチ'$1'を削除しますか？"
 
@@ -5819,11 +5819,11 @@ msgctxt "dlgSgLogRefreshRepositoryInvalid.btn:"
 msgid "Remove Repository"
 msgstr "リポジトリを削除"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.fur%1"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.fur"
 msgid "This could mean that the repository at\\n\\n$1was removed or renamed outside SmartGit."
 msgstr "下記のリポジトリが削除されたか、SmartGit の外部で名前が変更された可能性があります。\\n\\n$1"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl%1"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl"
 msgid "The opened repository '$1' became invalid."
 msgstr "開いていたリポジトリ'$1'が無効になりました。"
 
@@ -5959,7 +5959,7 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.fur"
 msgid "The specified directory does not appear to be a valid Git repository."
 msgstr "指定されたディレクトリは、有効な Git リポジトリではないようです。"
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.hdl%1"
+msgctxt "dlgSgOpenRepositoryInitializeGit.hdl"
 msgid "Should '$1' be initialized as a new Git repository?"
 msgstr "'$1' を新しい Git リポジトリとして初期化しますか?"
 
@@ -5967,7 +5967,7 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.tle"
 msgid "Add or Create Repository"
 msgstr "リポジトリの追加又は作成"
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur%1"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr "SmartGit では不可能な既存の SVN 作業コピーを開こうとしています。代わりに、$1 を使用して、SVN リポジトリの Git クローン \\(つまり、SVN ではなく Git に基づく作業コピー\\) を作成してください。"
 
@@ -6207,11 +6207,11 @@ msgctxt "dlgSgOutput.tle:"
 msgid "Output"
 msgstr "出力"
 
-msgctxt "dlgSgPingRepositoryFailed.fur%1"
+msgctxt "dlgSgPingRepositoryFailed.fur"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr "リポジトリURLを確認してください。\\n\\n$1"
 
-msgctxt "dlgSgPingRepositoryFailed.hdl%1"
+msgctxt "dlgSgPingRepositoryFailed.hdl"
 msgid "Could not connect to the repository '$1'."
 msgstr "リポジトリ'$1'に接続できませんでした。"
 
@@ -7519,7 +7519,7 @@ msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr "リンク"
 
-msgctxt "dlgSgProviderGenerateToken.hdl%1"
+msgctxt "dlgSgProviderGenerateToken.hdl"
 msgid "Generate a new API token for $1"
 msgstr ""
 
@@ -7579,7 +7579,7 @@ msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur"
 msgid "The merge request itself will not be deleted on the server."
 msgstr "マージリクエスト自体はサーバー上で削除されません。"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl%1"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl"
 msgid "Do you really want to drop the local commits of merge request $1?"
 msgstr "本当にマージリクエスト$1のローカルコミットを削除しますか?"
 
@@ -7595,7 +7595,7 @@ msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur"
 msgid "The pull request itself will not be deleted on the server."
 msgstr "プルリクエスト自体はサーバー上で削除されることはありません。"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl%1"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl"
 msgid "Do you want to drop the local commits of pull request $1?"
 msgstr "プルリクエスト $1 のローカルコミットを本当に削除しますか?"
 
@@ -7731,7 +7731,7 @@ msgctxt "dlgSgPullMergeInsteadOfRebase.btn:"
 msgid "Rebase"
 msgstr "リベース"
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.fur%1"
+msgctxt "dlgSgPullMergeInsteadOfRebase.fur"
 msgid "Amongst the changes to rebase there is merge-commit $1. Rebasing merge-commits can easily cause troubles."
 msgstr "リベースの対象となる変更の中に、マージコミット $1 があります。マージコミットをリベースすると、簡単にトラブルが発生します。"
 
@@ -7779,7 +7779,7 @@ msgctxt "dlgSgPullOrJustFetch.fur"
 msgid "You can change the Pull behavior in the Repository Settings."
 msgstr "プルの動作は、リポジトリ設定で変更することができます。"
 
-msgctxt "dlgSgPullOrJustFetch.hdl%1"
+msgctxt "dlgSgPullOrJustFetch.hdl"
 msgid "Do you want to pull or just fetch $1 repositories?"
 msgstr "リポジトリ $1 をフェッチしますか?"
 
@@ -7807,11 +7807,11 @@ msgctxt "dlgSgPushConfirmSingleBranch.chk"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgPushConfirmSingleBranch.fur%1"
+msgctxt "dlgSgPushConfirmSingleBranch.fur"
 msgid "1 branch will be pushed to '$1'."
 msgstr "1つのブランチが'$1'にプッシュされます。"
 
-msgctxt "dlgSgPushConfirmSingleBranch.hdl%1"
+msgctxt "dlgSgPushConfirmSingleBranch.hdl"
 msgid "Do you want to push branch '$1'?"
 msgstr "ブランチ'$1'をプッシュしますか？"
 
@@ -7995,11 +7995,11 @@ msgctxt "dlgSgPushToRemote.edt:"
 msgid "Target Repository"
 msgstr "ターゲットリポジトリ"
 
-msgctxt "dlgSgPushToRemote.hdl%1"
+msgctxt "dlgSgPushToRemote.hdl"
 msgid "Push '$1' branches to another remote"
 msgstr "別のリモートに '$1' ブランチをプッシュする"
 
-msgctxt "dlgSgPushToRemote.inf%1"
+msgctxt "dlgSgPushToRemote.inf"
 msgid "All branches of '$1' \\(as locally represented by the corresponding remote branches\\) will be pushed to the target repository."
 msgstr "'$1' のすべてのブランチがターゲットリポジトリにプッシュされます。\\r\\(リモートにローカルと対応するブランチが作成されます。\\)"
 
@@ -8055,7 +8055,7 @@ msgctxt "dlgSgPushTrackingConfigureSingle.fur"
 msgid "For your current branch tracking \\(its corresponding remote branch\\) has not been configured yet. Configuring tracking will keep your local branches in sync with the remote branches."
 msgstr "現在のブランチでは、トラッキング\\(対応するリモートブランチ\\)はまだ設定されていません。トラッキングを設定することで、ローカルブランチとリモートブランチの同期が保たれます。"
 
-msgctxt "dlgSgPushTrackingConfigureSingle.hdl%1"
+msgctxt "dlgSgPushTrackingConfigureSingle.hdl"
 msgid "Do you want to configure tracking for '$1' branch?"
 msgstr "'$1' ブランチに対してトラッキングを設定しますか？"
 
@@ -8091,7 +8091,7 @@ msgctxt "dlgSgRebaseConfirmUnreachable.fur"
 msgid "You only might be able to access this commit using the 'Recyclable Commits' option of the Branches view."
 msgstr "「ブランチ」 ビューの 「Recyclable Commits」 を選択することでのみ、このコミットにアクセスできる場合があります。"
 
-msgctxt "dlgSgRebaseConfirmUnreachable.hdl%1"
+msgctxt "dlgSgRebaseConfirmUnreachable.hdl"
 msgid "The Commit $1 would become unreachable by refs."
 msgstr "コミット $1 は参照\\(refs\\)によって到達不能になります。"
 
@@ -8107,7 +8107,7 @@ msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur%1"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur"
 msgid "The splitting of commit $1 still is in progress and all changes of this commit have been applied."
 msgstr "コミット $1 の分割はまだ進行中で、このコミットのすべての変更が適用されています。"
 
@@ -8250,7 +8250,7 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.btn:"
 msgid "Put Changes into Index"
 msgstr "Indexに変更を反映"
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur%1"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur"
 msgid "The splitting of commit $1 still is in progress, but not all changes of this commit have been applied.\\n\\nIf this is intentional, you can continue. Otherwise, you should click 'Put Changes into Index' and review your changes."
 msgstr "コミット $1 の分割はまだ進行中ですが、このコミットのすべての変更が適用されているわけではありません。\\n\\nこれが意図的なものである場合は、続行できます。それ以外の場合は、「Indexに変更を反映」 をクリックして、変更内容を確認してください。"
 
@@ -8262,19 +8262,19 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle"
 msgid "Rebase"
 msgstr "リベース"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur%1"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) onto the selected commit."
 msgstr "これにより、作業ツリーのブランチ '$1' \\(HEAD\\) からのすべてのコミットが、選択したコミットに適用されます。"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl%1"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl"
 msgid "Do you want to rebase '$1' onto the selected commit?"
 msgstr "'$1' を選択したコミットにリベースしますか？"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur%2"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) to '$2'."
 msgstr "これは、作業ツリーのブランチ '$1' \\(HEAD\\) からのすべてのコミットを '$2' に適用します。"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl%2"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl"
 msgid "Do you want to rebase '$1' to '$2'?"
 msgstr "'$1' を '$2' にリベースしますか？"
 
@@ -8394,7 +8394,7 @@ msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur"
 msgid "It might become hard or impossible to recover the commit again."
 msgstr "コミットを再び回復することが困難または不可能になる可能性があります。"
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl%1"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl"
 msgid "Do you want to remove the selected commit $1?"
 msgstr "選択したコミット $1 を削除しますか?"
 
@@ -8438,7 +8438,7 @@ msgctxt "dlgSgRebaseTagCommit.fur"
 msgid "After the rebase, the remaining commit won't be reachable anymore."
 msgstr "リベースの後、残りのコミットには到達できなくなります。"
 
-msgctxt "dlgSgRebaseTagCommit.hdl%1"
+msgctxt "dlgSgRebaseTagCommit.hdl"
 msgid "Should commit $1 be tagged?"
 msgstr "コミット$1 にタグを付ける必要がありますか？"
 
@@ -8530,7 +8530,7 @@ msgctxt "dlgSgRemoteDeleteConfirm.fur"
 msgid "This will just delete the link to the remote repository."
 msgstr "これは、リモートリポジトリへのリンクを削除するだけです。"
 
-msgctxt "dlgSgRemoteDeleteConfirm.hdl%1"
+msgctxt "dlgSgRemoteDeleteConfirm.hdl"
 msgid "Do you want to delete the remote repository '$1'?"
 msgstr "リモートリポジトリ'$1'を削除しますか？"
 
@@ -8690,7 +8690,7 @@ msgctxt "dlgSgRemotesAdd.tle"
 msgid "Add Remote Repository"
 msgstr "リモートリポジトリを追加"
 
-msgctxt "dlgSgRemotesNoRemoteDetected.fur%1"
+msgctxt "dlgSgRemotesNoRemoteDetected.fur"
 msgid "To perform the operation the repository configuration for $1 must contain one uniquely determined remote."
 msgstr "このこの操作を行うには、$1 のリポジトリ構成に、一意に決定された 1 つのリモートが含まれている必要があります。"
 
@@ -8742,7 +8742,7 @@ msgctxt "dlgSgRenameBranch.hdl"
 msgid "Rename branch"
 msgstr "ブランチの名前を変更する"
 
-msgctxt "dlgSgRenameBranch.inf%1"
+msgctxt "dlgSgRenameBranch.inf"
 msgid "Enter the new name for the branch '$1'."
 msgstr "ブランチの新しい名前 '$1' を入力してください。"
 
@@ -8938,7 +8938,7 @@ msgctxt "dlgSgRepositoryOpen.fur"
 msgid "If it is relocated, remove it and add its new location."
 msgstr "移動した場合は、削除して新しい場所を追加してください。"
 
-msgctxt "dlgSgRepositoryOpen.hdl%1"
+msgctxt "dlgSgRepositoryOpen.hdl"
 msgid "Do you want to remove the missing repository '$1'?"
 msgstr "見つからないリポジトリ'$1'を削除しますか？"
 
@@ -8950,7 +8950,7 @@ msgctxt "dlgSgRepositoryRemoveFailed1.fur"
 msgid "This could happen if the repository is open in another window or currently commands are executed."
 msgstr "別のウィンドウでリポジトリが開かれている場合や、コマンドが実行中の場合に、このようなことが起こる可能性があります。"
 
-msgctxt "dlgSgRepositoryRemoveFailed1.hdl%1"
+msgctxt "dlgSgRepositoryRemoveFailed1.hdl"
 msgid "The repository '$1' could not be removed."
 msgstr "リポジトリ '$1' を削除できませんでした。"
 
@@ -8962,7 +8962,7 @@ msgctxt "dlgSgRepositoryRemoveMultiGroup.fur"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "削除されたグループ内のリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl%1"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl"
 msgid "Do you want to remove $1 groups?"
 msgstr "グループ'$1'を削除しますか？"
 
@@ -8970,7 +8970,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepo.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "これは、ディスク上のリポジトリを維持しつつ、SmartGitに忘れさせるだけです。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl%1"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl"
 msgid "Do you want to remove $1 repositories?"
 msgstr "リポジトリ'$1'を削除しますか？"
 
@@ -8978,7 +8978,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "これにより、ディスク上のリポジトリは維持されますが、SmartGitはそのことを忘れてしまいます。削除されたグループの中にあるリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl"
 msgid "Do you want to remove $1 repositories and $2 groups?"
 msgstr "リポジトリ'$1'とグループ'$2'を削除しますか？"
 
@@ -8986,7 +8986,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "これにより、ディスク上のリポジトリは維持されますが、SmartGitはそのことを忘れてしまいます。削除されたグループの中にあるリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl"
 msgid "Do you want to remove $1 repositories and the group \"$2\"?"
 msgstr "リポジトリ'$1'とグループ'$2'を削除しますか？"
 
@@ -8994,7 +8994,7 @@ msgctxt "dlgSgRepositoryRemoveSingleGroup.fur"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "削除されたグループ内のリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl%1"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl"
 msgid "Do you want to remove the group \"$1\"?"
 msgstr "グループ'$1'を削除しますか？"
 
@@ -9002,7 +9002,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepo.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "これは、ディスク上のリポジトリを維持しつつ、SmartGitに忘れさせるだけです。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl%1"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl"
 msgid "Do you want to remove the repository \"$1\"?"
 msgstr "リポジトリ '$1' を削除しますか?"
 
@@ -9010,7 +9010,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "これにより、ディスク上のリポジトリは維持されますが、SmartGitはそのことを忘れてしまいます。削除されたグループの中にあるリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl"
 msgid "Do you want to remove the repository \"$1\" and $2 groups?"
 msgstr "リポジトリ '$1' および '$2' グループを削除しますか?"
 
@@ -9018,7 +9018,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "これにより、ディスク上のリポジトリは維持されますが、SmartGitはそのことを忘れてしまいます。削除されたグループの中にあるリポジトリは、グループの外に移動されます。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl"
 msgid "Do you want to remove the repository \"$1\" and the group \"$2\"?"
 msgstr "リポジトリ '$1' とグループ '$2' を削除しますか?"
 
@@ -9178,7 +9178,7 @@ msgctxt "dlgSgResetAdv.chk:"
 msgid "Thoroughly fix line-endings according to .gitattributes"
 msgstr ".gitattributes に従って行末を徹底的に修正する"
 
-msgctxt "dlgSgResetAdv.hdl%1"
+msgctxt "dlgSgResetAdv.hdl"
 msgid "Reset to commit $1"
 msgstr "コミット $1 にリセット"
 
@@ -9238,7 +9238,7 @@ msgctxt "dlgSgResetConfirm.fur"
 msgid "Current staged and local changes will be lost!"
 msgstr "現在のステージング領域とローカルの変更は失われます"
 
-msgctxt "dlgSgResetConfirm.hdl%1"
+msgctxt "dlgSgResetConfirm.hdl"
 msgid "Do you want to reset the HEAD to commit $1?"
 msgstr "HEADを コミット'$1' にリセットしますか？"
 
@@ -9298,7 +9298,7 @@ msgctxt "dlgSgResolveManuallyModifiedSingle.btn:"
 msgid "Overwrite"
 msgstr "上書き"
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.fur%1"
+msgctxt "dlgSgResolveManuallyModifiedSingle.fur"
 msgid "$1 seems to contain manual conflict resolutions. They will be lost when continuing."
 msgstr "$1では、手動でコンフリクトを解決しているようです。続行すると失われます。"
 
@@ -9346,7 +9346,7 @@ msgctxt "dlgSgRevealCommitLocalOrTracked.chk"
 msgid "Always reveal local branch"
 msgstr "常にローカルブランチを表示する"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.fur%2"
+msgctxt "dlgSgRevealCommitLocalOrTracked.fur"
 msgid "Select whether to reveal '$1' or '$2'."
 msgstr "どちらを表示するかを選択してください。\\r'$1'\\r'$2'"
 
@@ -9734,7 +9734,7 @@ msgctxt "dlgSgRollbackToCommit.fur"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr "HEAD と選択したコミット間のすべての差分が作業ツリーにチェックアウトされ、オプションでステージングされます。"
 
-msgctxt "dlgSgRollbackToCommit.hdl%1"
+msgctxt "dlgSgRollbackToCommit.hdl"
 msgid "Do you want to rollback the Index to the state of commit $1?"
 msgstr "インデックスをコミット $1 の状態にロールバックしますか？"
 
@@ -9986,7 +9986,7 @@ msgctxt "dlgSgSetupStdWnd.hdl"
 msgid "Do you want to use the Standard Window?"
 msgstr "スタンダードウィンドウを使用しますか？"
 
-msgctxt "dlgSgSetupStdWnd.tle%1"
+msgctxt "dlgSgSetupStdWnd.tle"
 msgid "Setup SmartGit $1"
 msgstr "SmartGit $1 のセットアップ"
 
@@ -9994,7 +9994,7 @@ msgctxt "dlgSgShowLocalChanges.btn:"
 msgid "Compare"
 msgstr "比較"
 
-msgctxt "dlgSgShowLocalChanges.hdl%1"
+msgctxt "dlgSgShowLocalChanges.hdl"
 msgid "File $1 modified in Index and working tree"
 msgstr "インデックスと作業ツリーでファイル$1が変更されました。"
 
@@ -10094,7 +10094,7 @@ msgctxt "dlgSgSshCredentials.hdl"
 msgid "SSH Credentials"
 msgstr "SSH 資格情報"
 
-msgctxt "dlgSgSshCredentials.inf%2"
+msgctxt "dlgSgSshCredentials.inf"
 msgid "Provide the credentials for authenticating to the SSH server '$1' as user '$2'."
 msgstr "ユーザー '$2' として SSH サーバー '$1' に接続するための資格情報を入力してください。"
 
@@ -10126,7 +10126,7 @@ msgctxt "dlgSgStageConflict.fur"
 msgid "The file contains conflict markers which indicate that you have not resolved all conflicts."
 msgstr "このファイルには、すべての競合が解決されていないことを示す競合マーカーが含まれています。"
 
-msgctxt "dlgSgStageConflict.hdl%1"
+msgctxt "dlgSgStageConflict.hdl"
 msgid "Should $1 really be staged?"
 msgstr "$1 は本当にステージングする必要がありますか?"
 
@@ -10514,7 +10514,7 @@ msgctxt "dlgSgSubmoduleDeinitConfirm.fur"
 msgid "The submodule will be skipped from the working tree. To get rid from the \\(remote\\) repository, you have to use Unregister instead."
 msgstr "サブモジュールは作業ツリーからスキップされます。 \\(リモート\\) リポジトリから削除するには、代わりに 「登録を解除」 を使用する必要があります。"
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.hdl%1"
+msgctxt "dlgSgSubmoduleDeinitConfirm.hdl"
 msgid "Do you want to deinit submodule '$1'?"
 msgstr "サブモジュール'$1'をdeinitしますか？"
 
@@ -10590,7 +10590,7 @@ msgctxt "dlgSgSubmoduleResetConfirm.fur"
 msgid "The corresponding commit will be checked out, so the submodule content will match the content of the registered commit."
 msgstr "対応するコミットがチェックアウトされるため、サブモジュールの内容は登録されたコミットの内容と一致します。"
 
-msgctxt "dlgSgSubmoduleResetConfirm.hdl%1"
+msgctxt "dlgSgSubmoduleResetConfirm.hdl"
 msgid "Do you want to reset submodule '$1' to the commit registered in the repository?"
 msgstr "サブモジュール '$1' をリポジトリに登録されているコミットの状態にリセットしますか？"
 
@@ -10738,7 +10738,7 @@ msgctxt "dlgSgSvnClientCertificate.hdl"
 msgid "Client Certificate"
 msgstr "クライアント証明書"
 
-msgctxt "dlgSgSvnClientCertificate.inf%1"
+msgctxt "dlgSgSvnClientCertificate.inf"
 msgid "Provide the client certificate for authentication to the SVN repository '$1'."
 msgstr "SVNリポジトリ'$1'への認証用クライアント証明書を提供します。"
 
@@ -10846,7 +10846,7 @@ msgctxt "dlgSgTagAddOverwrite.fur"
 msgid "Click 'Cancel' to choose a different tag name."
 msgstr "'キャンセル'をクリックすると、別のタグ名を選択できます。"
 
-msgctxt "dlgSgTagAddOverwrite.hdl%1"
+msgctxt "dlgSgTagAddOverwrite.hdl"
 msgid "The tag '$1' already exists. Do you want to overwrite it?"
 msgstr "タグ '$1' はすでに存在しています。上書きしますか？"
 
@@ -10862,7 +10862,7 @@ msgctxt "dlgSgTagDeleteConfirmSingle.chk"
 msgid "Delete from all remotes"
 msgstr "すべてのリモートから削除"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk%1"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk"
 msgid "Delete from remote '$1'"
 msgstr "リモート '$1' から削除"
 
@@ -10870,7 +10870,7 @@ msgctxt "dlgSgTagDeleteConfirmSingle.fur"
 msgid "You will not be able to restore it."
 msgstr "復元できなくなります。"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.hdl%1"
+msgctxt "dlgSgTagDeleteConfirmSingle.hdl"
 msgid "Do you want to delete the tag '$1'?"
 msgstr "タグ'$1'を削除しますか？"
 

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -733,10 +733,6 @@ msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - コンフリクトソルバー"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
-msgid "\\[$1\\] - $2"
-msgstr ""
-
 msgctxt "dlgScConflictSolverUnresolvedConflicts.chk"
 msgid "Don't warn me again"
 msgstr "次回から警告しない"
@@ -2373,13 +2369,13 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr "プッシュされていない変更が失われたり、ブランチの復元が困難になる可能性があります!"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
-msgid "Do you want to delete $1 local branches?"
-msgstr "$1 件のローカル ブランチを削除しますか?"
-
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl"
 msgid "Do you want to delete $1 local branches?"
 msgstr "$1個のローカルブランチを削除しますか？"
+
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
+msgid "Do you want to delete $1 local branches?"
+msgstr "$1 件のローカル ブランチを削除しますか?"
 
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle"
 msgid "Delete"
@@ -2413,13 +2409,13 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.fur:"
 msgid "Your local branch is tracking branch '$1'. Decide whether you also want to delete this branch from the remote repository."
 msgstr "ローカルブランチが '$1' ブランチを追跡しています。リモートリポジトリからもこのブランチを削除するか検討してください。"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
-msgid "Do you want to delete the local branch '$1'?"
-msgstr "ローカル ブランチ '$1' を削除しますか?"
-
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "ローカルブランチ'$1'を削除しますか？"
+
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
+msgid "Do you want to delete the local branch '$1'?"
+msgstr "ローカル ブランチ '$1' を削除しますか?"
 
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle"
 msgid "Delete"
@@ -2437,6 +2433,10 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "削除"
 
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
+msgid "Delete from remote repository '$1'"
+msgstr "リモートリポジトリ '$1' から削除する"
+
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
 msgstr "リモート '$1' から削除"
@@ -2445,13 +2445,13 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr "リモートリポジトリ'$1'から削除"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
-msgid "Delete from remote repository '$1'"
-msgstr "リモートリポジトリ '$1' から削除する"
-
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
 msgstr "ローカルにあるリモートブランチリストからブランチを削除するだけで、次のフェッチでブランチが復活する可能性があります。"
+
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
+msgid "Do you want to delete the branch '$1'?"
+msgstr "ブランチ '$1' を削除しますか？"
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the branch '$1'?"
@@ -2460,10 +2460,6 @@ msgstr "ブランチ'$1'を削除しますか？"
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr "リモートブランチ'$1'を削除しますか？"
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
-msgid "Do you want to delete the branch '$1'?"
-msgstr "ブランチ '$1' を削除しますか？"
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle"
 msgid "Delete"
@@ -3504,10 +3500,6 @@ msgstr "意図的に混在させた可能性がある行末の改行コードの
 msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr "右側のファイルは、改行コードが混在しているため編集できません。"
-
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
-msgid "\\[$1\\] - \\[$2\\] - $3"
-msgstr ""
 
 msgctxt "dlgSgConflictResolverExternalStarted.btn:"
 msgid "Mark Resolved"
@@ -7518,10 +7510,6 @@ msgstr "認証"
 msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr "リンク"
-
-msgctxt "dlgSgProviderGenerateToken.hdl"
-msgid "Generate a new API token for $1"
-msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.inf"
 msgid "Authenticate at GitLab and grant access to SmartGit."

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -18488,10 +18488,6 @@ msgstr ""
 #~ msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 #~ msgstr "作業ツリーは「リベース中」の状態です。リベースを中止できます。現在のパッチをスキップしたい場合は、代わりに\\[ブランチ\\]→\\[リベース\\]→\\[リベース HEAD to\\] を使用してください。\\n\\n中止すると、ローカルの変更を消去することができます。\\('git reset --hard' の実行\\）"
 
-#~ msgctxt "dlgSgAbortRevertingConfirm.hdl"
-#~ msgid "Do you want to abort the current revert?"
-#~ msgstr ""
-
 #~ msgctxt "dlgSgAbortRevertingConfirm.tle"
 #~ msgid "Discard"
 #~ msgstr "破棄"
@@ -18526,14 +18522,6 @@ msgstr ""
 #~ msgid "Configure a new hosting provider account"
 #~ msgstr "ホスティングプロバイダーの新規アカウント設定"
 
-#~ msgctxt "dlgSgHostingProviderAdd.inf"
-#~ msgid "Set or select the options according to your account."
-#~ msgstr ""
-
-#~ msgctxt "dlgSgOutput.lbl:"
-#~ msgid "stash failed \\(return code $1\\)"
-#~ msgstr ""
-
 #~ msgctxt "dlgSgProviderGenerateToken.hdl"
 #~ msgid "Generate a new API token for $1"
 #~ msgstr "$1 用の新しいAPIトークンを生成する"
@@ -18553,10 +18541,6 @@ msgstr ""
 #~ msgctxt "dlgSgRepositorySettings.inf:"
 #~ msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
 #~ msgstr "ここでは、このリポジトリ用のGit設定を編集することができます。デフォルトの設定は「環境設定」にあります。"
-
-#~ msgctxt "dlgSgResetAdv.inf"
-#~ msgid "Reset the current branch (HEAD) to the selected commit and optionally update Index and working tree."
-#~ msgstr ""
 
 #~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
 #~ msgid "Set to $1 \\(\"ours\", $2\\)"
@@ -18593,14 +18577,6 @@ msgstr ""
 #~ msgctxt "dlgTxtEditor.fileModified.hdl:"
 #~ msgid "The file config was changed. Reload it?"
 #~ msgstr "ファイル構成が変更されました。再読み込みしますか？"
-
-#~ msgctxt "ntmUpdateCheckFetchVersionSuccess:"
-#~ msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
-#~ msgstr ""
-
-#~ msgctxt "nttUpdateCheck:"
-#~ msgid "Quick Poll: $1"
-#~ msgstr ""
 
 #~ msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
 #~ msgid "<b>Last Updated By: </b>$1"

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -6765,6 +6765,11 @@ msgctxt "dlgSgOutput.chk:"
 msgid "Show automatically for failed command"
 msgstr "失敗したコマンドを自動的に表示する"
 
+# $1: Command name, $2: Return code
+msgctxt "dlgSgOutput.lbl:"
+msgid "$1 failed \\(return code $2\\)"
+msgstr ""
+
 msgctxt "dlgSgOutput.lbl:"
 msgid "Authentication using OAuth failed \\(see details below\\)"
 msgstr "OAuth を使用した認証に失敗しました \\(以下の詳細を参照\\)"
@@ -7008,10 +7013,6 @@ msgstr ""
 msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
 msgstr "次のファイルに対するローカルの変更は、チェックアウトによって上書きされます:\\n HEAD をデタッチできませんでした"
-
-msgctxt "dlgSgOutput.lbl:"
-msgid "stash failed \\(return code $1\\)"
-msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "unable to access '$1': Could not resolve host: $2"
@@ -13140,14 +13141,9 @@ msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
 msgstr "新しいバージョンが正常にダウンロードされると、再度通知されます。"
 
-# TODO: Check if the variable range is correct.
-#| msgid "SmartGit 25.1.093 needs to be restarted now for the changes to take effect."
+# $1: Software name and version
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
 msgid "$1 needs to be restarted now for the changes to take effect."
-msgstr ""
-
-msgctxt "ntmUpdateCheckFetchVersionSuccess:"
-msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
 msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
@@ -13289,10 +13285,6 @@ msgstr "アップデートを購入"
 msgctxt "nttSupportExpired:"
 msgid "Your support period has expired on $1."
 msgstr "$1 にサポート期間が終了しました。"
-
-msgctxt "nttUpdateCheck:"
-msgid "Quick Poll: $1"
-msgstr ""
 
 msgctxt "nttUpdateCheck:"
 msgid "Vote"
@@ -18538,6 +18530,10 @@ msgstr ""
 #~ msgid "Set or select the options according to your account."
 #~ msgstr ""
 
+#~ msgctxt "dlgSgOutput.lbl:"
+#~ msgid "stash failed \\(return code $1\\)"
+#~ msgstr ""
+
 #~ msgctxt "dlgSgProviderGenerateToken.hdl"
 #~ msgid "Generate a new API token for $1"
 #~ msgstr "$1 用の新しいAPIトークンを生成する"
@@ -18597,6 +18593,14 @@ msgstr ""
 #~ msgctxt "dlgTxtEditor.fileModified.hdl:"
 #~ msgid "The file config was changed. Reload it?"
 #~ msgstr "ファイル構成が変更されました。再読み込みしますか？"
+
+#~ msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+#~ msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
+#~ msgstr ""
+
+#~ msgctxt "nttUpdateCheck:"
+#~ msgid "Quick Poll: $1"
+#~ msgstr ""
 
 #~ msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
 #~ msgid "<b>Last Updated By: </b>$1"

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -39,7 +39,7 @@ msgstr "OK"
 
 msgctxt "*.chk:"
 msgid "Don't show again"
-msgstr ""
+msgstr "次回から表示しない"
 
 msgctxt "*.hnt:"
 msgid "Filter"

--- a/po/ja_JP.po
+++ b/po/ja_JP.po
@@ -37,6 +37,10 @@ msgctxt "*.btn:"
 msgid "OK"
 msgstr "OK"
 
+msgctxt "*.chk:"
+msgid "Don't show again"
+msgstr ""
+
 msgctxt "*.hnt:"
 msgid "Filter"
 msgstr "フィルタ"
@@ -161,6 +165,18 @@ msgctxt "dlgCommitInvisibleIndex.tle:"
 msgid "Commit"
 msgstr "コミット"
 
+msgctxt "dlgCommitNoEmailConfigured.fur:"
+msgid "Before committing you will have to configure your name and email, e.g. in the SmartGit Preferences."
+msgstr ""
+
+msgctxt "dlgCommitNoEmailConfigured.hdl:"
+msgid "Please configure the email for commit."
+msgstr ""
+
+msgctxt "dlgCommitNoEmailConfigured.tle:"
+msgid "Commit"
+msgstr ""
+
 msgctxt "dlgCommitView.hiddenOptions.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
@@ -269,6 +285,18 @@ msgctxt "dlgDgSetPerspectiveCantSwitch.tle:"
 msgid "Origins Perspective"
 msgstr "Origins パースペクティブ"
 
+msgctxt "dlgHostingProvider.canBeConfigured.btn:"
+msgid "Configure Hosting Provider"
+msgstr ""
+
+msgctxt "dlgHostingProvider.canBeConfigured.fur:"
+msgid "The easiest way to access the repository at $1 is through a hosting provider."
+msgstr ""
+
+msgctxt "dlgHostingProvider.canBeConfigured.hdl:"
+msgid "Do you want to configure a GitLab hosting provider?"
+msgstr ""
+
 msgctxt "dlgInfo.tle:"
 msgid "Discard"
 msgstr "破棄"
@@ -279,6 +307,11 @@ msgstr "停止"
 
 msgctxt "dlgProgress.lbl:"
 msgid "Please wait ..."
+msgstr "しばらくお待ちください..."
+
+# [decode] msgid "Please wait …"
+msgctxt "dlgProgress.lbl:"
+msgid "Please wait \\u2026"
 msgstr "しばらくお待ちください..."
 
 msgctxt "dlgProgress.tle:"
@@ -730,6 +763,10 @@ msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr "ファイルには、混在した \\(一貫性のない\\) 改行文字が含まれています。"
 
 msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
+msgid "\\[$1\\] - $2"
+msgstr ""
+
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - コンフリクトソルバー"
 
@@ -1033,9 +1070,17 @@ msgctxt "dlgScDialogAssertionHandlerLinkageError.btn:"
 msgid "Force Exit"
 msgstr "強制終了"
 
+msgctxt "dlgScDialogAssertionHandlerLinkageError.btn:"
+msgid "Just Exit"
+msgstr ""
+
 msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
 msgid "SmartGit has detected inconsistencies within its installation files \\(JAR files\\), what has most likely been caused by a faulty installation.\\n\\nPlease uninstall SmartGit completely, make sure there are no more installation files left \\(especially JAR files\\), then reinstall.\\n\\nIf the problem persists, send following log file as an attachment to smartgit@syntevo.com."
 msgstr "SmartGit のインストール ファイル (JAR ファイル) に不整合があることが判明しました。\\n\\nSmartGit を完全にアンインストールし、インストール ファイル (特に JAR ファイル) が残っていないことを確認してから、再インストールしてください。\\n\\n問題が解決しない場合は、次のログ ファイルを smartgit@syntevo.com に添付して送信してください。"
+
+msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
+msgid "Your SmartGit-installation seems to be damaged."
+msgstr ""
 
 msgctxt "dlgScDialogAssertionHandlerLinkageError.tle:"
 msgid "Internal Error"
@@ -1073,9 +1118,45 @@ msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr "SmartGit の評価期間は $1 日後に終了します。"
 
+msgctxt "dlgScEvaluationReminderContinue.hdl:"
+msgid "Your SmartGit evaluation ends today."
+msgstr ""
+
 msgctxt "dlgScEvaluationReminderContinue.tle:"
 msgid "Evaluation"
 msgstr "評価"
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "&Continue \\($1\\)"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "&Continue"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Continue \\($1\\)"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Exit"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Register"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.fur:"
+msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.hdl:"
+msgid "Your evaluation has already expired."
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.tle:"
+msgid "Evaluation"
+msgstr ""
 
 msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl:"
 msgid "Cannot run program \"$1\": $2"
@@ -1084,6 +1165,30 @@ msgstr "プログラム「\"$1\": $2」を実行できません"
 msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - コンフリクトソルバー"
+
+msgctxt "dlgScExternalFileStarterCommandNoFile.fur:"
+msgid "Be sure to add arguments to the appropriate input field."
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterCommandNoFile.hdl:"
+msgid "The specified command is no file."
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterCommandNoFile.tle:"
+msgid "Input Validation"
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterEmptyCommand.fur:"
+msgid "Select the command which should be invoked."
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterEmptyCommand.hdl:"
+msgid "The Command input field must not be empty!"
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterEmptyCommand.tle:"
+msgid "Input Validation"
+msgstr ""
 
 msgctxt "dlgScFileComparatorAdd.hdl:"
 msgid "Add external diff tool"
@@ -1473,6 +1578,10 @@ msgctxt "dlgScMasterPasswordEnter.inf:"
 msgid "A stored password or passphrase has been requested from the password store."
 msgstr "保存されたパスワードまたはパスフレーズがパスワードストアから要求されました。"
 
+msgctxt "dlgScMasterPasswordEnter.lbl:"
+msgid "Forgot it? Reset it in the preferences, 'Authentication' page."
+msgstr ""
+
 msgctxt "dlgScMasterPasswordEnter.tle:"
 msgid "Passwords"
 msgstr "パスワード"
@@ -1566,6 +1675,10 @@ msgid "Free Updates Until"
 msgstr "無料アップデート期間"
 
 msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
+msgid "License ID"
+msgstr ""
+
+msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "Name"
 msgstr "名前"
 
@@ -1609,6 +1722,34 @@ msgctxt "dlgScRegisterRequestRejected.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit ライセンス"
 
+msgctxt "dlgScSecretToken.btn:"
+msgid "Connect"
+msgstr ""
+
+msgctxt "dlgScSecretToken.edt:"
+msgid "API Key"
+msgstr ""
+
+msgctxt "dlgScSecretToken.hdl:"
+msgid "Provide API key for '$1'"
+msgstr ""
+
+msgctxt "dlgScSecretToken.inf:"
+msgid "An API key is required to access the AI at '$1'. It will be stored in SmartGit's password store."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://console.anthropic.com/settings/keys Anthropic account\\]."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://console.mistral.ai/api-keys Mistral account\\]."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://platform.openai.com/settings/organization/api-keys OpenAI account\\]."
+msgstr ""
+
 msgctxt "dlgScSetupLicense.btn:"
 msgid "Configure Proxy"
 msgstr "プロキシ設定"
@@ -1644,6 +1785,26 @@ msgstr "購入後にメールで送られてきたSmartGitのライセンスフ�
 msgctxt "dlgScSetupLicense.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit ライセンス"
+
+msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
+msgid "Exit Later"
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
+msgid "Restart Now"
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.fur:"
+msgid "You can do that now or manually later."
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.hdl:"
+msgid "SmartGit has to be restarted for the license change to take effect."
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.tle:"
+msgid "SmartGit License"
+msgstr ""
 
 msgctxt "dlgScSpellCheckDictionaryAdd.err:"
 msgid "Please enter a name."
@@ -2002,8 +2163,8 @@ msgid "Abort Rebase"
 msgstr "リベースを中止"
 
 msgctxt "dlgSgAbortRebasingConfirm.fur:"
-msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
-msgstr "作業ツリーは「リベース中」の状態です。リベースを中止できます。現在のパッチをスキップしたい場合は、代わりに\\[ブランチ\\]→\\[リベース\\]→\\[リベース HEAD to\\] を使用してください。\\n\\n中止すると、ローカルの変更を消去することができます。\\('git reset --hard' の実行\\）"
+msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use $1 instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
+msgstr ""
 
 msgctxt "dlgSgAbortRebasingConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
@@ -2034,6 +2195,10 @@ msgid "Discard"
 msgstr ""
 
 msgctxt "dlgSgAbout.btn:"
+msgid "Copy Evaluation-ID"
+msgstr ""
+
+msgctxt "dlgSgAbout.btn:"
 msgid "Register"
 msgstr "登録"
 
@@ -2048,6 +2213,10 @@ msgstr "アドレス"
 msgctxt "dlgSgAbout.edt:"
 msgid "Build Date"
 msgstr "ビルド日"
+
+msgctxt "dlgSgAbout.edt:"
+msgid "Demo Until"
+msgstr ""
 
 msgctxt "dlgSgAbout.edt:"
 msgid "Email"
@@ -2086,6 +2255,10 @@ msgid "User Count"
 msgstr "ユーザ数"
 
 msgctxt "dlgSgAbout.edt:"
+msgid "Valid Until"
+msgstr ""
+
+msgctxt "dlgSgAbout.edt:"
 msgid "Version"
 msgstr "バージョン"
 
@@ -2104,6 +2277,376 @@ msgstr "ライセンス"
 msgctxt "dlgSgAbout.tle:"
 msgid "About SmartGit"
 msgstr "SmartGitについて"
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.btn:"
+msgid "Drop"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.fur:"
+msgid "This will remove all AI-related Git notes from the repository."
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.hdl:"
+msgid "Do you want to drop all AI-related Git notes?"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.tle:"
+msgid "Drop AI Notes"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.btn:"
+msgid "Swap"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.edt:"
+msgid "New \\(To\\)"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.edt:"
+msgid "Old \\(From\\)"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.hdl:"
+msgid "Choose the diff direction"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.inf:"
+msgid "The two commits have diverged, so they can be compared in either direction. The diff represents the changes from Old to New."
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.tle:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
+msgid "Allow"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
+msgid "Deny"
+msgstr ""
+
+# $1: rootFile , $2: typeName , $3: details
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.fur:"
+msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to $2 are allowed. $3\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.hdl:"
+msgid "Do you allow SmartGit to upload repository data to $1?"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.tle:"
+msgid "AI Upload Consent"
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorError.hdl:"
+msgid "Failed to annotate selected commits."
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorError.tle:"
+msgid "Annotate Commits"
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorOutput.tle:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.fur:"
+msgid "Click the AI button again to generate your first commit message."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.hdl:"
+msgid "GitHub models are now configured."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.tle:"
+msgid "AI Commit Message Compose"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.fur:"
+msgid "No modifications found."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.hdl:"
+msgid "AI generation of the commit message failed."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.tle:"
+msgid "AI Commit Message Compose"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageNoModifications.fur:"
+msgid "There are no uncommitted changes in your working tree, so an AI commit message cannot be generated."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageNoModifications.hdl:"
+msgid "No local changes detected."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.btn:"
+msgid "Reword"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.fur:"
+msgid "SmartGit has detected a commit message containing an AI-generation marker. If the commit has not yet been pushed, it can be automatically reworded in the background.\\n\\nYou can enable or disable this option from the AI popup menu."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.hdl:"
+msgid "Do you want to reword marked commits in the background?"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.tle:"
+msgid "Commit Message Rewording"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.fur:"
+msgid "Your settings exclude untracked files from commits, so they will not be used to generate the AI commit message.\\n\\nTo include untracked files in commits, update the setting in Preferences."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.hdl:"
+msgid "Untracked files are excluded."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.tle:"
+msgid "AI Commit Message"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.hdl:"
+msgid "Configure AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.inf:"
+msgid "SmartGit supports AI-generated commit messages, with more AI features coming. GitHub models can be used out-of-the-box."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Configure manually \\(view documentation\\)"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Disable AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Use GitHub models for this repository"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Use GitHub models globally"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.tle:"
+msgid "AI Integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.btn:"
+msgid "Confirm"
+msgstr ""
+
+# [decode] msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data – either from the working tree or selected commits – to GitHub's servers.\n\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \(see the drop-down menu for configuration\)."
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.fur:"
+msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data \\u2013 either from the working tree or selected commits \\u2013 to GitHub's servers.\\n\\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \\(see the drop-down menu for configuration\\)."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.hdl:"
+msgid "Git diffs will be sent to GitHub for AI processing."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.tle:"
+msgid "Confirm GitHub AI Usage"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.btn:"
+msgid "Go Back"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable automatic stash messages"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable commit explanation"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable commit rewording"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Only for current repository"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "API URL"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "Model"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "URL Query"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Commit Rewording"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Explain Commits"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Please wait"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Stash Messages"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Welcome"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can automatically generate stash messages."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can explain individual commits or commit ranges in the background. Results are stored in Git notes."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can reword commit messages in the background when using special markers."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit offers AI-powered features to enhance productivity, simplify workflows, and assist you with your repositories."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "Verifying connectivity..."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "Verifying connectivity\\u2026"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Leave the stash message blank to enable auto-generation.\\n- SmartGit will generate a message and safely update the stash in the background.\\n- You can always enable or disable AI stash rewording in the Save Stash dialog.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Select one or more commits to generate a natural language explanation.\\n- For multiple commits, explanations are generated in the background and saved in Git Notes.\\n- Select two different branches to generate an explanation of their differences.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Use '@ai' to reword the entire commit message.\\n- 'WIP' will describe Work in Progress with an AI generated commit message.\\n- You can always enable or disable AI commit rewording features from the hamburger menu.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Optional parameters"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Please wait ..."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Please wait \\u2026"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Select your AI provider. This is the service SmartGit will use to generate AI-powered content."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "SmartGit won't ask about AI features again."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Steps"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Your GitHub credentials from the Hosting Provider configuration will be used. There is nothing more to set up here."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.rbt:"
+msgid "Disable AI integration globally"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.rbt:"
+msgid "Enable AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.tle:"
+msgid "AI Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.fur:"
+msgid "The configuration has been saved to '$1', which is included by '$2'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.hdl:"
+msgid "The AI integration has been configured successfully."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.tle:"
+msgid "AI Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupConnectivityFailed.fur:"
+msgid "Object '$1' not found."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConnectivityFailed.hdl:"
+msgid "Connection to '$1' failed."
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Back to Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Enable and Exit"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Exit without Enabling"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.fur:"
+msgid "You have selected some AI features. Do you want to enable them now, or exit the setup without enabling them?"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.hdl:"
+msgid "Enable already selected AI features?"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.tle:"
+msgid "AI Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.fur:"
+msgid "API URL missing."
+msgstr ""
+
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.hdl:"
+msgid "Configuration is invalid."
+msgstr ""
 
 msgctxt "dlgSgApplicationAlreadyRunning.fur:"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
@@ -2477,6 +3020,22 @@ msgctxt "dlgSgBranchTrackingSetConfirm.tle:"
 msgid "Set Tracked Branch"
 msgstr "追跡ブランチの設定"
 
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.btn:"
+msgid "Open"
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.fur:"
+msgid "You can see a detailed list of pull requests in the Log's Branches view and review changes in the Graph."
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.hdl:"
+msgid "Do you want to review pull requests in the Log?"
+msgstr ""
+
 msgctxt "dlgSgBugReportSettings.btn:"
 msgid "Exit"
 msgstr "終了"
@@ -2573,6 +3132,34 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.tle:"
 msgid "Check Out"
 msgstr "チェックアウト"
 
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.btn:"
+msgid "Checkout"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.fur:"
+msgid "The target branch has a different submodules configuration \\(.gitmodules\\). If you were expecting this change, you can proceed as usual.\\n\\nOtherwise, be aware that significant changes to your submodule configuration can lead to complex working tree states. In some cases, it might be simpler to perform a fresh clone of the target branch."
+msgstr ""
+
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.hdl:"
+msgid "Do you want to check out branch '$1'?"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.btn:"
+msgid "Switch"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.fur:"
+msgid "A worktree repository already exists for the selected branch. Therefore, you can't check out this branch directly, but you can switch to this worktree."
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.hdl:"
+msgid "Do you want to switch to worktree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.tle:"
+msgid "Check Out"
+msgstr ""
+
 msgctxt "dlgSgCheckoutTarget.btn:"
 msgid "Checkout"
 msgstr "チェックアウト"
@@ -2584,6 +3171,10 @@ msgstr "リモートブランチ '$1' を追跡"
 msgctxt "dlgSgCheckoutTarget.chk:"
 msgid "Track remote branch"
 msgstr "リモート ブランチの追跡"
+
+msgctxt "dlgSgCheckoutTarget.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
 
 msgctxt "dlgSgCheckoutTarget.hdl:"
 msgid "Check out commit"
@@ -2696,6 +3287,10 @@ msgstr "コミットメッセージにソースSHAを追加する"
 msgctxt "dlgSgCherryPickConfirmation.fur:"
 msgid "This will cherry-pick the selected commit into the Working Tree."
 msgstr "これにより、選択されたコミットが作業ツリーにチェリーピックされます。"
+
+msgctxt "dlgSgCherryPickConfirmation.fur:"
+msgid "This will cherry-pick the selected commits into the Working Tree."
+msgstr ""
 
 msgctxt "dlgSgCherryPickConfirmation.hdl:"
 msgid "Do you want to cherry-pick?"
@@ -2817,6 +3412,18 @@ msgctxt "dlgSgClone.btn:"
 msgid "Configure"
 msgstr "設定"
 
+msgctxt "dlgSgClone.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgClone.btn:"
+msgid "Go Back"
+msgstr ""
+
+msgctxt "dlgSgClone.chk:"
+msgid "Configure newly cloned repository to use SmartGit as credential helper"
+msgstr ""
+
 msgctxt "dlgSgClone.chk:"
 msgid "Create upstream remote"
 msgstr "上流リモートの作成"
@@ -2841,7 +3448,7 @@ msgctxt "dlgSgClone.chk:"
 msgid "Map SVN trunk, tags and branches to Git"
 msgstr "SVNのトランク、タグ、ブランチをGitにマップする"
 
-msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
+msgctxt "dlgSgClone.chk:"
 msgid "Skip large files \\(\"partial clone\"\\)"
 msgstr "大きなファイルをスキップする \\(\"partial clone\"\\)"
 
@@ -2929,6 +3536,11 @@ msgctxt "dlgSgClone.hnt:"
 msgid "Searching ..."
 msgstr "検索中..."
 
+# [decode] msgid "Searching …"
+msgctxt "dlgSgClone.hnt:"
+msgid "Searching \\u2026"
+msgstr "検索中..."
+
 msgctxt "dlgSgClone.inf:"
 msgid "Customize how and what to clone."
 msgstr "クローンする方法と内容をカスタマイズできます。"
@@ -2964,6 +3576,18 @@ msgstr "例: https://user@server:port/path/to/repository"
 msgctxt "dlgSgClone.mni:"
 msgid "Add Hosting Provider"
 msgstr "ホスティングプロバイダーを追加"
+
+msgctxt "dlgSgClone.mni:"
+msgid "Own Repositories"
+msgstr ""
+
+msgctxt "dlgSgClone.mni:"
+msgid "Starred Repositories"
+msgstr ""
+
+msgctxt "dlgSgClone.mni:"
+msgid "Top Repositories"
+msgstr ""
 
 msgctxt "dlgSgClone.rbt:"
 msgid "Clone all revisions \\(recommended\\)"
@@ -3177,9 +3801,9 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Merge commit \\(multiple parents\\)"
 msgstr "マージ コミット \\(複数の親\\)"
 
-msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
+msgctxt "dlgSgCommit.rbt:"
 msgid "Simple commit \\(one parent, \"squash\"\\)"
-msgstr "シンプルなコミット \\(一つの親 、\"スカッシュ\" \\)"
+msgstr ""
 
 msgctxt "dlgSgCommit.rbt:"
 msgid "Staged Changes"
@@ -3350,6 +3974,10 @@ msgid "Select a commit"
 msgstr "コミットを選択する"
 
 msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
+msgid "No graph roots selected."
+msgstr ""
+
+msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
 msgid "No repository selected."
 msgstr "リポジトリが選択されていません。"
 
@@ -3480,6 +4108,10 @@ msgstr "意図的に混在させた可能性がある行末の改行コードの
 msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl:"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr "右側のファイルは、改行コードが混在しているため編集できません。"
+
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle:"
+msgid "\\[$1\\] - \\[$2\\] - $3"
+msgstr ""
 
 msgctxt "dlgSgConflictResolverExternalStarted.btn:"
 msgid "Mark Resolved"
@@ -3754,14 +4386,12 @@ msgid "GIT_DIR for repository at '$1' does not exist."
 msgstr "'$1' にあるリポジトリの GIT_DIR が存在しません。"
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
+msgid "No valid worktree state of the repository."
+msgstr ""
+
+msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Repository '$1' is not valid."
 msgstr "リポジトリ '$1' は無効です。"
-
-# Needs review: Check whether the URL needs to be made variable
-#, fuzzy
-msgctxt "dlgSgErrorUtilsClientException.fur:"
-msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-msgstr "サーバーが URL: https://gitlab.com/oauth/token に対して HTTP 応答コード: 400 を返しました"
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "svn: $1"
@@ -3834,6 +4464,22 @@ msgstr "変更は表示されませんが、ファイルの比較を開きます
 msgctxt "dlgSgFileCompareNoChanges.tle:"
 msgid "File Compare"
 msgstr "ファイルの比較"
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.btn:"
+msgid "Rerun"
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.fur:"
+msgid "For the initial commit\\(s\\) where the file was added, SmartGit will try to find a similar pre-existing file. If it finds one, it will continue the Log for that file as the source from which it might have been copied.\\n\\nTo enable this feature by default, set the Low-Level Property `log.file.followCopies` in the Preferences."
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.hdl:"
+msgid "Do you want to re-run the Log with copy-detection enabled?"
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.tle:"
+msgid "Follow Copies"
+msgstr ""
 
 msgctxt "dlgSgFindObject.edt:"
 msgid "Repository Path, Commit ID or Ref"
@@ -4395,6 +5041,46 @@ msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle:"
 msgid "Run Garbage Collector"
 msgstr "ガベージコレクタの実行"
 
+msgctxt "dlgSgGitConfigEditConfigNotFound.fur:"
+msgid "The file $1config could not be opened for editing."
+msgstr ""
+
+msgctxt "dlgSgGitConfigEditConfigNotFound.hdl:"
+msgid "The file config was not found."
+msgstr ""
+
+msgctxt "dlgSgGitConfigEditConfigNotFound.tle:"
+msgid "Edit Config"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
+msgid "Refresh"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
+msgid "Select"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.col:"
+msgid "Number"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.col:"
+msgid "Title"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.hdl:"
+msgid "Select commit message by GitHub issue"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.inf:"
+msgid "The selected issue summary will be used as commit message."
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.tle:"
+msgid "Select Issue"
+msgstr ""
+
 msgctxt "dlgSgGitHubGenerateToken.btn:"
 msgid "Authenticate"
 msgstr "認証"
@@ -4593,6 +5279,26 @@ msgctxt "dlgSgGitLabSettingsInvalidToken.tle:"
 msgid "Input Validation"
 msgstr "入力検証"
 
+msgctxt "dlgSgGitNoteAdd.btn:"
+msgid "Add Note"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.edt:"
+msgid "Category"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.hdl:"
+msgid "Add a note to a commit"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.inf:"
+msgid "Provider the text which should be added to the selected commit."
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.tle:"
+msgid "Add Note"
+msgstr ""
+
 msgctxt "dlgSgHeadMessageListenerReplaceMessage.btn:"
 msgid "Don't Replace"
 msgstr "置換しない"
@@ -4620,6 +5326,10 @@ msgstr "コミット"
 msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
 msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
 msgstr "影響を受けるコミットのうち少なくとも1つは、HEADの最初の親となる履歴の一部ではありません。"
+
+msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
+msgid "To modify commits of a different branch, you need to first check out this branch."
+msgstr ""
 
 msgctxt "dlgSgHistoryCommitCantBeModified.hdl:"
 msgid "At least one selected commit can't be modified."
@@ -4668,6 +5378,26 @@ msgstr "新しいコミットの作者とそのメールアドレスを入力し
 msgctxt "dlgSgHistoryEditAuthor.tle:"
 msgid "Edit Author"
 msgstr "作者を編集"
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.btn:"
+msgid "From Commit"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.btn:"
+msgid "From Failed Command"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.fur:"
+msgid "A previous Edit Message command invocation failed for this commit. Decide whether to use the commit message from the failed run or the commit's message."
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.hdl:"
+msgid "Which commit message you like to use?"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.tle:"
+msgid "Edit Message"
+msgstr ""
 
 msgctxt "dlgSgHistoryEditMessage.btn:"
 msgid "JIRA"
@@ -4818,6 +5548,10 @@ msgid "Do you want to modify commits which are already pushed?"
 msgstr "既にプッシュされているコミットを修正しますか?"
 
 msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.tle:"
+msgid "Edit Author"
+msgstr ""
+
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.tle:"
 msgid "Edit Message"
 msgstr "メッセージの編集"
 
@@ -4864,6 +5598,10 @@ msgstr "選択したコミットを複数のコミットに分割しますか?"
 msgctxt "dlgSgHistorySplitConfirm.tle:"
 msgid "Split Commit"
 msgstr "コミットの分割"
+
+msgctxt "dlgSgHistorySquash.btn:"
+msgid "Add co-authors"
+msgstr ""
 
 msgctxt "dlgSgHistorySquash.btn:"
 msgid "JIRA"
@@ -4990,7 +5728,35 @@ msgid "The entered URL is invalid - it should look like https://server"
 msgstr "入力された URL は無効です - https://server のようになります"
 
 msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Azure DevOps Server account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Azure DevOps account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Bitbucket Server account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Bitbucket account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitHub Enterprise account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Add GitHub account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitLab \\(Self Hosted\\) account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitLab account"
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.hdl:"
@@ -5018,6 +5784,10 @@ msgstr "Azure DevOps アカウント設定で生成できる「個人アクセ�
 msgctxt "dlgSgHostingProviderAdd.lbl:"
 msgid "Provide a 'personal access token' which you can generate in your GitHub account settings."
 msgstr "GitHub アカウント設定で生成できる「個人アクセストークン」を入力してください。"
+
+msgctxt "dlgSgHostingProviderAdd.lbl:"
+msgid "Required scopes are 'api' and 'write_repository'."
+msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.lbl:"
 msgid "SSL Client Certificate \\(optional\\)"
@@ -5414,6 +6184,10 @@ msgstr "リポジトリのルートディレクトリの .gitignore"
 msgctxt "dlgSgIgnoreFile.edt:"
 msgid "Ignore File"
 msgstr "Ignoreファイル"
+
+msgctxt "dlgSgIgnoreFile.err:"
+msgid "Enter a pattern for the file\\(s\\) to be ignored. Use \\* to match multiple or ? for a single arbitrary character."
+msgstr ""
 
 msgctxt "dlgSgIgnoreFile.err:"
 msgid "The pattern must match all selected file names. For instance, '$1' is not matched."
@@ -5879,6 +6653,10 @@ msgctxt "dlgSgMergeHowToMerge.fur:"
 msgid "If there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
 msgstr "競合がない場合、Gitは自動的にマージコミットを作成します。代わりに、作業ツリーにマージすることもできます。\\n作業ツリーにマージ を選択すると、マージコミットが作成されますが、スカッシュマージ を選択すると通常のコミットが作成されます \\(マージされたコミットに関する情報は破棄されます\\)。どちらの場合も、後で手動でコミットする必要があります。"
 
+msgctxt "dlgSgMergeHowToMerge.fur:"
+msgid "You are about to perform an Octopus Merge from $1 source branches.\\n\\nIf there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
+msgstr ""
+
 msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from branch '$1'?"
 msgstr "ブランチ '$1' からどのようにマージしますか?"
@@ -5886,6 +6664,10 @@ msgstr "ブランチ '$1' からどのようにマージしますか?"
 msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from tag '$1'?"
 msgstr "タグ '$1' からどのようにマージしますか?"
+
+msgctxt "dlgSgMergeHowToMerge.hdl:"
+msgid "How to merge the $1 selected branches?"
+msgstr ""
 
 msgctxt "dlgSgMergeHowToMerge.tle:"
 msgid "Merge"
@@ -5939,6 +6721,26 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.tle:"
 msgid "Add or Create Repository"
 msgstr "リポジトリの追加又は作成"
 
+msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
+msgid "Inner Repository"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
+msgid "Outer Repository"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.fur:"
+msgid "At the specified path nested repositories were found.\\nInner repository: $1\\nOuter repository: $2"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.hdl:"
+msgid "Do you want to open the outer or inner repository?"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.tle:"
+msgid "Add or Create Repository"
+msgstr ""
+
 msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur:"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr "SmartGit では不可能な既存の SVN 作業コピーを開こうとしています。代わりに、$1 を使用して、SVN リポジトリの Git クローン \\(つまり、SVN ではなく Git に基づく作業コピー\\) を作成してください。"
@@ -5974,6 +6776,10 @@ msgstr "ブランチはまずマージする必要があります。"
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Abort failed!"
 msgstr "コマンド「中止」に失敗しました!"
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Add Branch failed!"
+msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Add Submodule failed!"
@@ -6032,6 +6838,18 @@ msgid "Command Discard failed!"
 msgstr "コマンド「破棄」に失敗しました!"
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Discard produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Edit Author produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Edit Message failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Fetch Pull Request produced warnings."
 msgstr "コマンド 「プルリクエストのフェッチ」 が警告を発しました。"
 
@@ -6042,6 +6860,10 @@ msgstr "コマンド 「フェッチ」 に失敗しました!"
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Fetch produced warnings."
 msgstr "コマンド 「フェッチ」 が警告を発しました。"
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command LFS Install failed!"
+msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Merge produced warnings."
@@ -6060,6 +6882,10 @@ msgid "Command Move produced warnings."
 msgstr "コマンド 「移動」 が警告を発しました。"
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Pull \\(Merge\\) failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Pull \\(Merge\\) produced warnings."
 msgstr "コマンド \\「プル \\(マージ\\)」 は警告を発しました。"
 
@@ -6076,6 +6902,14 @@ msgid "Command Push failed!"
 msgstr "コマンド 「プッシュ」 に失敗しました!"
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Rebase HEAD \\($1\\) to $2 failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Rebase HEAD \\($1\\) to $2 produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase Interactive failed!"
 msgstr "コマンド 「対話的なリベース」 に失敗しました!"
 
@@ -6086,6 +6920,10 @@ msgstr "コマンド 「リベース」 に失敗した！"
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase produced warnings."
 msgstr "コマンド 「リベース」 が警告を発しました。"
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Remove Worktree failed!"
+msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Reset failed!"
@@ -6132,6 +6970,10 @@ msgid "Command Start Support Branch failed!"
 msgstr "コマンド 「サポートブランチを開始」 に失敗しました!"
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Tool $1 produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Unregister Submodule failed!"
 msgstr "コマンド「サブモジュールの登録解除」に失敗しました！"
 
@@ -6148,12 +6990,40 @@ msgid "Not all refs have been pushed."
 msgstr "すべての参照がプッシュされたわけではありません。"
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "The command output below contains more details on the problem."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "The working tree has local changes."
 msgstr "作業ツリーにローカルな変更があります。"
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Tool $1 succeeded."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "You have not concluded your merge \\(MERGE_HEAD exists\\)."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
 msgstr "次のファイルに対するローカルの変更は、チェックアウトによって上書きされます:\\n HEAD をデタッチできませんでした"
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "stash failed \\(return code $1\\)"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to access '$1': Could not resolve host: $2"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to access '$1': server certificate verification failed. CAfile: $2 CRLfile: $3"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to auto-detect email address \\(got '$1.\\(none\\)'\\)"
+msgstr ""
 
 msgctxt "dlgSgOutput.mni:"
 msgid "Copy Selection"
@@ -6182,6 +7052,10 @@ msgstr "出力"
 msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr "リポジトリURLを確認してください。\\n\\n$1"
+
+msgctxt "dlgSgPingRepositoryFailed.fur:"
+msgid "repository '$1' not found."
+msgstr ""
 
 msgctxt "dlgSgPingRepositoryFailed.hdl:"
 msgid "Could not connect to the repository '$1'."
@@ -6236,6 +7110,10 @@ msgid "Import"
 msgstr "インポート"
 
 msgctxt "dlgSgPreferences.btn:"
+msgid "Load All Stored Secrets"
+msgstr ""
+
+msgctxt "dlgSgPreferences.btn:"
 msgid "Move Down"
 msgstr "下へ"
 
@@ -6266,6 +7144,10 @@ msgstr "リセット"
 msgctxt "dlgSgPreferences.btn:"
 msgid "Show Password"
 msgstr "パスワードを表示"
+
+msgctxt "dlgSgPreferences.cdl:"
+msgid "AI Integration"
+msgstr ""
 
 msgctxt "dlgSgPreferences.cdl:"
 msgid "Authentication"
@@ -6368,6 +7250,10 @@ msgid "Allow modifying pushed commits \\(e.g. forced-push\\)"
 msgstr "プッシュされたコミットの修正を許可する (例: force-push)"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Allow modifying pushed commits \\(e.g. forced-push\\):"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Allow to open multiple Log windows for the same repository/file"
 msgstr "同一のリポジトリ/ファイルに対して複数のログウィンドウを開くことを許可する"
 
@@ -6420,6 +7306,18 @@ msgid "Configure SmartGit as credential helper \\(for repository authentication\
 msgstr "SmartGit を認証ヘルパーとして設定する \\(リポジトリ認証用\\)"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Configure SmartGit as credential helper for Git command line"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Configure newly cloned repository to use SmartGit as credential helper on Git command line"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Delete branch"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Detect local changes in closed 'favorite' repositories"
 msgstr "閉じた「お気に入り」リポジトリのローカルな変更の検出"
 
@@ -6432,8 +7330,16 @@ msgid "Detect renames \\(for added and removed files, as command line Git does\\
 msgstr "リネームの検出（コマンドラインGitと同様に、追加されたファイルと削除されたファイルの検出）"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Disable AI integration \\(globally\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Distinguish between content and EOL-only changes \\(slightly more expensive\\)"
 msgstr "コンテンツとEOLのみの変更を区別する（やや高コストな処理）"
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Enable AI integration"
+msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
 msgid "Enable integration for configured hosting providers \\(pull requests, comments\\)"
@@ -6500,6 +7406,10 @@ msgid "Push all tags"
 msgstr "全てのタグをプッシュ"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Quick Polls \\(help shape SmartGit\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Refresh file system also while SmartGit is in background"
 msgstr "SmartGit がバックグラウンド動作している間、ファイルシステムを更新する"
 
@@ -6556,6 +7466,10 @@ msgid "Sign all commits"
 msgstr "すべてのコミットに署名する"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "SmartGit-related announcements"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Swap 'ours' and 'theirs' on Rebase conflicts for easier understanding"
 msgstr "リベースの競合で'ours'と'theirs'を入れ替えて理解しやすくする。"
 
@@ -6605,6 +7519,11 @@ msgstr "自動的にライト/ダークを選択"
 
 msgctxt "dlgSgPreferences.cmb:"
 msgid "Custom..."
+msgstr "カスタム..."
+
+# [decode] msgid "Custom…"
+msgctxt "dlgSgPreferences.cmb:"
+msgid "Custom\\u2026"
 msgstr "カスタム..."
 
 msgctxt "dlgSgPreferences.cmb:"
@@ -6662,6 +7581,10 @@ msgstr "コマンドと引数"
 msgctxt "dlgSgPreferences.col:"
 msgid "Command"
 msgstr "コマンド"
+
+msgctxt "dlgSgPreferences.col:"
+msgid "Credential"
+msgstr ""
 
 msgctxt "dlgSgPreferences.col:"
 msgid "Default"
@@ -6788,6 +7711,10 @@ msgid "Name"
 msgstr "名前"
 
 msgctxt "dlgSgPreferences.edt:"
+msgid "Notify about"
+msgstr ""
+
+msgctxt "dlgSgPreferences.edt:"
 msgid "On startup"
 msgstr "起動時"
 
@@ -6908,6 +7835,10 @@ msgid "Changing these low-level properties can be harmful to the stability or pe
 msgstr "ローレベルのプロパティを変更すると、SmartGitの安定性や性能に悪影響を及ぼす可能性があります。\\r自分が何をしているのか確信が持てる場合のみ、作業を続行するべきです。\\r変更したプロパティの末尾に\\*が付いている場合は、再起動が必要です。"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Changing these low-level properties may harm the stability or performance of SmartGit.\\n\\[_ Changed properties\\] with a trailing \\\\\\* need a restart to be applied."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Checkout \\(Switch branch\\)"
 msgstr "チェックアウト \\(ブランチの切り替え\\)"
 
@@ -6944,8 +7875,16 @@ msgid "External tool:"
 msgstr "外部ツール:"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Finish Feature"
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Garbage Collector"
 msgstr "ガベージコレクタ"
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "General"
+msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "Here you can edit your account's 'gitconfig' which contains the defaults for all repositories."
@@ -6968,8 +7907,16 @@ msgid "In order to use all SmartGit functionality, you need to have command line
 msgstr "SmartGitのすべての機能を使用するには、システムにコマンドラインGitがインストールされている必要があります。インストールした'git'実行ファイルのフルパスを入力してください。"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Learn how to tailor AI for your projects with the complete \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI SmartGit AI Integration documentation\\]."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Local and Remote Changes"
 msgstr "ローカルとリモートの変更"
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "Note: Some repositories may already have per-repository AI settings."
+msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "Note: The password will be stored in plain text in SmartGit's configuration area!"
@@ -7012,6 +7959,22 @@ msgid "Stash"
 msgstr "スタッシュ"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*configured globally\\*. Change it via AI button > \\*Reconfigure\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*disabled globally\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*manually configured\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*not yet configured\\* \\(globally\\)."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "The last check was performed on $1."
 msgstr "前回のチェックは $1 に実施されました。"
 
@@ -7024,6 +7987,14 @@ msgid "This file will be sent as is: $1"
 msgstr "このファイルはそのまま送信されます: $1"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "To change it, edit your Git config files directly."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "To configure, click the AI button in the Commit Message view or the Commit dialog."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "To manually update in-place use the '...' button located next to the version number in the About dialog."
 msgstr "手動でインプレースアップデートするには、バージョン情報ダイアログのバージョン番号の横にある「...」ボタンを使用します。"
 
@@ -7034,6 +8005,10 @@ msgstr ""
 msgctxt "dlgSgPreferences.lbl:"
 msgid "When comparing files, this list is searched from top to bottom to find a matching diff tool. If none is found, the built-in file compare is used for text files."
 msgstr "ファイルを比較する際には、このリストを上から下に向かって検索し、一致する 比較 ツールを探します。\\r見つからない場合は、テキスト ファイルの場合は内蔵のファイル比較が使用されます。"
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "When enabled, the AI button appears in the Commit Message view and the Commit dialog. Click it to complete the initial setup."
+msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "When invoking the Conflict Solver feature, this list is searched from top to bottom to find a matching entry. If none is found, the built-in Conflict Solver is used for text files."
@@ -7122,6 +8097,10 @@ msgstr "キーをコピー"
 msgctxt "dlgSgPreferences.mni:"
 msgid "Copy Selection in Column"
 msgstr "この列の選択範囲をコピーする"
+
+msgctxt "dlgSgPreferences.mni:"
+msgid "Credential"
+msgstr ""
 
 msgctxt "dlgSgPreferences.mni:"
 msgid "Default"
@@ -7272,6 +8251,10 @@ msgid "Exact case \\('Foo' will match 'Foo', but not 'foo'\\)"
 msgstr "大文字小文字を区別する"
 
 msgctxt "dlgSgPreferences.rbt:"
+msgid "For all branches"
+msgstr ""
+
+msgctxt "dlgSgPreferences.rbt:"
 msgid "Ignore case \\('Foo' will match 'Foo' and 'foo'\\)"
 msgstr "大文字小文字を区別しない"
 
@@ -7286,6 +8269,10 @@ msgstr "ロググラフ"
 msgctxt "dlgSgPreferences.rbt:"
 msgid "Log graph \\(commit oriented\\)"
 msgstr "ロググラフ \\(コミット中心\\)"
+
+msgctxt "dlgSgPreferences.rbt:"
+msgid "Only for feature branches"
+msgstr ""
 
 msgctxt "dlgSgPreferences.rbt:"
 msgid "Other Git Executable:"
@@ -7358,6 +8345,10 @@ msgstr "動作"
 msgctxt "dlgSgPreferences.tab:"
 msgid "Colors"
 msgstr "色"
+
+msgctxt "dlgSgPreferences.tab:"
+msgid "Credential Helper"
+msgstr ""
 
 msgctxt "dlgSgPreferences.tab:"
 msgid "Encoding"
@@ -7459,6 +8450,10 @@ msgctxt "dlgSgProcessKiller.lbl:"
 msgid "If you think the process is hanging, click the 'Kill Process' button, otherwise 'Wait'."
 msgstr "プロセスがハングしていると思われる場合は、[強制終了] ボタンをクリックします。それ以外の場合は [待機] ボタンをクリックします。"
 
+msgctxt "dlgSgProcessKiller.lbl:"
+msgid "SmartGit is waiting for the following process to finish."
+msgstr ""
+
 msgctxt "dlgSgProcessKiller.tle:"
 msgid "Process Not Responding"
 msgstr "プロセスが応答していません"
@@ -7483,6 +8478,30 @@ msgctxt "dlgSgProviderCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr "コメントを編集"
 
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.btn:"
+msgid "Confirm"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.cmb:"
+msgid "github.com"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.edt:"
+msgid "Provider"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.hdl:"
+msgid "Select which GitHub account to use"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.inf:"
+msgid "Select which account you want to use for connecting to '$1'."
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.tle:"
+msgid "Select GitHub account"
+msgstr ""
+
 msgctxt "dlgSgProviderGenerateToken.btn:"
 msgid "Authenticate"
 msgstr "認証"
@@ -7490,6 +8509,14 @@ msgstr "認証"
 msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr "リンク"
+
+msgctxt "dlgSgProviderGenerateToken.hdl:"
+msgid "Generate a new API token for $1"
+msgstr ""
+
+msgctxt "dlgSgProviderGenerateToken.inf:"
+msgid "Authenticate at GitHub and grant access to SmartGit."
+msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.inf:"
 msgid "Authenticate at GitLab and grant access to SmartGit."
@@ -7795,6 +8822,14 @@ msgctxt "dlgSgPushConfirmSingleTag.chk:"
 msgid "Don't show again"
 msgstr "次回から表示しない"
 
+msgctxt "dlgSgPushConfirmSingleTag.fur:"
+msgid "$1 tag will be pushed to '$2'."
+msgstr ""
+
+msgctxt "dlgSgPushConfirmSingleTag.hdl:"
+msgid "Do you want to push tag '$1'?"
+msgstr ""
+
 msgctxt "dlgSgPushConfirmSingleTag.tle:"
 msgid "Push"
 msgstr "プッシュ"
@@ -7808,8 +8843,8 @@ msgid "Pushing to the remote branch is not fast-forward, so the push has to be f
 msgstr "リモートブランチへのプッシュは ファストフォワードできないので、強制的にプッシュする必要があります。リモートブランチでのコミットは失われます。"
 
 msgctxt "dlgSgPushForced.hdl:"
-msgid "Do you want to force-push \\(replace\\) the remote branch?"
-msgstr "リモートブランチを強制プッシュ（置き換え）しますか？"
+msgid "Do you want to force-push \\(replace\\) the remote branch '$1'?"
+msgstr ""
 
 msgctxt "dlgSgPushForced.tle:"
 msgid "Push"
@@ -8139,6 +9174,46 @@ msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle:"
 msgid "Rebase"
 msgstr "リベース"
 
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.btn:"
+msgid "Continue \\(Resume\\)"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.fur:"
+msgid "Clicking 'Continue' will resume the rebase, e.g. to finish after having modified the commit\\(s\\)."
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.hdl:"
+msgid "Do you want to continue the modify-commit-rebase?"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.tle:"
+msgid "Modify Commit"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.btn:"
+msgid "Step"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.fur:"
+msgid "Clicking 'Step' will continue the rebase and stop at the next commit. Use it to step through all pending commits, e.g. to verify whether they successfully build."
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.hdl:"
+msgid "Do you want to step to the next commit?"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.tle:"
+msgid "Modify Commit"
+msgstr ""
+
 msgctxt "dlgSgRebaseContinueNothingToCommitSkip.btn:"
 msgid "Skip Commit"
 msgstr "コミットをスキップ"
@@ -8354,6 +9429,14 @@ msgctxt "dlgSgRebaseInteractiveMessage.tle:"
 msgid "Edit Message"
 msgstr "メッセージの編集"
 
+msgctxt "dlgSgRebaseInteractiveNoAutomaticSquashableCommitsFound.fur:"
+msgid "Auto-Squash searches for commits with identical messages and amend-commits them."
+msgstr ""
+
+msgctxt "dlgSgRebaseInteractiveNoAutomaticSquashableCommitsFound.hdl:"
+msgid "No automatic squashable commits found."
+msgstr ""
+
 msgctxt "dlgSgRebaseInteractiveRemoveCommit.btn:"
 msgid "Remove"
 msgstr "除去"
@@ -8382,6 +9465,14 @@ msgctxt "dlgSgRebaseNoop.tle:"
 msgid "Merge"
 msgstr "マージ"
 
+msgctxt "dlgSgRebaseNoopParent.fur:"
+msgid "Rebasing a commit onto its parent is allowed by Git but will not create a new commit or any meaningful changes."
+msgstr ""
+
+msgctxt "dlgSgRebaseNoopParent.hdl:"
+msgid "There is nothing to rebase."
+msgstr ""
+
 msgctxt "dlgSgRebaseNoopSelf.fur:"
 msgid "Rebasing a commit onto itself is allowed by Git but will not create a new commit or any meaningful changes."
 msgstr "コミットを自身にリベースすることはGitで可能ですが、新しいコミットや意味のある変更は一切発生しません。"
@@ -8393,6 +9484,18 @@ msgstr "リベースするものは何もありません。"
 msgctxt "dlgSgRebaseNoopSelf.tle:"
 msgid "Rebase"
 msgstr "リベース"
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.btn:"
+msgid "Rebase Single Commit"
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.fur:"
+msgid "You are about to rebase your branch onto its own history. This action is allowed by Git but will not create a new commit or any meaningful changes.\\n\\nTo rebase a single commit, you can do so now.\\n\\nTo rebase a range of commits, select them in the Graph and drag & drop to the target commit."
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.hdl:"
+msgid "Do you want to rebase only the HEAD commit?"
+msgstr ""
 
 msgctxt "dlgSgRebaseTagCommit.btn:"
 msgid "Add Tag"
@@ -8706,6 +9809,10 @@ msgctxt "dlgSgRenameBranch.edt:"
 msgid "Name"
 msgstr "名前"
 
+msgctxt "dlgSgRenameBranch.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
+
 msgctxt "dlgSgRenameBranch.hdl:"
 msgid "Rename branch"
 msgstr "ブランチの名前を変更する"
@@ -8725,6 +9832,10 @@ msgstr "リネーム"
 msgctxt "dlgSgRenameFile.edt:"
 msgid "Path"
 msgstr "パス"
+
+msgctxt "dlgSgRenameFile.err:"
+msgid "No valid path specified."
+msgstr ""
 
 msgctxt "dlgSgRenameFile.hdl:"
 msgid "Move or Rename the file"
@@ -8866,6 +9977,10 @@ msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Close"
 msgstr "強制的に閉じる"
 
+msgctxt "dlgSgRepositoryClose.btn:"
+msgid "Force Exit"
+msgstr ""
+
 msgctxt "dlgSgRepositoryClose.fur:"
 msgid "Note that currently running Git processes might not be interrupted."
 msgstr "現在実行中のGitプロセスは中止されない可能性があることに注意してください。"
@@ -8877,6 +9992,10 @@ msgstr "本当に今すぐ閉じますか？"
 msgctxt "dlgSgRepositoryClose.tle:"
 msgid "Close"
 msgstr "閉じる"
+
+msgctxt "dlgSgRepositoryClose.tle:"
+msgid "Exit"
+msgstr ""
 
 msgctxt "dlgSgRepositoryFrameCloseWithoutPush.btn:"
 msgid "Close Now"
@@ -8995,6 +10114,10 @@ msgid "Always fetch new commits, tags and branches from submodule"
 msgstr "サブモジュールから常に新しいコミット、タグ、ブランチを取得する"
 
 msgctxt "dlgSgRepositorySettings.chk:"
+msgid "Configure SmartGit as credential helper for Git command line"
+msgstr ""
+
+msgctxt "dlgSgRepositorySettings.chk:"
 msgid "Initialize new submodules"
 msgstr "新しいサブモジュールを初期化"
 
@@ -9067,12 +10190,16 @@ msgid "Edit the repository settings"
 msgstr "リポジトリの設定を編集する"
 
 msgctxt "dlgSgRepositorySettings.inf:"
-msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
-msgstr "ここでは、このリポジトリ用のGit設定を編集することができます。デフォルトの設定は「環境設定」にあります。"
+msgid "Here you can edit the Git settings for the repository. The default settings can be found in the Preferences."
+msgstr ""
 
 msgctxt "dlgSgRepositorySettings.lbl:"
 msgid "\\* if repository commit references non-pushed submodule commit"
 msgstr "\\* リポジトリのコミットがプッシュされていないサブモジュールのコミットを参照している場合"
+
+msgctxt "dlgSgRepositorySettings.tab:"
+msgid "Credential Helper"
+msgstr ""
 
 msgctxt "dlgSgRepositorySettings.tab:"
 msgid "Encoding"
@@ -9121,6 +10248,10 @@ msgstr "<b>複数のグループパターン</b>"
 msgctxt "dlgSgRepositorySettings.ttpGroupPatterns:"
 msgid "Patterns will show up in the GUI using auto-generated labels which are derived from their regular expression. You can assign a custom label <tt>label</tt> to a pattern by prefixing it by <tt>label:</tt>; a label may only contain letters, digits and '_'."
 msgstr "パターンは、その正規表現から派生した自動生成されたラベルを使用してGUIに表示されます。ラベルには、<tt>label:</tt> という接頭辞を付けて <tt>label</tt> を割り当てることができます。ラベルには、文字、数字、'_' のみ使用できます。"
+
+msgctxt "dlgSgRepositorySettings.wrn:"
+msgid "It is recommended to set an email address used for committing."
+msgstr ""
 
 msgctxt "dlgSgRepositorySettings.wrn:"
 msgid "The entered email address does not look like a valid one."
@@ -9242,21 +10373,21 @@ msgctxt "dlgSgResolve.rbt:"
 msgid "Open Conflict Solver"
 msgstr "競合解決ツールを開く"
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"ours\", $2\\)"
-msgstr "$1 に設定\\(\"ours\", $2\\)"
+msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"theirs\", $2\\)"
-msgstr "$1 に設定\\(\"theirs\", $2\\)"
+msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebase target \\(\"theirs\", $1\\)"
-msgstr "リベースターゲットに設定 \\(\"theirs\", $1\\)"
+msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
-msgstr "リベースされたブランチ\"$1\"に設定 \\(\"ours\", $2\\)"
+msgstr ""
 
 msgctxt "dlgSgResolve.tle:"
 msgid "Resolve"
@@ -9783,12 +10914,24 @@ msgid "Send usage statistics"
 msgstr "使用状況の統計情報の送信"
 
 msgctxt "dlgSgSetup.chk:"
+msgid "Use SmartGit for authentication \\(ignoring your current credential.helper configuration\\)"
+msgstr ""
+
+msgctxt "dlgSgSetup.chk:"
 msgid "Use gravatar.com to show images for the users"
 msgstr "gravatar.comを使用してユーザーアイコンを表示する"
 
 msgctxt "dlgSgSetup.edt:"
 msgid "Email"
 msgstr "電子メール"
+
+msgctxt "dlgSgSetup.edt:"
+msgid "Full Name"
+msgstr ""
+
+msgctxt "dlgSgSetup.edt:"
+msgid "Git Email"
+msgstr ""
 
 msgctxt "dlgSgSetup.edt:"
 msgid "Git Executable"
@@ -9810,9 +10953,33 @@ msgctxt "dlgSgSetup.edt:"
 msgid "User Name"
 msgstr "ユーザ名"
 
+msgctxt "dlgSgSetup.hdl:"
+msgid "Git Executable"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "License"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "Privacy"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "Style"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "User Information"
+msgstr ""
+
 msgctxt "dlgSgSetup.inf:"
 msgid "If you are using SSH to connect to other Git repositories, select what SSH client to use. You can change it later in the Preferences."
 msgstr "SSHを使って他のGitリポジトリに接続する場合は、使用するSSHクライアントを選択します。この設定は後から「環境設定」で変更できます。"
+
+msgctxt "dlgSgSetup.inf:"
+msgid "Please review the following privacy options. You can change them later in the Preferences."
+msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
 msgid "Please review the following privacy options. You can change them later in the preferences."
@@ -9829,6 +10996,10 @@ msgstr "SmartGitは、お使いのシステムに互換性のあるGitがイン�
 msgctxt "dlgSgSetup.inf:"
 msgid "User name and email will be stored as part of your commits. Here you can configure the default values which are stored in .gitconfig."
 msgstr "ユーザー名とメールアドレスは、コミットの一部として保存されます。ここでは、.gitconfig に保存されるデフォルト値を設定することができます。"
+
+msgctxt "dlgSgSetup.inf:"
+msgid "User name and email will be stored as part of your commits. Here you can configure the default values which are stored in ~/.gitconfig."
+msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
 msgid "Welcome to SmartGit! Please confirm that you are accepting the license agreement."
@@ -9895,6 +11066,10 @@ msgid "may be harder to configure and use for new users, but is more flexible"
 msgstr "新しいユーザーにとっては設定や使い方が難しいかもしれませんが、より柔軟性があります。"
 
 msgctxt "dlgSgSetup.rbt:"
+msgid "Bundled Git"
+msgstr ""
+
+msgctxt "dlgSgSetup.rbt:"
 msgid "Commits \\(Log History\\)"
 msgstr "コミット \\(ログ履歴\\)"
 
@@ -9909,6 +11084,10 @@ msgstr "ロググラフ \\(コミット中心\\)"
 msgctxt "dlgSgSetup.rbt:"
 msgid "Non-commercial use only \\(most features, no support\\)"
 msgstr "非商用利用のみ （ほとんどの機能、サポートなし）"
+
+msgctxt "dlgSgSetup.rbt:"
+msgid "Other Git Executable:"
+msgstr ""
 
 msgctxt "dlgSgSetup.rbt:"
 msgid "Registered user, commercial use \\(all features, support\\)"
@@ -9947,8 +11126,8 @@ msgid "Use Standard Window"
 msgstr "スタンダードウィンドウを使用する"
 
 msgctxt "dlgSgSetupStdWnd.fur:"
-msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
-msgstr "初めてのGitユーザーまたは経験の浅い方には、スタンダードウィンドウをおすすめします。\\n\\n以前にSmartGitの古いバージョンを使用していた場合、スタンダードウィンドウが従来のものとは\\*異なる見た目\\*になっていることに驚かれるかもしれません。\\n以前のバージョンと同様の体験をしたい場合は、\\*ロググラフ\\* ウィンドウまたは \\*作業ツリー\\* ウィンドウを選択してみてください。"
+msgid "We recommend the Standard window for \\*new SmartGit users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
+msgstr ""
 
 msgctxt "dlgSgSetupStdWnd.hdl:"
 msgid "Do you want to use the Standard Window?"
@@ -10231,6 +11410,10 @@ msgid "Automatically save stash"
 msgstr "自動的にスタッシュを保存"
 
 msgctxt "dlgSgStashOnDemandConfirmation.fur:"
+msgid "Add Branch may require a clean working tree to complete successfully. After the Add Branch succeeded, the stashed local changes will be automatically reapplied."
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.fur:"
 msgid "Check Out may require a clean working tree to complete successfully. After the Check Out succeeded, the stashed local changes will be automatically reapplied."
 msgstr "チェックアウトを正常に完了するには、作業ツリーがクリーンである必要があります。チェックアウトが成功すると、スタッシュされたローカルの変更が自動的に再適用されます。"
 
@@ -10259,6 +11442,10 @@ msgid "Squash Commits may require a clean working tree to complete successfully.
 msgstr "コミットのスカッシュを正常に完了するには、作業ツリーがクリーンである必要があります。コミットのスカッシュが成功すると、スタッシュされたローカルの変更が自動的に再適用されます。"
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
+msgid "Do you want to save local changes to a stash and retry Add Branch?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "Do you want to save local changes to a stash and retry Check Out?"
 msgstr "ローカルの変更をスタッシュに保存して、チェックアウトを再試行しますか？"
 
@@ -10277,6 +11464,10 @@ msgstr "ローカルの変更をスタッシュに保存して、プルを再試
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "Do you want to save local changes to a stash and retry Reorder Commits?"
 msgstr "ローカルの変更をスタッシュに保存して、コミットの並べ替えを再試行しますか？"
+
+msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
+msgid "Do you want to save local changes to a stash and retry Squash Commits?"
+msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "Do you want to save untracked files to a stash and retry Edit Message?"
@@ -10303,16 +11494,44 @@ msgid "Checkout"
 msgstr "チェックアウト"
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Edit Message"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
 msgstr "プル"
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Reorder Commits"
+msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Reset"
 msgstr "リセット"
 
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Squash Commits"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.fur:"
+msgid "It might be hard or impossible to restore them!"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.hdl:"
+msgid "Do you really want to discard the local changes?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.tle:"
+msgid "Reset"
+msgstr ""
+
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
-msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
-msgstr "プルが完了したら、最新のスタッシュを手動で適用し、ローカルの変更を作業ツリーに戻す必要があります。"
+msgid "Once you have concluded the Reorder Commits, you should manually apply the latest stash to get your local changes back into the working tree."
+msgstr ""
 
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl:"
 msgid "Your local changes have been stashed away, but could not be reapplied."
@@ -10419,15 +11638,40 @@ msgid "Directory '$1' already exists."
 msgstr "ディレクトリ '$1' は既に存在します。"
 
 msgctxt "dlgSgSubmoduleAdd.err:"
+msgid "Please specify the URL of the remote repository or the path of the local repository that should be cloned."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.err:"
 msgid "Please specify the URL of the remote repository to be cloned."
 msgstr "クローンするリモートリポジトリの URL を指定してください。"
+
+msgctxt "dlgSgSubmoduleAdd.err:"
+msgid "The specified directory is not the root of a repository."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hdl:"
+msgid "Path"
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hdl:"
+msgid "Repository"
+msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.hnt:"
 msgid "No repository found."
 msgstr "リポジトリが見つかりませんでした。"
 
 msgctxt "dlgSgSubmoduleAdd.hnt:"
+msgid "No repository matches the entered filter."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hnt:"
 msgid "Searching ..."
+msgstr "検索中..."
+
+# [decode] msgid "Searching …"
+msgctxt "dlgSgSubmoduleAdd.hnt:"
+msgid "Searching \\u2026"
 msgstr "検索中..."
 
 msgctxt "dlgSgSubmoduleAdd.inf:"
@@ -10509,6 +11753,14 @@ msgstr "サブモジュールエントリが .git/config に追加されます�
 msgctxt "dlgSgSubmoduleInitAll.tle:"
 msgid "Initialize Submodule"
 msgstr "サブモジュールを初期化"
+
+msgctxt "dlgSgSubmoduleInitAllConfigured.fur:"
+msgid "You may now pull individual submodules or on the root directory to clone the configured repositories."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleInitAllConfigured.hdl:"
+msgid "Submodules have been configured."
+msgstr ""
 
 msgctxt "dlgSgSubmoduleInitGit.btn:"
 msgid "Initialize && Pull"
@@ -10626,9 +11878,25 @@ msgctxt "dlgSgSubmoduleUnregisterConfirm.fur:"
 msgid "All relevant files will be adjusted. Afterwards you will only need to perform a commit to finish the operation. To just skip the submodule from the working tree, use Deinit."
 msgstr "関連するすべてのファイルが調整されます。その後、操作を完了するにはコミットを実行するだけで済みます。作業ツリーからサブモジュールをスキップするには、Deinit を使用します。"
 
+msgctxt "dlgSgSubmoduleUnregisterConfirm.hdl:"
+msgid "Do you want to unregister submodule '$1'?"
+msgstr ""
+
 msgctxt "dlgSgSubmoduleUnregisterConfirm.tle:"
 msgid "Unregister Submodule"
 msgstr "サブモジュールの登録を解除"
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Configure"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Go Back"
+msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.chk:"
 msgid "Create local branch \\(for advanced operations\\)"
@@ -10651,12 +11919,65 @@ msgid "Local Path"
 msgstr "ローカルパス"
 
 msgctxt "dlgSgSubtreeAdd.edt:"
+msgid "Relative Path"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.edt:"
 msgid "Remote"
 msgstr "リモート"
 
 msgctxt "dlgSgSubtreeAdd.edt:"
 msgid "Repository URL"
 msgstr "リポジトリ URL"
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "A local branch with this name already exists. Use a different name."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Consecutive dots are not allowed."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Consecutive slashes are not allowed."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Directory '$1' already exists."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Enter the name of the local branch."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Please enter a valid relative path. The submodule will be created at this path inside the repository."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Please select a valid branch."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "The name must not contain control characters, space, ~, ^, :, ?, \\*, \\[, < or >."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.hdl:"
+msgid "Path"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.hdl:"
+msgid "Repository"
+msgstr ""
+
+# [decode] msgid "Searching …"
+msgctxt "dlgSgSubtreeAdd.hnt:"
+msgid "Searching \\u2026"
+msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.inf:"
 msgid "Provide the path where the subtree should be added relative to the outer repository root directory."
@@ -10666,9 +11987,17 @@ msgctxt "dlgSgSubtreeAdd.inf:"
 msgid "Specify the repository to clone as subtree."
 msgstr "サブツリーとしてクローンするリポジトリを指定します。"
 
+msgctxt "dlgSgSubtreeAdd.inf:"
+msgid "Specify the repository to clone as subtree.\\nTo configure multiple accounts of the same hosting provider, use the Preferences."
+msgstr ""
+
 msgctxt "dlgSgSubtreeAdd.lbl:"
 msgid "Local branches for subtrees will only be useful if you plan to use Subtree-Split and Subtree-Reset operations."
 msgstr "サブツリーのローカル ブランチは、Subtree-Split および Subtree-Reset を使用する予定がある場合にのみ役立ちます。"
+
+msgctxt "dlgSgSubtreeAdd.lbl:"
+msgid "Steps"
+msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.lbl:"
 msgid "e.g. https://user@server:port/path/to/repository"
@@ -10685,6 +12014,90 @@ msgstr "リモートリポジトリ"
 msgctxt "dlgSgSubtreeAdd.tle:"
 msgid "Add Subtree"
 msgstr "サブツリーを追加"
+
+msgctxt "dlgSgSubtreeAddSuccess.fur:"
+msgid "Subtree operations are now available in \\*Branches\\* and \\*Graph\\* view, for \\*$1\\* and refs belonging to the \\*$2\\* remote."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.fur:"
+msgid "Subtree operations are now available in \\*Branches\\* and \\*Graph\\* view, for refs belonging to the \\*$1\\* remote."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.hdl:"
+msgid "Subtree '$1' has been successfully added."
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.btn:"
+msgid "Merge"
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.fur:"
+msgid "Changes from '$1' will be merged into sub-directory '$2'."
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.hdl:"
+msgid "Do you want to merge subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.chk:"
+msgid "Annotate generated history with prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.chk:"
+msgid "Rejoin generated history \\(for more efficient future splits\\)"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.edt:"
+msgid "Prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.hdl:"
+msgid "Do you want to push back subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.inf:"
+msgid "HEAD changes from sub-directory '$1' will be rewritten onto '$2' and pushed back."
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.btn:"
+msgid "Reset"
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.fur:"
+msgid "This will reset the sub-directory '$1' in your main history to the same state as in the subtree history at '$2'.\\n\\nChanges in the sub-directory which are only present in your main history commits will be lost. Only use this operation after your changes have been merged into the subtree history!"
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.hdl:"
+msgid "Do you want to reset subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.chk:"
+msgid "Annotate generated history with prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.chk:"
+msgid "Rejoin generated history \\(for more efficient future splits\\)"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.edt:"
+msgid "Prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.edt:"
+msgid "Subtree-Branch to update"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.hdl:"
+msgid "Do you want to update subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.inf:"
+msgid "HEAD changes from sub-directory '$1' will be rewritten onto '$2'."
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.lbl:"
+msgid "The selected branch pointer will be set to the HEAD of the generated history."
+msgstr ""
 
 msgctxt "dlgSgSvnClientCertificate.btn:"
 msgid "Login"
@@ -10714,9 +12127,9 @@ msgctxt "dlgSgSvnClientCertificate.tle:"
 msgid "SVN Authentication"
 msgstr "SVN認証"
 
-msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
+msgctxt "dlgSgSvnClientCertificate.wrn:"
 msgid "Authentication to the SVN repository '$1' failed with error: $2'"
-msgstr "SVN リポジトリ '$1' への認証に失敗し、次のエラーが発生しました: '$2'"
+msgstr ""
 
 msgctxt "dlgSgSvnSslFingerprintChanged.btn:"
 msgid "Accept"
@@ -10881,6 +12294,10 @@ msgstr "キーボード ショートカット"
 msgctxt "dlgSgToolEdit.err:"
 msgid "Please enter the name for this command."
 msgstr "このコマンドの名前を入力してください。"
+
+msgctxt "dlgSgToolEdit.err:"
+msgid "Select the command which should be invoked."
+msgstr ""
 
 msgctxt "dlgSgToolEdit.hdl:"
 msgid "Edit external tool"
@@ -11170,6 +12587,254 @@ msgctxt "dlgShPushTrackingLocalSvnBranches.tle:"
 msgid "Push"
 msgstr "プッシュ"
 
+msgctxt "dlgStdCheckoutCommit.btn:"
+msgid "Add Branch && Checkout"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.edt:"
+msgid "Branch"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.hdl:"
+msgid "Add branch at commit $1"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.inf:"
+msgid "Enter the name of the local branch to create. It will be checked out."
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.rbt:"
+msgid "Checkout local branch:"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.rbt:"
+msgid "Create local branch:"
+msgstr ""
+
+msgctxt "dlgStdDiscard.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdDiscard.fur:"
+msgid "You won't be able to restore them."
+msgstr ""
+
+msgctxt "dlgStdDiscard.hdl:"
+msgid "Do you want to discard local changes?"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.fur:"
+msgid "You are about to delete untracked files permanently. This action cannot be undone."
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.hdl:"
+msgid "Do you want to delete untracked files?"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.tle:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.btn:"
+msgid "Confirm"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Feature Prefix"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Main Branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Main Branches"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.hdl:"
+msgid "Configure main and feature branches"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.hdl:"
+msgid "Configure main branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.inf:"
+msgid "Set the main branch for your repository and an optional prefix for feature branches."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.inf:"
+msgid "Set the main branch for your repository."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.lbl:"
+msgid "Example: develop, release-.\\*"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.lbl:"
+msgid "The 'main branch' represents the main development branch of your repository and serves as a foundation for releases. Usually it is named 'develop', 'master' or 'main'.\\n\\nBranches that are used to develop a single new feature, bugfix or other related changes \\(temporarily\\) isolated from the main branch are called 'feature branch' \\(or short 'feature'\\). They typically have a special name prefix, e.g. 'feature/'.\\n\\nNew features will be forked off from a main branch using 'Start'. For an existing feature, new changes from the main branch will be integrated using 'Integrate'. Once you have finished the feature, you can incorporate it into the main branch using 'Finish'.\\n\\nFor extended configuration options, invoke '\\u30d6\\u30e9\\u30f3\\u30c1 \\| Feature \\u306e\\u8a2d\\u5b9a'."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.ttp:"
+msgid "The <b>Feature Prefix</b> is optional. <tt>feature/</tt>is commonly used and compatible with Git-Flow."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.ttp:"
+msgid "You can configure one or more <b>Main Branches</b> by specifying their names separated by semicolon. To specify patterns instead of singular names, use regular expressions. For example: <tt>main,release-.\\*</tt>."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfigurationSimple.hdl:"
+msgid "'$1' has been configured as main branch and '$2' as feature-prefix."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.btn:"
+msgid "Select"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Create merge commit"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Delete feature branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Push results"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.edt:"
+msgid "Merge Message"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.hdl:"
+msgid "Finish feature '$1'"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.inf:"
+msgid "Choose how to finish the feature branch '$1'. This operation will integrate the feature branch into the '$2' branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.rbt:"
+msgid "Create Pull Request"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.rbt:"
+msgid "Finish to main branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinishFeatureEmpty.fur:"
+msgid "Your feature branch does not contain any new commits. Finishing now will simply remove the branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinishFeatureEmpty.hdl:"
+msgid "Feature branch is empty."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "Branch '$1' is ahead of '$2'.\\n\\nConsolidate the '$3'-branch, then invoke Integrate again."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "The feature branch has been rebased onto '$1'.\\n\\nYou may now verify and push the branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "The local feature branch has been rebased onto the remote branch '$1'.\\n\\nYou may now verify and push the branch, then invoke Integrate again."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Resolve diverged main branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Verify integrated main changes."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Verify integrated remote changes."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.lbl:"
+msgid "Steps"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.btn:"
+msgid "Start"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.edt:"
+msgid "Feature Name"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.hdl:"
+msgid "Start a new feature"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.inf:"
+msgid "Enter the name of the new feature branch. This operation will fork a new branch from '$1'."
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.lbl:"
+msgid "Resulting Branch: $1"
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.btn:"
+msgid "Switch Anyway"
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.fur:"
+msgid "Your working tree currently has local modifications, and you are not currently on the main branch. Initiating a new feature now will require switching commits, which can potentially fail due to the presence of local changes.\\n\\nThe recommended course of action is either to commit your local changes \\(if they pertain to the current branch\\) or stash them away in order to have a clean working tree before starting a new feature."
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.hdl:"
+msgid "Do you want to switch to a different branch despite having local changes?"
+msgstr ""
+
+msgctxt "dlgStdOutputCommandConflicts.fur:"
+msgid "These conflicts must be resolved before continuing. Select the conflicted files in the Local Files view and use the Conflict Solver to resolve them, then continue the operation."
+msgstr ""
+
+msgctxt "dlgStdOutputCommandConflicts.hdl:"
+msgid "SmartGit encountered conflicts during the Integrate main operation."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.fur:"
+msgid "Commit or stash local changes before cherry-picking."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.fur:"
+msgid "Commit or stash local changes before reverting."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.hdl:"
+msgid "The working tree contains local changes."
+msgstr ""
+
+msgctxt "dlgStdRemove.btn:"
+msgid "Delete Local Files"
+msgstr ""
+
+msgctxt "dlgStdRemove.btn:"
+msgid "Keep Local Files"
+msgstr ""
+
+msgctxt "dlgStdRemove.fur:"
+msgid "You can just remove the files from the repository \\(keeping the local files, e.g. to mark them later as ignored\\), or also delete the local files."
+msgstr ""
+
+msgctxt "dlgStdRemove.hdl:"
+msgid "How do you want to remove the files from the repository?"
+msgstr ""
+
 msgctxt "dlgTxtEditor.fileModified.btn:"
 msgid "Keep Content"
 msgstr "コンテンツを保持"
@@ -11183,8 +12848,8 @@ msgid "Unless you want to see the old file state, it is recommended to reload."
 msgstr "古いファイルの状態を見たいのでなければ、再読み込みすることをお勧めします。"
 
 msgctxt "dlgTxtEditor.fileModified.hdl:"
-msgid "The file config was changed. Reload it?"
-msgstr "ファイル構成が変更されました。再読み込みしますか？"
+msgid "The file $1 was changed. Reload it?"
+msgstr ""
 
 msgctxt "dlgTxtEditor.fileModified.tle:"
 msgid "Editor"
@@ -11291,6 +12956,10 @@ msgid "In case you are encountering strange errors or unexpected dialog popups, 
 msgstr "奇妙なエラーや予期せぬダイアログのポップアップが表示される場合は、この設定を無効にして、SmartGitに認証処理を任せてみてください。"
 
 msgctxt "ntmCredentialHelper:"
+msgid "In general this should be fine and is the recommended configuration when working with multiple Git clients. If unexpected credential popups or weird errors occur, try to let SmartGit handle the authentication itself."
+msgstr ""
+
+msgctxt "ntmCredentialHelper:"
 msgid "In general this should be fine and is the recommended configuration when working with multiple Git clients. In case you are encountering strange errors or unexpected dialog popups, try to disable this configuration and let SmartGit handle the authentication itself."
 msgstr "一般的にはこれで問題ありません。複数のGitクライアントを使用する場合には推奨される構成です。ただし、不明なエラーや予期しないダイアログのポップアップが表示される場合は、この構成を無効にして、SmartGitに認証を任せるようにしてみてください。"
 
@@ -11305,6 +12974,18 @@ msgstr "SmartGit は、設定ファイル $1 で<b>credential.helper</b>が設�
 msgctxt "ntmCredentialHelper:"
 msgid "To disable this configuration, open the above config file, locate the <b>\\[credential\\]</b>-section and comment out the <b>helper\\=</b> line using <b>#</b>"
 msgstr "この設定を無効にするには、上記の設定ファイルを開き、 <b>\\[credential\\]</b>セクションの<b>helper\\=</b>の行頭に<b>#</b>を付加してコメントアウトしてください。"
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Directory '$1' \\($2\\) has been excluded from file monitoring because it's listed in some .gitignore file."
+msgstr ""
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Sometimes ignored directories are containing tracked files in which case changes to these files might not show up automatically. If this is the case for you, you may disable this optimization by setting system property 'fileMonitor.excludeIgnoredDirectories\\=false'."
+msgstr ""
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Usually this does not cause any problems but improves Refreshing performance and reduces required inotify handles."
+msgstr ""
 
 msgctxt "ntmFollowUsOnTwitter:"
 msgid "<link1>Facebook</link1>: news"
@@ -11351,16 +13032,40 @@ msgid "poll for opinions on how to implement new or change existing features"
 msgstr "機能追加・変更に関する意見募集"
 
 msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Bluesky</link1>: news"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Bluesky</link1>: news, polls, discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
 msgid "<link1>Facebook</link1>: news"
 msgstr "<link1>Facebook</link1>: ニュース"
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Mastodon</link1>: news"
+msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
 msgid "<link1>Mastodon</link1>: news, polls, discussions"
 msgstr "<link1>Mastodon</link1>: ニュース、投票、ディスカッション"
 
 msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Reddit</link1>: discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>UserEcho</link1>: feature requests, voting"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
 msgid "<link1>UserEcho</link1>: improvement ideas, discussions"
 msgstr "<link1>UserEcho</link1>: 改善のアイデア、ディスカッション"
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>X</link1>: news"
+msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
 msgid "<link1>X</link1>: news, polls, discussions"
@@ -11391,6 +13096,10 @@ msgctxt "ntmHostingProviderIntegrationNotYetConfigured:"
 msgid "SmartGit provides special support for $1. The integration can be configured in the Preferences."
 msgstr "SmartGit は、$1 との連携に対応しています。連携機能は「環境設定」で設定することができます。"
 
+msgctxt "ntmLcTypeProblem:"
+msgid "If you experience problems with garbled file names/paths containing non-US-ASCII characters, consider to set the environment variables <tt>LC_ALL</tt>, or both <tt>LC_CTYPE</tt> and <tt>LANG</tt> to a country code which ends with \"<tt>.UTF-8</tt>\"."
+msgstr ""
+
 msgctxt "ntmMarkRepositoriesAsFavorite:"
 msgid "Git repositories marked as 'favorites' will be refreshed and fetched automatically in the background."
 msgstr "「お気に入り」としてマークされた Git リポジトリは、バックグラウンドで自動的に更新およびフェッチされます。"
@@ -11411,6 +13120,10 @@ msgctxt "ntmRepositoryGitCleanup:"
 msgid "The repository '$1' contains a significant amount of loose or even unused 'objects'. Running a cleanup will reduce disk space and increase performance. SmartGit will try to do so, when it is idle."
 msgstr "リポジトリ '$1' には、多数の loose objects や使用されていないオブジェクトが含まれています。クリーンアップを実行すると、ディスクスペースが節約され、パフォーマンスが向上します。SmartGitは、アイドル状態のときにこれを試みます。"
 
+msgctxt "ntmRepositoryRefsReadingManyLoose:"
+msgid "The repository '$1' contains many 'loose' refs which makes refreshing inefficient. Repacking the refs will improve performance."
+msgstr ""
+
 msgctxt "ntmSupportExpired:"
 msgid "To extend your support, please purchase an update license and upgrade to the latest SmartGit version."
 msgstr "サポートを延長するには、更新ライセンスを購入し、SmartGit の最新バージョンにアップグレードしてください。"
@@ -11419,9 +13132,23 @@ msgctxt "ntmSupportExpired:"
 msgid "You may continue to use SmartGit, just your support period expired."
 msgstr "サポート期間が終了しましたが、引き続きSmartGitを使用することができます。"
 
+msgctxt "ntmUpdateCheckChannelSubscribePolls:"
+msgid "Occasionally, you'll be invited to quick polls here in the notification area. Your feedback helps shape SmartGit's future. You can turn this off anytime in the Preferences."
+msgstr ""
+
 msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
 msgstr "新しいバージョンが正常にダウンロードされると、再度通知されます。"
+
+# TODO: Check if the variable range is correct.
+#| msgid "SmartGit 25.1.093 needs to be restarted now for the changes to take effect."
+msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+msgid "$1 needs to be restarted now for the changes to take effect."
+msgstr ""
+
+msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
+msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
 msgid "SmartGit needs to be restarted now for the changes to take effect."
@@ -11443,9 +13170,25 @@ msgctxt "ntmVoteForUs:"
 msgid "vote at <link1>alternativeto.net</link1>"
 msgstr "<link1>alternativeto.net</link1>で投票"
 
+msgctxt "ntmWslWorkaround:"
+msgid "To work around some problems with WSL, please check our documentation."
+msgstr ""
+
+msgctxt "nttCredentialHelper:"
+msgid "External Credential Helper detected"
+msgstr ""
+
 msgctxt "nttCredentialHelper:"
 msgid "External Credentials Helper detected"
 msgstr "外部の認証情報ヘルパーが検出されました"
+
+msgctxt "nttCredentialHelper:"
+msgid "Let SmartGit handle Authentication"
+msgstr ""
+
+msgctxt "nttFileMonitorDirectoriesExcluded:"
+msgid "Ignored directories are not monitored"
+msgstr ""
 
 msgctxt "nttFollowUsOnTwitter:"
 msgid "Follow SmartGit on Twitter!"
@@ -11471,6 +13214,10 @@ msgctxt "nttGeneral:"
 msgid "Remind me later"
 msgstr "後で通知する"
 
+msgctxt "nttGeneral:"
+msgid "Skip this Poll"
+msgstr ""
+
 msgctxt "nttHighMemoryUsage:"
 msgid "Contact Support"
 msgstr "サポートに連絡"
@@ -11486,6 +13233,10 @@ msgstr "$1との連携はまだ設定されていません。"
 msgctxt "nttHostingProviderIntegrationNotYetConfigured:"
 msgid "Configure Now"
 msgstr "今すぐ設定する"
+
+msgctxt "nttLcTypeProblem:"
+msgid "Experience problems with non-US-ASCII file names?"
+msgstr ""
 
 msgctxt "nttMarkRepositoriesAsFavorite:"
 msgid "Mark repositories as 'favorite' for automatic background refresh."
@@ -11519,6 +13270,18 @@ msgctxt "nttRepositoryGitCleanup:"
 msgid "Run Garbage Collector Now"
 msgstr "今すぐガベージコレクタを実行"
 
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Do not warn me again for this repository"
+msgstr ""
+
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Many loose refs"
+msgstr ""
+
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Repack"
+msgstr ""
+
 msgctxt "nttSupportExpired:"
 msgid "Purchase Update"
 msgstr "アップデートを購入"
@@ -11527,9 +13290,29 @@ msgctxt "nttSupportExpired:"
 msgid "Your support period has expired on $1."
 msgstr "$1 にサポート期間が終了しました。"
 
+msgctxt "nttUpdateCheck:"
+msgid "Quick Poll: $1"
+msgstr ""
+
+msgctxt "nttUpdateCheck:"
+msgid "Vote"
+msgstr ""
+
+msgctxt "nttUpdateCheckChannelSubscribePolls:"
+msgid "Turn on"
+msgstr ""
+
+msgctxt "nttUpdateCheckChannelSubscribePolls:"
+msgid "Want to influence SmartGit's development?"
+msgstr ""
+
 msgctxt "nttUpdateCheckFetchVersionStart:"
 msgid "Started downloading version $1 \\($2\\)."
 msgstr "バージョン $1 \\($2\\) のダウンロードを開始しました。"
+
+msgctxt "nttUpdateCheckFetchVersionStart:"
+msgid "Started downloading version $1."
+msgstr ""
 
 msgctxt "nttUpdateCheckFetchVersionSuccess:"
 msgid "Restart SmartGit"
@@ -11551,9 +13334,21 @@ msgctxt "nttVoteForUs:"
 msgid "What do you like in SmartGit?"
 msgstr "SmartGitのどこが好きですか？"
 
+msgctxt "nttWslWorkaround:"
+msgid "It seems that you're running SmartGit in WSL."
+msgstr ""
+
+msgctxt "nttWslWorkaround:"
+msgid "Open Documentation"
+msgstr ""
+
 msgctxt "pop:"
 msgid "$1 succeeded."
 msgstr "$1 が成功しました。"
+
+msgctxt "pop:"
+msgid "Already up-to-date"
+msgstr ""
 
 msgctxt "pop:"
 msgid "Command $1 has been aborted."
@@ -11598,6 +13393,10 @@ msgstr "名前を変更するスタッシュを選択します。"
 msgctxt "pop:"
 msgid "The dropped directory is no Git repository."
 msgstr "ドロップされたディレクトリは Git リポジトリではありません。"
+
+msgctxt "pop:"
+msgid "The working tree contains local changes."
+msgstr ""
 
 msgctxt "pop:"
 msgid "There are no obsolete repositories."
@@ -11647,21 +13446,21 @@ msgctxt "ttpBranches:"
 msgid "<b>Incoming</b> from repository <b>$1</b> branch <b>$2</b> to branch <b>$3</b>"
 msgstr "<b>受信中</b> リポジトリ <b>$1</b> のブランチ <b>$2</b> からブランチ <b>$3</b>"
 
-msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
+msgctxt "ttpBranches:"
 msgid "<b>Last Updated By: </b>$1"
-msgstr "<b>最終更新者: </b>$1"
+msgstr ""
 
 msgctxt "ttpBranches:"
 msgid "<b>Local Branch:\\t</b>$1"
 msgstr "<b>ローカルブランチ:\\t</b>$1"
 
-msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
+msgctxt "ttpBranches:"
 msgid "<b>On: </b>$1"
-msgstr "<b>On: </b>$1"
+msgstr ""
 
-msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
-msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
-msgstr "ブランチ <b>$1</b> からリポジトリ <b>$2</b> の<b>main</b>ブランチへ<b>送信</b>"
+msgctxt "ttpBranches:"
+msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>$3</b>"
+msgstr ""
 
 msgctxt "ttpBranches:"
 msgid "<b>Push Target:\\t</b>$1"
@@ -11738,6 +13537,10 @@ msgstr "<b>追跡状態:\\t</b>1 コミットをプッシュ可能"
 msgctxt "ttpBranches:"
 msgid "<b>Tracking State:\\t</b>identical"
 msgstr "<b>追跡状態:\\t</b>同一"
+
+msgctxt "ttpBranches:"
+msgid "<b>Worktree:\\t</b>$1"
+msgstr ""
 
 msgctxt "ttpBranches:"
 msgid "<b>\\t</b><col1>Tracking is configured in .git/config but the tracked branch is not present \\(any more\\)."
@@ -11840,6 +13643,10 @@ msgid "<b>Remotes:\\t</b>"
 msgstr "<b>リモート:\\t</b>"
 
 msgctxt "ttpRepositories:"
+msgid "<b>Tracked Branch:\\t</b>$1"
+msgstr ""
+
+msgctxt "ttpRepositories:"
 msgid "<b>Tracked Branch:\\t</b>$1<col1>$2</col1>"
 msgstr "<b>追跡対象のブランチ:\\t</b>$1<col1>$2</col1>"
 
@@ -11902,6 +13709,62 @@ msgstr "$1 のリポジトリが<b>見つかりません</b>"
 msgctxt "ttpRepositories:"
 msgid "The remote repository contains new commits."
 msgstr "リモートリポジトリには新しいコミットが含まれています。"
+
+msgctxt "wnd.mni:"
+msgid "About SmartGit"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Contact Support"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "License Agreement"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open File"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open in Terminal"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open in VSCode"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Reveal in Finder"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "SmartGit Website"
+msgstr ""
+
+msgctxt "wnd.mniBisectTryCommit:"
+msgid "Try Commit"
+msgstr ""
+
+msgctxt "wnd.mniFixCaseChange:"
+msgid "Fix Case-Change"
+msgstr ""
+
+msgctxt "wnd.mniIntegrateMain:"
+msgid "Integrate Main"
+msgstr ""
+
+msgctxt "wnd.mniShowInMyHistory:"
+msgid "Show in My History"
+msgstr ""
+
+msgctxt "wnd.mniWindow-maximize:"
+msgid "Zoom"
+msgstr ""
+
+msgctxt "wnd.mniWindowMaximizeRestore:"
+msgid "Maximize View"
+msgstr ""
 
 msgctxt "wndAnnotate.cmb:"
 msgid "Age"
@@ -12062,6 +13925,16 @@ msgstr "ドキュメント"
 msgctxt "wndAnnotate.tab:"
 msgid "History of current line"
 msgstr "現在の行の履歴"
+
+# $1: File Name $2 Relative path
+msgctxt "wndAnnotate.tle:"
+msgid "$1 - Blame of $2"
+msgstr ""
+
+# $1: File Name ,$2 Relative path ,$3:CommitID
+msgctxt "wndAnnotate.tle:"
+msgid "$1 - Blame of $2@$3"
+msgstr ""
 
 msgctxt "wndAnnotate.tle:"
 msgid "$1 - Blame"
@@ -12351,6 +14224,11 @@ msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame \\(in progress...\\)"
 msgstr "ブレーム\\(処理中…\\)"
 
+# [decode] msgid "Blame \(in progress…\)"
+msgctxt "wndDeepgit.lblBlameHeader:"
+msgid "Blame \\(in progress\\u2026\\)"
+msgstr "ブレーム\\(処理中…\\)"
+
 msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame for"
 msgstr "ブレーム"
@@ -12587,6 +14465,10 @@ msgctxt "wndDeepgit.mniDgFilterSetSelection:"
 msgid "Set Selection as Filter"
 msgstr "選択範囲をフィルターとして設定"
 
+msgctxt "wndDeepgit.mniDgFollowInsignificantMerges:"
+msgid "Follow Insignificant Merges \\(experimental\\)"
+msgstr ""
+
 msgctxt "wndDeepgit.mniDgFollowRenames:"
 msgid "Follow Renames"
 msgstr "リネームを追跡"
@@ -12748,7 +14630,16 @@ msgid "Files changed in commit $1"
 msgstr "コミット $1 で変更されたファイル"
 
 msgctxt "wndDeepgit.tab:"
+msgid "Files"
+msgstr ""
+
+msgctxt "wndDeepgit.tab:"
 msgid "Navigation \\(initializing...\\)"
+msgstr "ナビゲーション \\(初期化中...\\)"
+
+# [decode] msgid "Navigation \(initializing…\)"
+msgctxt "wndDeepgit.tab:"
+msgid "Navigation \\(initializing\\u2026\\)"
 msgstr "ナビゲーション \\(初期化中...\\)"
 
 msgctxt "wndDeepgit.tab:"
@@ -12883,6 +14774,10 @@ msgctxt "wndEditor.mni:"
 msgid "LF \\(Unix, macOS\\)"
 msgstr "LF \\(Unix, macOS\\)"
 
+msgctxt "wndEditor.mniBlockSelection:"
+msgid "Block Selection"
+msgstr ""
+
 msgctxt "wndEditor.mniEdit-undo:"
 msgid "Undo"
 msgstr "元に戻す"
@@ -12934,6 +14829,10 @@ msgstr "行内の変更をステージ"
 msgctxt "wndGit.indexEditor.mni:"
 msgid "Stage Line"
 msgstr "行をステージ"
+
+msgctxt "wndGit.indexEditor.mni:"
+msgid "Stage Lines"
+msgstr ""
 
 msgctxt "wndGit.indexEditor.mni:"
 msgid "Stage Selection"
@@ -13012,20 +14911,157 @@ msgid "$1 - Index Editor"
 msgstr "$1 - index エディタ"
 
 msgctxt "wndLog.hnt:"
+msgid "No commit matches the filter."
+msgstr ""
+
+msgctxt "wndLog.hnt:"
 msgid "No graph roots selected."
 msgstr "グラフのルートが選択されていません。"
+
+msgctxt "wndLog.mni:"
+msgid "Add $1 Git repositories to Group '$2'"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Continue in Background"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Continue with Description"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Copy Name <email>"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Drop All Notes"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Explain Commit"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "On Manual Intervention"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Reconfigure"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Reword '@ai' and 'WIP' commits"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Stop"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "generate \\(active\\)"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "github \\(active\\)"
+msgstr ""
+
+msgctxt "wndLog.mniCopyCommitId:"
+msgid "Copy"
+msgstr ""
 
 msgctxt "wndLog.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr "大文字小文字の修正"
 
+msgctxt "wndLog.mniGitNoteAdd:"
+msgid "Add Note"
+msgstr ""
+
+# [decode] msgid "Graph \(Initializing Subtree-Cache…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Initializing Subtree-Cache\\u2026\\)"
+msgstr ""
+
+# [decode] msgid "Graph \(Loading…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Loading\\u2026\\)"
+msgstr ""
+
+# [decode] msgid "Graph \(Running log…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Running log\\u2026\\)"
+msgstr ""
+
+# [decode] msgid "Graph \(Scanning WT…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Scanning WT\\u2026\\)"
+msgstr ""
+
+msgctxt "wndLog.tbt:"
+msgid "Hidden toolbar items..."
+msgstr ""
+
 msgctxt "wndLog.tbt:"
 msgid "Refresh information from GitHub."
 msgstr "GitHub から情報を更新します。"
 
+#| msgid "Rewording 1 commits\\u2026"
+msgctxt "wndLog.tbtAi.commitMessageCompose:"
+msgid "Rewording $1 commits\\u2026"
+msgstr ""
+
+msgctxt "wndLog.tbtFlowContext:"
+msgid "Start a new Git-Flow feature."
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Base"
+msgstr ""
+
 msgctxt "wndProject.mni:"
 msgid "Log Selection"
 msgstr "選択項目の履歴"
+
+msgctxt "wndProject.mni:"
+msgid "New_key"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "PR_Review"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Review_Tool"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Show Rewritten Behind Commits"
+msgstr ""
+
+msgctxt "wndProject.mniCopyCommitId:"
+msgid "Copy"
+msgstr ""
+
+msgctxt "wndProject.mniFixCaseChange:"
+msgid "Fix Case-Change"
+msgstr ""
+
+msgctxt "wndProject.mniOpen:"
+msgid "Open"
+msgstr ""
 
 msgctxt "wndStd.btn:"
 msgid "Compare"
@@ -13056,8 +15092,25 @@ msgid "Commit files: select 1 commit\\nDiff between Commits: select 2 commits"
 msgstr "コミットするファイル: コミットを 1 つ選択\\nコミット間の差分: コミットを 2 つ選択"
 
 msgctxt "wndStd.hnt:"
+msgid "Filter by repository name or path"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
 msgid "Loading ..."
 msgstr "読み込み中…"
+
+# [decode] msgid "Loading …"
+msgctxt "wndStd.hnt:"
+msgid "Loading \\u2026"
+msgstr "読み込み中…"
+
+msgctxt "wndStd.hnt:"
+msgid "No files below the selected directory"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "No graph roots selected."
+msgstr ""
 
 msgctxt "wndStd.hnt:"
 msgid "No locally changed files below the selected directory"
@@ -13066,6 +15119,14 @@ msgstr "選択したディレクトリの下に変更されたローカルファ
 msgctxt "wndStd.hnt:"
 msgid "No locally changed files"
 msgstr "ローカルで変更されたファイルはありません"
+
+msgctxt "wndStd.hnt:"
+msgid "The repository's\\nreflog is empty."
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "This repository has\\nno stashes yet."
+msgstr ""
 
 msgctxt "wndStd.lbl:"
 msgid "Force Compare"
@@ -13100,6 +15161,10 @@ msgid "All files, incl. ignored"
 msgstr "すべてのファイル (無視されたファイルを含む)"
 
 msgctxt "wndStd.mni:"
+msgid "All my branches"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Apply Stash"
 msgstr "スタッシュを適用"
 
@@ -13110,6 +15175,38 @@ msgstr "注釈"
 msgctxt "wndStd.mni:"
 msgid "Changed files"
 msgstr "変更されたファイル"
+
+msgctxt "wndStd.mni:"
+msgid "Close Others"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Close to the Right"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Continue in Background"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Continue with Description"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Copy Path"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Don't Show Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Drop All Notes"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Explain Commit"
+msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Fetch All"
@@ -13132,12 +15229,24 @@ msgid "Log"
 msgstr "ログ"
 
 msgctxt "wndStd.mni:"
-msgid "On master: SmartGit: automatic stash on Pull."
-msgstr "masterブランチ: SmartGit: プル時に自動スタッシュ"
+msgid "On $1: SmartGit: automatic stash on Pull."
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "On Manual Intervention"
+msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Only current branch \\(HEAD\\)"
 msgstr "現在のブランチのみ \\(HEAD\\)"
+
+msgctxt "wndStd.mni:"
+msgid "Open in GitHub"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Open"
+msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Rebase"
@@ -13156,8 +15265,32 @@ msgid "Reset"
 msgstr "リセット"
 
 msgctxt "wndStd.mni:"
+msgid "Reword '@ai' and 'WIP' commits"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Save Stash"
 msgstr "スタッシュに保存"
+
+msgctxt "wndStd.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show 'My' Pull Requests \\(involving me\\)"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show 'My' and Unassigned Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show All Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show Tags"
+msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Sort by File Name"
@@ -13167,6 +15300,10 @@ msgctxt "wndStd.mni:"
 msgid "Sort by Path"
 msgstr "パスで並べ替え"
 
+msgctxt "wndStd.mni:"
+msgid "Stop"
+msgstr ""
+
 msgctxt "wndStd.mniBisectTryCommit:"
 msgid "Try Commit"
 msgstr "コミットを試行"
@@ -13175,9 +15312,21 @@ msgctxt "wndStd.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr "大文字小文字の変更を修正"
 
+msgctxt "wndStd.mniGitNoteAdd:"
+msgid "Add Note"
+msgstr ""
+
+msgctxt "wndStd.mniIndexEditor:"
+msgid "Edit in Index Editor"
+msgstr ""
+
 msgctxt "wndStd.mniIntegrateMain:"
 msgid "Integrate Main"
 msgstr "メインを統合"
+
+msgctxt "wndStd.mniStdCiResultOpenInBrowser:"
+msgid "Open CI Result"
+msgstr ""
 
 msgctxt "wndStd.mniStdOpenSubmodule:"
 msgid "Open a Submodule"
@@ -13186,6 +15335,18 @@ msgstr "サブモジュールを開く"
 msgctxt "wndStd.mniStdOpenSubmoduleFromFile:"
 msgid "Open this Submodule"
 msgstr "このサブモジュールを開く"
+
+msgctxt "wndStd.mniStdProviderOpenFileInBrowser:"
+msgid "Open in GitHub"
+msgstr ""
+
+msgctxt "wndStd.mniStdProviderOpenInBrowser:"
+msgid "Open in $1"
+msgstr ""
+
+msgctxt "wndStd.mniStdProviderOpenRefInBrowser:"
+msgid "Open in GitHub"
+msgstr ""
 
 msgctxt "wndStd.mniStdSetModeHistory:"
 msgid "Show History"
@@ -13203,13 +15364,33 @@ msgctxt "wndStd.tbr:"
 msgid "Submodule"
 msgstr "サブモジュール"
 
+msgctxt "wndStd.tbt:"
+msgid "History"
+msgstr ""
+
+msgctxt "wndStd.tbt:"
+msgid "Show filter input field."
+msgstr ""
+
+msgctxt "wndStd.tbtFlowFeatureFinish:"
+msgid "Finish the current feature branch."
+msgstr ""
+
 msgctxt "wndStd.tbtFlowFeatureStart:"
 msgid "Start a new feature branch."
 msgstr "新しいフィーチャーブランチを開始します。"
 
+msgctxt "wndStd.tbtIntegrateMain:"
+msgid "Integrate latest changes from the main branch into the current feature branch."
+msgstr ""
+
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).lblStatusBarMessage:"
 msgid "Ready"
 msgstr "準備完了"
+
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
+msgid "Enter Full Screen"
+msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
 msgid "Full Screen"
@@ -13218,6 +15399,10 @@ msgstr "フルスクリーン"
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
 msgid "Maximize"
 msgstr "最大化"
+
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
+msgid "Zoom"
+msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore:"
 msgid "Restore"
@@ -13726,10 +15911,6 @@ msgstr "ファイル"
 msgctxt "wnd(Log|Project|Std|).lbl:"
 msgid "Files"
 msgstr "ファイル"
-
-msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
-msgid "Show Rewritten Behind Commits"
-msgstr "コミット後に書き換えられたものを表示"
 
 msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "<no entry>"
@@ -14378,6 +16559,10 @@ msgstr "選択されたブランチとタグのみ表示"
 msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Show Only Selected Refs"
 msgstr "選択されたRefのみ表示"
+
+msgctxt "wnd(Log|Project|Std|).mni:"
+msgid "Show Rewritten Behind Commits"
+msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Show Unchanged Directories"
@@ -15787,10 +17972,6 @@ msgctxt "wnd(Log|Project|Std|).tab:"
 msgid "Repositories"
 msgstr "リポジトリ"
 
-msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
-msgid "History"
-msgstr "履歴"
-
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Add Branch"
 msgstr "ブランチを追加"
@@ -15874,6 +18055,10 @@ msgstr "完了"
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Git-Flow"
 msgstr "Git-Flow"
+
+msgctxt "wnd(Log|Project|Std|).tbr:"
+msgid "History"
+msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Ignore WS"
@@ -16299,9 +18484,17 @@ msgctxt "wnd(Log|Project|Std|).tle:"
 msgid "$1 \\[$2\\] - Log for $3"
 msgstr "$1 \\[$2\\] - $3 のログ"
 
+msgctxt "wnd(Log|Std|).mniOpen:"
+msgid "Open from Working Tree"
+msgstr ""
+
 #~ msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 #~ msgid "\\[$1\\] - $2"
 #~ msgstr "\\[$1\\] - $2"
+
+#~ msgctxt "dlgSgAbortRebasingConfirm.fur:"
+#~ msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
+#~ msgstr "作業ツリーは「リベース中」の状態です。リベースを中止できます。現在のパッチをスキップしたい場合は、代わりに\\[ブランチ\\]→\\[リベース\\]→\\[リベース HEAD to\\] を使用してください。\\n\\n中止すると、ローカルの変更を消去することができます。\\('git reset --hard' の実行\\）"
 
 #~ msgctxt "dlgSgAbortRevertingConfirm.hdl"
 #~ msgid "Do you want to abort the current revert?"
@@ -16311,9 +18504,23 @@ msgstr "$1 \\[$2\\] - $3 のログ"
 #~ msgid "Discard"
 #~ msgstr "破棄"
 
+#~ msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
+#~ msgid "Skip large files \\(\"partial clone\"\\)"
+#~ msgstr "大きなファイルをスキップする \\(\"partial clone\"\\)"
+
+#~ msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
+#~ msgid "Simple commit \\(one parent, \"squash\"\\)"
+#~ msgstr "シンプルなコミット \\(一つの親 、\"スカッシュ\" \\)"
+
 #~ msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
 #~ msgid "\\[$1\\] - \\[$2\\] - $3"
 #~ msgstr "\\[$1\\] - \\[$2\\] - $3"
+
+# Needs review: Check whether the URL needs to be made variable
+#, fuzzy
+#~ msgctxt "dlgSgErrorUtilsClientException.fur:"
+#~ msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
+#~ msgstr "サーバーが URL: https://gitlab.com/oauth/token に対して HTTP 応答コード: 400 を返しました"
 
 #~ msgctxt "dlgSgFlowHotfixFinish.hdl"
 #~ msgid "Finish a hotfix"
@@ -16343,10 +18550,74 @@ msgstr "$1 \\[$2\\] - $3 のログ"
 #~ msgid "Your browser should have opened automatically, let you authenticate with your preferred account at $1 and grant access to SmartGit. If this didn't happen, manually open following link:"
 #~ msgstr "ブラウザが自動的に開き、$1のアカウントで認証を行い、SmartGitへのアクセスを許可します。自動的に開かなかった場合は、以下のリンクを手動で開いてください："
 
+#~ msgctxt "dlgSgPushForced.hdl:"
+#~ msgid "Do you want to force-push \\(replace\\) the remote branch?"
+#~ msgstr "リモートブランチを強制プッシュ（置き換え）しますか？"
+
+#~ msgctxt "dlgSgRepositorySettings.inf:"
+#~ msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
+#~ msgstr "ここでは、このリポジトリ用のGit設定を編集することができます。デフォルトの設定は「環境設定」にあります。"
+
 #~ msgctxt "dlgSgResetAdv.inf"
 #~ msgid "Reset the current branch (HEAD) to the selected commit and optionally update Index and working tree."
 #~ msgstr ""
 
+#~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
+#~ msgid "Set to $1 \\(\"ours\", $2\\)"
+#~ msgstr "$1 に設定\\(\"ours\", $2\\)"
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
+#~ msgid "Set to $1 \\(\"theirs\", $2\\)"
+#~ msgstr "$1 に設定\\(\"theirs\", $2\\)"
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
+#~ msgid "Set to rebase target \\(\"theirs\", $1\\)"
+#~ msgstr "リベースターゲットに設定 \\(\"theirs\", $1\\)"
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
+#~ msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
+#~ msgstr "リベースされたブランチ\"$1\"に設定 \\(\"ours\", $2\\)"
+
 #~ msgctxt "dlgSgRevealCommitLocalOrTracked.tle"
 #~ msgid "Reveal Commit"
 #~ msgstr "コミットを表示する"
+
+#~ msgctxt "dlgSgSetupStdWnd.fur:"
+#~ msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
+#~ msgstr "初めてのGitユーザーまたは経験の浅い方には、スタンダードウィンドウをおすすめします。\\n\\n以前にSmartGitの古いバージョンを使用していた場合、スタンダードウィンドウが従来のものとは\\*異なる見た目\\*になっていることに驚かれるかもしれません。\\n以前のバージョンと同様の体験をしたい場合は、\\*ロググラフ\\* ウィンドウまたは \\*作業ツリー\\* ウィンドウを選択してみてください。"
+
+#~ msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
+#~ msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
+#~ msgstr "プルが完了したら、最新のスタッシュを手動で適用し、ローカルの変更を作業ツリーに戻す必要があります。"
+
+#~ msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
+#~ msgid "Authentication to the SVN repository '$1' failed with error: $2'"
+#~ msgstr "SVN リポジトリ '$1' への認証に失敗し、次のエラーが発生しました: '$2'"
+
+#~ msgctxt "dlgTxtEditor.fileModified.hdl:"
+#~ msgid "The file config was changed. Reload it?"
+#~ msgstr "ファイル構成が変更されました。再読み込みしますか？"
+
+#~ msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
+#~ msgid "<b>Last Updated By: </b>$1"
+#~ msgstr "<b>最終更新者: </b>$1"
+
+#~ msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
+#~ msgid "<b>On: </b>$1"
+#~ msgstr "<b>On: </b>$1"
+
+#~ msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
+#~ msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
+#~ msgstr "ブランチ <b>$1</b> からリポジトリ <b>$2</b> の<b>main</b>ブランチへ<b>送信</b>"
+
+#~ msgctxt "wndStd.mni:"
+#~ msgid "On master: SmartGit: automatic stash on Pull."
+#~ msgstr "masterブランチ: SmartGit: プル時に自動スタッシュ"
+
+#~ msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
+#~ msgid "Show Rewritten Behind Commits"
+#~ msgstr "コミット後に書き換えられたものを表示"
+
+#~ msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
+#~ msgid "History"
+#~ msgstr "履歴"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -101,19 +101,19 @@ msgctxt "dlgCommit.replaceMessage.btn:"
 msgid "Replace"
 msgstr ""
 
-msgctxt "dlgCommit.replaceMessage.chk"
+msgctxt "dlgCommit.replaceMessage.chk:"
 msgid "Always replace"
 msgstr ""
 
-msgctxt "dlgCommit.replaceMessage.fur"
+msgctxt "dlgCommit.replaceMessage.fur:"
 msgid "After replacing you can find the previous message when clicking the history button."
 msgstr ""
 
-msgctxt "dlgCommit.replaceMessage.hdl"
+msgctxt "dlgCommit.replaceMessage.hdl:"
 msgid "Replace the existing message?"
 msgstr ""
 
-msgctxt "dlgCommit.replaceMessage.tle"
+msgctxt "dlgCommit.replaceMessage.tle:"
 msgid "Replace Message"
 msgstr ""
 
@@ -121,11 +121,11 @@ msgctxt "dlgCommitGitHubConfirmEmail.btn:"
 msgid "Confirm Email"
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.fur"
+msgctxt "dlgCommitGitHubConfirmEmail.fur:"
 msgid "If this repository is open-source, you might want to hide your email address, as \\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\], and use instead <username>@users.noreply.github.com."
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.hdl%1"
+msgctxt "dlgCommitGitHubConfirmEmail.hdl%1:"
 msgid "Commit with default email address $1?"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgctxt "dlgCommitGitHubConfirmEmail.rbt:"
 msgid "Use following email address:"
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.tle"
+msgctxt "dlgCommitGitHubConfirmEmail.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -149,46 +149,46 @@ msgctxt "dlgCommitInvisibleIndex.btn:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "dlgCommitInvisibleIndex.fur"
+msgctxt "dlgCommitInvisibleIndex.fur:"
 msgid "Some staged files are not visible at the moment."
 msgstr ""
 
-msgctxt "dlgCommitInvisibleIndex.hdl"
+msgctxt "dlgCommitInvisibleIndex.hdl:"
 msgid "Commit invisible staged files?"
 msgstr ""
 
-msgctxt "dlgCommitInvisibleIndex.tle"
+msgctxt "dlgCommitInvisibleIndex.tle:"
 msgid "Commit"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgCommitNoEmailConfigured.fur"
+msgctxt "dlgCommitNoEmailConfigured.fur:"
 msgid "Before committing you will have to configure your name and email, e.g. in the SmartGit Preferences."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgCommitNoEmailConfigured.hdl"
+msgctxt "dlgCommitNoEmailConfigured.hdl:"
 msgid "Please configure the email for commit."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgCommitNoEmailConfigured.tle"
+msgctxt "dlgCommitNoEmailConfigured.tle:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.chk"
+msgctxt "dlgCommitView.hiddenOptions.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.fur"
+msgctxt "dlgCommitView.hiddenOptions.fur:"
 msgid "To use the options, they need to remain visible."
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.hdl"
+msgctxt "dlgCommitView.hiddenOptions.hdl:"
 msgid "Hidden options will be treated as unselected."
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.tle"
+msgctxt "dlgCommitView.hiddenOptions.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -232,27 +232,27 @@ msgctxt "dlgDgAbout.tab:"
 msgid "Licensee"
 msgstr ""
 
-msgctxt "dlgDgAbout.tle"
+msgctxt "dlgDgAbout.tle:"
 msgid "About DeepGit"
 msgstr ""
 
-msgctxt "dlgDgClientException.hdl"
+msgctxt "dlgDgClientException.hdl:"
 msgid "Executing a command has failed."
 msgstr ""
 
-msgctxt "dlgDgClientException.tle"
+msgctxt "dlgDgClientException.tle:"
 msgid "Command Failed"
 msgstr ""
 
-msgctxt "dlgDgRefMapperGroupConfig.hdl"
+msgctxt "dlgDgRefMapperGroupConfig.hdl:"
 msgid "Configure patterns for grouping tags of this repository"
 msgstr ""
 
-msgctxt "dlgDgRefMapperGroupConfig.inf"
+msgctxt "dlgDgRefMapperGroupConfig.inf:"
 msgid "Tags, branches and other refs matched by this configuration will be displayed in the Navigation graph."
 msgstr ""
 
-msgctxt "dlgDgRefMapperGroupConfig.tle"
+msgctxt "dlgDgRefMapperGroupConfig.tle:"
 msgid "Configure Tag-Grouping"
 msgstr ""
 
@@ -260,27 +260,27 @@ msgctxt "dlgDgSetEncoding.edt:"
 msgid "Text File Encoding"
 msgstr ""
 
-msgctxt "dlgDgSetEncoding.hdl"
+msgctxt "dlgDgSetEncoding.hdl:"
 msgid "Configure Encoding"
 msgstr ""
 
-msgctxt "dlgDgSetEncoding.inf"
+msgctxt "dlgDgSetEncoding.inf:"
 msgid "Specify the encoding which should be used for processing and viewing files. Note, that UTF-8 encoding will be auto-detected, regardless of the configuration here."
 msgstr ""
 
-msgctxt "dlgDgSetEncoding.tle"
+msgctxt "dlgDgSetEncoding.tle:"
 msgid "Set Encoding"
 msgstr ""
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.fur"
+msgctxt "dlgDgSetPerspectiveCantSwitch.fur:"
 msgid "In order to inspect available Origins, they have to be evaluated first. Select a line in the Blame view. Then wait until the calculation of possible Origins has finished."
 msgstr ""
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.hdl"
+msgctxt "dlgDgSetPerspectiveCantSwitch.hdl:"
 msgid "Can't switch perspective."
 msgstr ""
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.tle"
+msgctxt "dlgDgSetPerspectiveCantSwitch.tle:"
 msgid "Origins Perspective"
 msgstr ""
 
@@ -288,15 +288,15 @@ msgctxt "dlgHostingProvider.canBeConfigured.btn:"
 msgid "Configure Hosting Provider"
 msgstr ""
 
-msgctxt "dlgHostingProvider.canBeConfigured.fur"
+msgctxt "dlgHostingProvider.canBeConfigured.fur:"
 msgid "The easiest way to access the repository at $1 is through a hosting provider."
 msgstr ""
 
-msgctxt "dlgHostingProvider.canBeConfigured.hdl"
+msgctxt "dlgHostingProvider.canBeConfigured.hdl:"
 msgid "Do you want to configure a GitLab hosting provider?"
 msgstr ""
 
-msgctxt "dlgInfo.tle"
+msgctxt "dlgInfo.tle:"
 msgid "Discard"
 msgstr ""
 
@@ -358,15 +358,15 @@ msgctxt "dlgProgress.tle:"
 msgid "Verifying executables"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.fur%1"
+msgctxt "dlgQBugFileSendingFailed.fur%1:"
 msgid "Maybe you need to configure a proxy or our server is temporarily down.\\nDetails: $1"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.hdl%1"
+msgctxt "dlgQBugFileSendingFailed.hdl%1:"
 msgid "Could not send the crash logs to $1"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.tle"
+msgctxt "dlgQBugFileSendingFailed.tle:"
 msgid "Native Crash Logs"
 msgstr ""
 
@@ -422,23 +422,23 @@ msgctxt "dlgQBugReportSend.lbl:"
 msgid "What did you do? We often solve a difficult bug after receiving just one good hint!"
 msgstr ""
 
-msgctxt "dlgQBugReportSend.tle"
+msgctxt "dlgQBugReportSend.tle:"
 msgid "Internal Error"
 msgstr ""
 
-msgctxt "dlgQDockManagerClosedView.chk"
+msgctxt "dlgQDockManagerClosedView.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgQDockManagerClosedView.fur"
+msgctxt "dlgQDockManagerClosedView.fur:"
 msgid "To reopen it again, use the corresponding menu item from the Window menu."
 msgstr ""
 
-msgctxt "dlgQDockManagerClosedView.hdl%1"
+msgctxt "dlgQDockManagerClosedView.hdl%1:"
 msgid "You've closed the view '$1'."
 msgstr ""
 
-msgctxt "dlgQDockManagerClosedView.tle"
+msgctxt "dlgQDockManagerClosedView.tle:"
 msgid "Closed View"
 msgstr ""
 
@@ -446,15 +446,15 @@ msgctxt "dlgQFileSaveAcceptFilterOverwrite.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur:"
 msgid "To save to a different file, click 'Cancel'."
 msgstr ""
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl%1"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl%1:"
 msgid "The file $1 already exists. Do you want to overwrite it?"
 msgstr ""
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.tle"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.tle:"
 msgid "Overwrite File"
 msgstr ""
 
@@ -474,23 +474,23 @@ msgctxt "dlgQFrameManagerExit.fur:"
 msgid "There are unsaved changes which would be lost when exiting now!"
 msgstr ""
 
-msgctxt "dlgQFrameManagerExit.hdl"
+msgctxt "dlgQFrameManagerExit.hdl:"
 msgid "Do you really want to exit SmartGit?"
 msgstr ""
 
-msgctxt "dlgQFrameManagerExit.tle"
+msgctxt "dlgQFrameManagerExit.tle:"
 msgid "Exit"
 msgstr ""
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.fur%2"
+msgctxt "dlgQIntegerInputProviderInvalidValue.fur%2:"
 msgid "Port must be in the range from $1 to $2."
 msgstr ""
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.hdl%1"
+msgctxt "dlgQIntegerInputProviderInvalidValue.hdl%1:"
 msgid "The text in field '$1' is not valid."
 msgstr ""
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.tle"
+msgctxt "dlgQIntegerInputProviderInvalidValue.tle:"
 msgid "Input Validation"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgctxt "dlgQProxyConfigure.rbt:"
 msgid "Use following proxy"
 msgstr ""
 
-msgctxt "dlgQProxyConfigure.tle"
+msgctxt "dlgQProxyConfigure.tle:"
 msgid "Configure Proxy"
 msgstr ""
 
@@ -542,15 +542,15 @@ msgctxt "dlgQProxyConnectionFailed.btn:"
 msgid "Retry"
 msgstr ""
 
-msgctxt "dlgQProxyConnectionFailed.fur"
+msgctxt "dlgQProxyConnectionFailed.fur:"
 msgid "Details: syntevo.com"
 msgstr ""
 
-msgctxt "dlgQProxyConnectionFailed.hdl%1"
+msgctxt "dlgQProxyConnectionFailed.hdl%1:"
 msgid "Could not connect to $1."
 msgstr ""
 
-msgctxt "dlgQProxyConnectionFailed.tle"
+msgctxt "dlgQProxyConnectionFailed.tle:"
 msgid "Connection Failed"
 msgstr ""
 
@@ -570,27 +570,27 @@ msgctxt "dlgQUpdateCheckForNewVersion.btn:"
 msgid "Skip"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersion.hdl"
+msgctxt "dlgQUpdateCheckForNewVersion.hdl:"
 msgid "SmartGit needs to check for updates"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersion.inf"
+msgctxt "dlgQUpdateCheckForNewVersion.inf:"
 msgid "If necessary, please configure the proxy and retry."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersion.tle"
+msgctxt "dlgQUpdateCheckForNewVersion.tle:"
 msgid "Check for New Version"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.fur%1"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.fur%1:"
 msgid "Details: Failed to connect to '$1'."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.hdl"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.hdl:"
 msgid "Checking for new versions has failed."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.tle"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.tle:"
 msgid "Check for New Version"
 msgstr ""
 
@@ -598,27 +598,27 @@ msgctxt "dlgQUpdateCheckLatestBuild.btn:"
 msgid "Get Latest Build"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckLatestBuild.fur"
+msgctxt "dlgQUpdateCheckLatestBuild.fur:"
 msgid "Only use the latest build if requested by the support team."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckLatestBuild.hdl"
+msgctxt "dlgQUpdateCheckLatestBuild.hdl:"
 msgid "Do you want to download the latest build?"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckLatestBuild.tle"
+msgctxt "dlgQUpdateCheckLatestBuild.tle:"
 msgid "Check for Latest Build"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur%1"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur%1:"
 msgid "Details: $1"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.hdl"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.hdl:"
 msgid "Initializing upgrade failed."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.tle"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.tle:"
 msgid "Check for Latest Build"
 msgstr ""
 
@@ -626,39 +626,39 @@ msgctxt "dlgQUpdateCheckNewVersion.btn:"
 msgid "Download"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNewVersion.fur"
+msgctxt "dlgQUpdateCheckNewVersion.fur:"
 msgid "It's recommended to update to the new version."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNewVersion.hdl"
+msgctxt "dlgQUpdateCheckNewVersion.hdl:"
 msgid "A new version of SmartGit is available."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNewVersion.tle"
+msgctxt "dlgQUpdateCheckNewVersion.tle:"
 msgid "Check for New Version"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.fur"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.fur:"
 msgid "You are already using the latest build."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.hdl"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.hdl:"
 msgid "No newer build found."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.tle"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.tle:"
 msgid "Check for Latest Build"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.fur"
+msgctxt "dlgQUpdateCheckNowNewerVersion.fur:"
 msgid "You are already using the latest version."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.hdl"
+msgctxt "dlgQUpdateCheckNowNewerVersion.hdl:"
 msgid "No newer version found."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.tle"
+msgctxt "dlgQUpdateCheckNowNewerVersion.tle:"
 msgid "Check for New Version"
 msgstr ""
 
@@ -686,15 +686,15 @@ msgctxt "dlgRewriteTextFiles.edt:"
 msgid "Line-Endings"
 msgstr ""
 
-msgctxt "dlgRewriteTextFiles.hdl"
+msgctxt "dlgRewriteTextFiles.hdl:"
 msgid "Rewrite text files with selected line-endings"
 msgstr ""
 
-msgctxt "dlgRewriteTextFiles.inf"
+msgctxt "dlgRewriteTextFiles.inf:"
 msgid "Select the line-endings that should be used to write the text files."
 msgstr ""
 
-msgctxt "dlgRewriteTextFiles.tle"
+msgctxt "dlgRewriteTextFiles.tle:"
 msgid "Fix Line-Endings"
 msgstr ""
 
@@ -702,15 +702,15 @@ msgctxt "dlgScAboutUpdateInstallation.btn:"
 msgid "Upgrade Installation"
 msgstr ""
 
-msgctxt "dlgScAboutUpdateInstallation.fur"
+msgctxt "dlgScAboutUpdateInstallation.fur:"
 msgid "This will take a few moments and has to restart SmartGit."
 msgstr ""
 
-msgctxt "dlgScAboutUpdateInstallation.hdl%1"
+msgctxt "dlgScAboutUpdateInstallation.hdl%1:"
 msgid "Do you want to upgrade the installation directory to version $1?"
 msgstr ""
 
-msgctxt "dlgScAboutUpdateInstallation.tle"
+msgctxt "dlgScAboutUpdateInstallation.tle:"
 msgid "Upgrade Installation"
 msgstr ""
 
@@ -726,63 +726,63 @@ msgctxt "dlgScApplicationStarterRestart.btn:"
 msgid "Restart"
 msgstr ""
 
-msgctxt "dlgScApplicationStarterRestart.fur"
+msgctxt "dlgScApplicationStarterRestart.fur:"
 msgid "The downloaded program update should be applied now."
 msgstr ""
 
-msgctxt "dlgScApplicationStarterRestart.hdl"
+msgctxt "dlgScApplicationStarterRestart.hdl:"
 msgid "SmartGit requires a restart."
 msgstr ""
 
-msgctxt "dlgScApplicationStarterRestart.tle"
+msgctxt "dlgScApplicationStarterRestart.tle:"
 msgid "Restart"
 msgstr ""
 
-msgctxt "dlgScConflictSolverAdd.hdl"
+msgctxt "dlgScConflictSolverAdd.hdl:"
 msgid "Add conflict solver"
 msgstr ""
 
-msgctxt "dlgScConflictSolverAdd.tle"
+msgctxt "dlgScConflictSolverAdd.tle:"
 msgid "Add"
 msgstr ""
 
-msgctxt "dlgScConflictSolverEdit.hdl"
+msgctxt "dlgScConflictSolverEdit.hdl:"
 msgid "Edit conflict solver"
 msgstr ""
 
-msgctxt "dlgScConflictSolverEdit.tle"
+msgctxt "dlgScConflictSolverEdit.tle:"
 msgid "Edit"
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.fur"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.fur:"
 msgid "The merge file content contains mixed \\(inconsistent\\) line-endings. If these line-endings are intentionally mixed, be sure to not overwrite them while saving this file."
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl:"
 msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%1"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%1:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%2"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%2:"
 msgid "\\[$1\\] - $2"
 msgstr ""
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.chk"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.chk:"
 msgid "Don't warn me again"
 msgstr ""
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.fur"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.fur:"
 msgid "Not all conflicts have been resolved."
 msgstr ""
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.hdl"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.hdl:"
 msgid "Do you want to close the Conflict Solver?"
 msgstr ""
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.tle"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.tle:"
 msgid "Unresolved Conflicts"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgctxt "dlgScConflictSolver(Add|Edit).edt:"
 msgid "File Pattern"
 msgstr ""
 
-msgctxt "dlgScConflictSolver(Add|Edit).inf"
+msgctxt "dlgScConflictSolver(Add|Edit).inf:"
 msgid "Define the file pattern \\(e.g. \\*.txt\\) and select the merge tool which should be used to resolve conflicting files matching this pattern."
 msgstr ""
 
@@ -878,15 +878,15 @@ msgctxt "dlgScCustomizeAccelerators.edt:"
 msgid "Accelerator"
 msgstr ""
 
-msgctxt "dlgScCustomizeAccelerators.hdl"
+msgctxt "dlgScCustomizeAccelerators.hdl:"
 msgid "Customize Accelerators"
 msgstr ""
 
-msgctxt "dlgScCustomizeAccelerators.inf"
+msgctxt "dlgScCustomizeAccelerators.inf:"
 msgid "Double click on the menu item for which the accelerator should be changed, then press the accelerator keys and click the Assign button."
 msgstr ""
 
-msgctxt "dlgScCustomizeAccelerators.tle"
+msgctxt "dlgScCustomizeAccelerators.tle:"
 msgid "Customize"
 msgstr ""
 
@@ -938,7 +938,7 @@ msgctxt "dlgScCustomizeToolBar.mni:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlgScCustomizeToolBar.tle"
+msgctxt "dlgScCustomizeToolBar.tle:"
 msgid "Configure Toolbar"
 msgstr ""
 
@@ -958,15 +958,15 @@ msgctxt "dlgScDevOpsCredentials.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgScDevOpsCredentials.hdl%1"
+msgctxt "dlgScDevOpsCredentials.hdl%1:"
 msgid "Login to '$1'"
 msgstr ""
 
-msgctxt "dlgScDevOpsCredentials.inf"
+msgctxt "dlgScDevOpsCredentials.inf:"
 msgid "Provide the user name and password for authenticating to JIRA."
 msgstr ""
 
-msgctxt "dlgScDevOpsCredentials.tle"
+msgctxt "dlgScDevOpsCredentials.tle:"
 msgid "Login to JIRA"
 msgstr ""
 
@@ -990,15 +990,15 @@ msgctxt "dlgScDevOpsSslClientCertificate.edt:"
 msgid "Passphrase"
 msgstr ""
 
-msgctxt "dlgScDevOpsSslClientCertificate.hdl%1"
+msgctxt "dlgScDevOpsSslClientCertificate.hdl%1:"
 msgid "Select the client certificate for $1"
 msgstr ""
 
-msgctxt "dlgScDevOpsSslClientCertificate.inf"
+msgctxt "dlgScDevOpsSslClientCertificate.inf:"
 msgid "Select the client certificate file for authenticating to JIRA."
 msgstr ""
 
-msgctxt "dlgScDevOpsSslClientCertificate.tle"
+msgctxt "dlgScDevOpsSslClientCertificate.tle:"
 msgid "JIRA Client Certificate"
 msgstr ""
 
@@ -1034,7 +1034,7 @@ msgctxt "dlgScDevOpsSslFingerprintNew.lbl:"
 msgid "When in doubt, contact your server administrator."
 msgstr ""
 
-msgctxt "dlgScDevOpsSslFingerprintNew.tle"
+msgctxt "dlgScDevOpsSslFingerprintNew.tle:"
 msgid "SSL Authentication"
 msgstr ""
 
@@ -1058,7 +1058,7 @@ msgctxt "dlgScDialogAssertionHandler.lbl:"
 msgid "SmartGit has crashed due to insufficient system memory"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandler.tle"
+msgctxt "dlgScDialogAssertionHandler.tle:"
 msgid "Native Crash Logs"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
 msgid "Your SmartGit-installation seems to be damaged."
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerLinkageError.tle"
+msgctxt "dlgScDialogAssertionHandlerLinkageError.tle:"
 msgid "Internal Error"
 msgstr ""
 
@@ -1090,15 +1090,15 @@ msgctxt "dlgScDialogAssertionHandlerOutOfMemory.btn:"
 msgid "Force Exit"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur%1"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur%1:"
 msgid "It is strongly recommended to restart SmartGit.\\n\\nTo increase the maximum memory limit edit $1, increase the value of the -Xmx option, for example to -Xmx1024m \\(or add it if not yet existing\\) and restart SmartGit."
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.hdl"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.hdl:"
 msgid "SmartGit ran out of memory!"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.tle"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.tle:"
 msgid "Out Of Memory"
 msgstr ""
 
@@ -1116,20 +1116,20 @@ msgstr ""
 # msgctxt "dlgScEvaluationReminderContinue.fur"
 # msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
 #, fuzzy
-msgctxt "dlgScEvaluationReminderContinue.fur%2"
+msgctxt "dlgScEvaluationReminderContinue.fur%2:"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScEvaluationReminderContinue.hdl"
+msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends today."
 msgstr ""
 
-msgctxt "dlgScEvaluationReminderContinue.hdl%1"
+msgctxt "dlgScEvaluationReminderContinue.hdl%1:"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr ""
 
-msgctxt "dlgScEvaluationReminderContinue.tle"
+msgctxt "dlgScEvaluationReminderContinue.tle:"
 msgid "Evaluation"
 msgstr ""
 
@@ -1161,59 +1161,59 @@ msgid "Register"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScEvaluationReminderExpiredGrace.fur"
+msgctxt "dlgScEvaluationReminderExpiredGrace.fur:"
 msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScEvaluationReminderExpiredGrace.hdl"
+msgctxt "dlgScEvaluationReminderExpiredGrace.hdl:"
 msgid "Your evaluation has already expired."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScEvaluationReminderExpiredGrace.tle"
+msgctxt "dlgScEvaluationReminderExpiredGrace.tle:"
 msgid "Evaluation"
 msgstr ""
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl%2"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl%2:"
 msgid "Cannot run program \"$1\": $2"
 msgstr ""
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle%1"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle%1:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScExternalFileStarterCommandNoFile.fur"
+msgctxt "dlgScExternalFileStarterCommandNoFile.fur:"
 msgid "Be sure to add arguments to the appropriate input field."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScExternalFileStarterCommandNoFile.hdl"
+msgctxt "dlgScExternalFileStarterCommandNoFile.hdl:"
 msgid "The specified command is no file."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScExternalFileStarterCommandNoFile.tle"
+msgctxt "dlgScExternalFileStarterCommandNoFile.tle:"
 msgid "Input Validation"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScExternalFileStarterEmptyCommand.fur"
+msgctxt "dlgScExternalFileStarterEmptyCommand.fur:"
 msgid "Select the command which should be invoked."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScExternalFileStarterEmptyCommand.hdl"
+msgctxt "dlgScExternalFileStarterEmptyCommand.hdl:"
 msgid "The Command input field must not be empty!"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScExternalFileStarterEmptyCommand.tle"
+msgctxt "dlgScExternalFileStarterEmptyCommand.tle:"
 msgid "Input Validation"
 msgstr ""
 
-msgctxt "dlgScFileComparatorAdd.hdl"
+msgctxt "dlgScFileComparatorAdd.hdl:"
 msgid "Add external diff tool"
 msgstr ""
 
@@ -1229,11 +1229,11 @@ msgctxt "dlgScFileComparatorAdd.mni:"
 msgid "Base Title"
 msgstr ""
 
-msgctxt "dlgScFileComparatorAdd.tle"
+msgctxt "dlgScFileComparatorAdd.tle:"
 msgid "Add"
 msgstr ""
 
-msgctxt "dlgScFileComparatorEdit.hdl"
+msgctxt "dlgScFileComparatorEdit.hdl:"
 msgid "Edit external diff tool"
 msgstr ""
 
@@ -1249,7 +1249,7 @@ msgctxt "dlgScFileComparatorEdit.mni:"
 msgid "Base Title"
 msgstr ""
 
-msgctxt "dlgScFileComparatorEdit.tle"
+msgctxt "dlgScFileComparatorEdit.tle:"
 msgid "Edit"
 msgstr ""
 
@@ -1265,7 +1265,7 @@ msgctxt "dlgScFileComparator(Add|Edit).edt:"
 msgid "File Pattern"
 msgstr ""
 
-msgctxt "dlgScFileComparator(Add|Edit).inf"
+msgctxt "dlgScFileComparator(Add|Edit).inf:"
 msgid "Define the file pattern \\(e.g. \\*.png\\) and select the compare command which should be used to compare files matching the file pattern."
 msgstr ""
 
@@ -1329,15 +1329,15 @@ msgctxt "dlgScFileCompareFileChanged.btn:"
 msgid "Save"
 msgstr ""
 
-msgctxt "dlgScFileCompareFileChanged.fur"
+msgctxt "dlgScFileCompareFileChanged.fur:"
 msgid "Your changes will be lost, if you don't save them."
 msgstr ""
 
-msgctxt "dlgScFileCompareFileChanged.hdl"
+msgctxt "dlgScFileCompareFileChanged.hdl:"
 msgid "Do you want to save your changes?"
 msgstr ""
 
-msgctxt "dlgScFileCompareFileChanged.tle"
+msgctxt "dlgScFileCompareFileChanged.tle:"
 msgid "File Changed"
 msgstr ""
 
@@ -1357,15 +1357,15 @@ msgctxt "dlgScFileCompareSaveAll.chk:"
 msgid "Right file"
 msgstr ""
 
-msgctxt "dlgScFileCompareSaveAll.hdl"
+msgctxt "dlgScFileCompareSaveAll.hdl:"
 msgid "Save file changes"
 msgstr ""
 
-msgctxt "dlgScFileCompareSaveAll.inf"
+msgctxt "dlgScFileCompareSaveAll.inf:"
 msgid "Decide which file content to save."
 msgstr ""
 
-msgctxt "dlgScFileCompareSaveAll.tle"
+msgctxt "dlgScFileCompareSaveAll.tle:"
 msgid "Save Changes"
 msgstr ""
 
@@ -1373,11 +1373,11 @@ msgctxt "dlgScFilePatternsEdit.edt:"
 msgid "File Pattern"
 msgstr ""
 
-msgctxt "dlgScFilePatternsEdit.hdl%1"
+msgctxt "dlgScFilePatternsEdit.hdl%1:"
 msgid "Language: $1"
 msgstr ""
 
-msgctxt "dlgScFilePatternsEdit.inf"
+msgctxt "dlgScFilePatternsEdit.inf:"
 msgid "File patterns are used to determine file language, which is used for syntax coloring."
 msgstr ""
 
@@ -1385,7 +1385,7 @@ msgctxt "dlgScFilePatternsEdit.lbl:"
 msgid "Valid wildcards are ?\\u00a0\\(one arbitrary character\\) and \\*\\u00a0\\(any number of arbitrary characters\\). Separate multiple patterns by comma. Example:\\u00a0\\*.txt,\\u00a0\\*.html"
 msgstr ""
 
-msgctxt "dlgScFilePatternsEdit.tle"
+msgctxt "dlgScFilePatternsEdit.tle:"
 msgid "File Patterns"
 msgstr ""
 
@@ -1393,7 +1393,7 @@ msgctxt "dlgScFindAction.edt:"
 msgid "Action name"
 msgstr ""
 
-msgctxt "dlgScFindAction.tle"
+msgctxt "dlgScFindAction.tle:"
 msgid "Find Command"
 msgstr ""
 
@@ -1413,15 +1413,15 @@ msgctxt "dlgScHostKeyVerifier.edt:"
 msgid "Server"
 msgstr ""
 
-msgctxt "dlgScHostKeyVerifier.fur"
+msgctxt "dlgScHostKeyVerifier.fur:"
 msgid "If you are unsure, contact your administrator."
 msgstr ""
 
-msgctxt "dlgScHostKeyVerifier.hdl"
+msgctxt "dlgScHostKeyVerifier.hdl:"
 msgid "Please confirm the SSH server fingerprint."
 msgstr ""
 
-msgctxt "dlgScHostKeyVerifier.tle"
+msgctxt "dlgScHostKeyVerifier.tle:"
 msgid "SSH Server Verification"
 msgstr ""
 
@@ -1457,11 +1457,11 @@ msgctxt "dlgScJiraCommitMessageSelect.col:"
 msgid "Summary"
 msgstr ""
 
-msgctxt "dlgScJiraCommitMessageSelect.hdl"
+msgctxt "dlgScJiraCommitMessageSelect.hdl:"
 msgid "Select commit message by JIRA issue"
 msgstr ""
 
-msgctxt "dlgScJiraCommitMessageSelect.inf"
+msgctxt "dlgScJiraCommitMessageSelect.inf:"
 msgid "The selected issue summary will be used as commit message."
 msgstr ""
 
@@ -1477,7 +1477,7 @@ msgctxt "dlgScJiraCommitMessageSelect.lbl:"
 msgid "Query Configuration"
 msgstr ""
 
-msgctxt "dlgScJiraCommitMessageSelect.tle"
+msgctxt "dlgScJiraCommitMessageSelect.tle:"
 msgid "Select Issue"
 msgstr ""
 
@@ -1505,15 +1505,15 @@ msgctxt "dlgScJiraResolveIssue.edt:"
 msgid "Summary"
 msgstr ""
 
-msgctxt "dlgScJiraResolveIssue.hdl%1"
+msgctxt "dlgScJiraResolveIssue.hdl%1:"
 msgid "Resolve issue $1"
 msgstr ""
 
-msgctxt "dlgScJiraResolveIssue.inf"
+msgctxt "dlgScJiraResolveIssue.inf:"
 msgid "Select whether to resolve this issue and for which version to mark as resolved."
 msgstr ""
 
-msgctxt "dlgScJiraResolveIssue.tle"
+msgctxt "dlgScJiraResolveIssue.tle:"
 msgid "Resolve JIRA Issue"
 msgstr ""
 
@@ -1529,11 +1529,11 @@ msgctxt "dlgScMasterPasswordChange.edt:"
 msgid "Retype New Master Password"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordChange.hdl"
+msgctxt "dlgScMasterPasswordChange.hdl:"
 msgid "Change or reset the master password"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordChange.inf"
+msgctxt "dlgScMasterPasswordChange.inf:"
 msgid "To change the master password, enter the current one. To go without a master password, leave the new field blank."
 msgstr ""
 
@@ -1549,7 +1549,7 @@ msgctxt "dlgScMasterPasswordChange.rbt:"
 msgid "Set new master password"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordChange.tle"
+msgctxt "dlgScMasterPasswordChange.tle:"
 msgid "Change Master Password"
 msgstr ""
 
@@ -1561,11 +1561,11 @@ msgctxt "dlgScMasterPasswordCreate.edt:"
 msgid "Retype Again"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordCreate.hdl"
+msgctxt "dlgScMasterPasswordCreate.hdl:"
 msgid "Configure the master password for the encrypted password store"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordCreate.inf"
+msgctxt "dlgScMasterPasswordCreate.inf:"
 msgid "The master password is used to protect passwords and passphrases which are used to authenticate with servers."
 msgstr ""
 
@@ -1585,7 +1585,7 @@ msgctxt "dlgScMasterPasswordCreate.rbt:"
 msgid "Use the following master password"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordCreate.tle"
+msgctxt "dlgScMasterPasswordCreate.tle:"
 msgid "Master Password"
 msgstr ""
 
@@ -1593,11 +1593,11 @@ msgctxt "dlgScMasterPasswordEnter.edt:"
 msgid "Master Password"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordEnter.hdl"
+msgctxt "dlgScMasterPasswordEnter.hdl:"
 msgid "Enter the master password"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordEnter.inf"
+msgctxt "dlgScMasterPasswordEnter.inf:"
 msgid "A stored password or passphrase has been requested from the password store."
 msgstr ""
 
@@ -1605,31 +1605,31 @@ msgctxt "dlgScMasterPasswordEnter.lbl:"
 msgid "Forgot it? Reset it in the preferences, 'Authentication' page."
 msgstr ""
 
-msgctxt "dlgScMasterPasswordEnter.tle"
+msgctxt "dlgScMasterPasswordEnter.tle:"
 msgid "Passwords"
 msgstr ""
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.fur"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.fur:"
 msgid "The process could not be started."
 msgstr ""
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.hdl"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr ""
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.tle"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.tle:"
 msgid "SmartGit Installation Update"
 msgstr ""
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.fur"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.fur:"
 msgid "Be sure to remember it, otherwise you won't be able to access your stored passwords anymore."
 msgstr ""
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.hdl"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.hdl:"
 msgid "The master password has been changed."
 msgstr ""
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.tle"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.tle:"
 msgid "Change Master Password"
 msgstr ""
 
@@ -1637,15 +1637,15 @@ msgctxt "dlgScPropertiesReset.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgScPropertiesReset.fur"
+msgctxt "dlgScPropertiesReset.fur:"
 msgid "The new values will be active after restarting SmartGit."
 msgstr ""
 
-msgctxt "dlgScPropertiesReset.hdl%1"
+msgctxt "dlgScPropertiesReset.hdl%1:"
 msgid "Do you want to reset $1 system properties to their defaults?"
 msgstr ""
 
-msgctxt "dlgScPropertiesReset.tle"
+msgctxt "dlgScPropertiesReset.tle:"
 msgid "Reset Properties"
 msgstr ""
 
@@ -1653,11 +1653,11 @@ msgctxt "dlgScPropertyEdit.edt:"
 msgid "Value"
 msgstr ""
 
-msgctxt "dlgScPropertyEdit.hdl"
+msgctxt "dlgScPropertyEdit.hdl:"
 msgid "Edit low-level property value"
 msgstr ""
 
-msgctxt "dlgScPropertyEdit.inf%1"
+msgctxt "dlgScPropertyEdit.inf%1:"
 msgid "Set the value for property '$1'"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgctxt "dlgScPropertyEdit.rbt:"
 msgid "true"
 msgstr ""
 
-msgctxt "dlgScPropertyEdit.tle"
+msgctxt "dlgScPropertyEdit.tle:"
 msgid "Edit Property"
 msgstr ""
 
@@ -1714,7 +1714,7 @@ msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "User Count"
 msgstr ""
 
-msgctxt "dlgScRegisterFormLicenseConfirmDetails.tle"
+msgctxt "dlgScRegisterFormLicenseConfirmDetails.tle:"
 msgid "SmartGit License"
 msgstr ""
 
@@ -1722,27 +1722,27 @@ msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.btn:"
 msgid "Purchase Update"
 msgstr ""
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.fur"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.fur:"
 msgid "You may use an older SmartGit version or purchase an update license."
 msgstr ""
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.hdl"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.hdl:"
 msgid "The free update period for this license does not cover this version."
 msgstr ""
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.tle"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.tle:"
 msgid "SmartGit License"
 msgstr ""
 
-msgctxt "dlgScRegisterRequestRejected.fur"
+msgctxt "dlgScRegisterRequestRejected.fur:"
 msgid "The license server rejected the request. Please manually register the latest license file you've got by email or try again later."
 msgstr ""
 
-msgctxt "dlgScRegisterRequestRejected.hdl"
+msgctxt "dlgScRegisterRequestRejected.hdl:"
 msgid "Failed to update license file."
 msgstr ""
 
-msgctxt "dlgScRegisterRequestRejected.tle"
+msgctxt "dlgScRegisterRequestRejected.tle:"
 msgid "SmartGit License"
 msgstr ""
 
@@ -1755,11 +1755,11 @@ msgid "API Key"
 msgstr ""
 
 #| msgid "Provide API key for 'custom'"
-msgctxt "dlgScSecretToken.hdl"
+msgctxt "dlgScSecretToken.hdl:"
 msgid "Provide API key for '$1'"
 msgstr ""
 
-msgctxt "dlgScSecretToken.inf"
+msgctxt "dlgScSecretToken.inf:"
 msgid "An API key is required to access the AI at 'http://127.0.0.1:1234/'. It will be stored in SmartGit's password store."
 msgstr ""
 
@@ -1799,15 +1799,15 @@ msgctxt "dlgScSetupLicense.edt:"
 msgid "License Server URL"
 msgstr ""
 
-msgctxt "dlgScSetupLicense.hdl"
+msgctxt "dlgScSetupLicense.hdl:"
 msgid "Register license file"
 msgstr ""
 
-msgctxt "dlgScSetupLicense.inf"
+msgctxt "dlgScSetupLicense.inf:"
 msgid "Please provide your SmartGit license file you've received by email after purchase."
 msgstr ""
 
-msgctxt "dlgScSetupLicense.tle"
+msgctxt "dlgScSetupLicense.tle:"
 msgid "SmartGit License"
 msgstr ""
 
@@ -1822,17 +1822,17 @@ msgid "Restart Now"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScSetupLicenseNeedsRestart.fur"
+msgctxt "dlgScSetupLicenseNeedsRestart.fur:"
 msgid "You can do that now or manually later."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScSetupLicenseNeedsRestart.hdl"
+msgctxt "dlgScSetupLicenseNeedsRestart.hdl:"
 msgid "SmartGit has to be restarted for the license change to take effect."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgScSetupLicenseNeedsRestart.tle"
+msgctxt "dlgScSetupLicenseNeedsRestart.tle:"
 msgid "SmartGit License"
 msgstr ""
 
@@ -1844,19 +1844,19 @@ msgctxt "dlgScSpellCheckDictionaryAdd.err:"
 msgid "Please select a dictionary file."
 msgstr ""
 
-msgctxt "dlgScSpellCheckDictionaryAdd.hdl"
+msgctxt "dlgScSpellCheckDictionaryAdd.hdl:"
 msgid "Add spell checker dictionary"
 msgstr ""
 
-msgctxt "dlgScSpellCheckDictionaryAdd.tle"
+msgctxt "dlgScSpellCheckDictionaryAdd.tle:"
 msgid "Add"
 msgstr ""
 
-msgctxt "dlgScSpellCheckDictionaryEdit.hdl"
+msgctxt "dlgScSpellCheckDictionaryEdit.hdl:"
 msgid "Edit spell checker dictionary"
 msgstr ""
 
-msgctxt "dlgScSpellCheckDictionaryEdit.tle"
+msgctxt "dlgScSpellCheckDictionaryEdit.tle:"
 msgid "Edit"
 msgstr ""
 
@@ -1868,7 +1868,7 @@ msgctxt "dlgScSpellCheckDictionary(Add|Edit).edt:"
 msgid "Name"
 msgstr ""
 
-msgctxt "dlgScSpellCheckDictionary(Add|Edit).inf"
+msgctxt "dlgScSpellCheckDictionary(Add|Edit).inf:"
 msgid "Specify the MySpell dictionary file to use, e.g. \\*.dic from Mozilla Firefox' or Thunderbird's \"dictionary\" directory\\). The name is used when switching between different dictionaries."
 msgstr ""
 
@@ -1896,7 +1896,7 @@ msgctxt "dlgScSslFingerprint.lbl:"
 msgid "This might indicate a security problem! When in doubt, contact your server administrator."
 msgstr ""
 
-msgctxt "dlgScSslFingerprint.tle"
+msgctxt "dlgScSslFingerprint.tle:"
 msgid "Server Fingerprint"
 msgstr ""
 
@@ -1904,15 +1904,15 @@ msgctxt "dlgScTextFinderFindFromEnd.btn:"
 msgid "Find from End"
 msgstr ""
 
-msgctxt "dlgScTextFinderFindFromEnd.fur"
+msgctxt "dlgScTextFinderFindFromEnd.fur:"
 msgid "No occurrences have been found until the beginning of the document."
 msgstr ""
 
-msgctxt "dlgScTextFinderFindFromEnd.hdl"
+msgctxt "dlgScTextFinderFindFromEnd.hdl:"
 msgid "Do you want to continue from the end of the document?"
 msgstr ""
 
-msgctxt "dlgScTextFinderFindFromEnd.tle"
+msgctxt "dlgScTextFinderFindFromEnd.tle:"
 msgid "Find Text"
 msgstr ""
 
@@ -1920,23 +1920,23 @@ msgctxt "dlgScTextFinderFindFromStart.btn:"
 msgid "Find from Beginning"
 msgstr ""
 
-msgctxt "dlgScTextFinderFindFromStart.fur"
+msgctxt "dlgScTextFinderFindFromStart.fur:"
 msgid "No occurrences have been found until the end of the document."
 msgstr ""
 
-msgctxt "dlgScTextFinderFindFromStart.hdl"
+msgctxt "dlgScTextFinderFindFromStart.hdl:"
 msgid "Do you want to continue from the beginning of the document?"
 msgstr ""
 
-msgctxt "dlgScTextFinderFindFromStart.tle"
+msgctxt "dlgScTextFinderFindFromStart.tle:"
 msgid "Find Text"
 msgstr ""
 
-msgctxt "dlgScTextFinderNothingFound.hdl"
+msgctxt "dlgScTextFinderNothingFound.hdl:"
 msgid "No \\(more\\) occurrences have been found."
 msgstr ""
 
-msgctxt "dlgScTextFinderNothingFound.tle"
+msgctxt "dlgScTextFinderNothingFound.tle:"
 msgid "Find Text"
 msgstr ""
 
@@ -1944,11 +1944,11 @@ msgctxt "dlgScTextMultiComponentGoToLine.edt:"
 msgid "Line Number"
 msgstr ""
 
-msgctxt "dlgScTextMultiComponentGoToLine.tle"
+msgctxt "dlgScTextMultiComponentGoToLine.tle:"
 msgid "Go to Line"
 msgstr ""
 
-msgctxt "dlgScTextMultiComponentSyntaxHighlightingSelection.tle"
+msgctxt "dlgScTextMultiComponentSyntaxHighlightingSelection.tle:"
 msgid "Select Syntax-Highlighting"
 msgstr ""
 
@@ -2060,43 +2060,43 @@ msgctxt "dlgScTextSettings.tab:"
 msgid "General"
 msgstr ""
 
-msgctxt "dlgScTextSettings.tle"
+msgctxt "dlgScTextSettings.tle:"
 msgid "Settings"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationResumeFailure.fur"
+msgctxt "dlgScUpdateInstallationResumeFailure.fur:"
 msgid "The process could not be started."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationResumeFailure.hdl"
+msgctxt "dlgScUpdateInstallationResumeFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationResumeFailure.tle"
+msgctxt "dlgScUpdateInstallationResumeFailure.tle:"
 msgid "Upgrade"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.fur"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.fur:"
 msgid "The process could not be started."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.hdl"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle:"
 msgid "SmartGit Installation Update"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur%1"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur%1:"
 msgid "Please get rid of '$1' manually and retry the upgrade."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.hdl"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.hdl:"
 msgid "Clearing updater directory failed."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.tle"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.tle:"
 msgid "SmartGit Installation Update"
 msgstr ""
 
@@ -2104,15 +2104,15 @@ msgctxt "dlgScUpdateInstallationUpgrade.btn:"
 msgid "Upgrade Now"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpgrade.fur%1"
+msgctxt "dlgScUpdateInstallationUpgrade.fur%1:"
 msgid "The new version $1 has been downloaded which needs to be installed."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpgrade.hdl"
+msgctxt "dlgScUpdateInstallationUpgrade.hdl:"
 msgid "Do you want to upgrade SmartGit now?"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpgrade.tle"
+msgctxt "dlgScUpdateInstallationUpgrade.tle:"
 msgid "Upgrade SmartGit"
 msgstr ""
 
@@ -2120,11 +2120,11 @@ msgctxt "dlgSelectDiff.col:"
 msgid "Command"
 msgstr ""
 
-msgctxt "dlgSelectDiff.hdl"
+msgctxt "dlgSelectDiff.hdl:"
 msgid "Select the diff tool"
 msgstr ""
 
-msgctxt "dlgSelectDiff.inf"
+msgctxt "dlgSelectDiff.inf:"
 msgid "Select which matching diff tool should be used."
 msgstr ""
 
@@ -2136,7 +2136,7 @@ msgctxt "dlgSelectDiff.lbl:"
 msgid "Diff tool:"
 msgstr ""
 
-msgctxt "dlgSelectDiff.tle"
+msgctxt "dlgSelectDiff.tle:"
 msgid "File Compare"
 msgstr ""
 
@@ -2144,15 +2144,15 @@ msgctxt "dlgSgAbortBisectingConfirm.btn:"
 msgid "Abort Bisect"
 msgstr ""
 
-msgctxt "dlgSgAbortBisectingConfirm.fur"
+msgctxt "dlgSgAbortBisectingConfirm.fur:"
 msgid "Your working tree is in 'bisecting' state. You may abort it to get out of this state.\\n\\nAborting will checkout the branch or commit before starting bisect."
 msgstr ""
 
-msgctxt "dlgSgAbortBisectingConfirm.hdl"
+msgctxt "dlgSgAbortBisectingConfirm.hdl:"
 msgid "Do you want to reset your working tree?"
 msgstr ""
 
-msgctxt "dlgSgAbortBisectingConfirm.tle"
+msgctxt "dlgSgAbortBisectingConfirm.tle:"
 msgid "Abort"
 msgstr ""
 
@@ -2160,15 +2160,15 @@ msgctxt "dlgSgAbortCherryPickingConfirm.btn:"
 msgid "Abort Cherry-Pick"
 msgstr ""
 
-msgctxt "dlgSgAbortCherryPickingConfirm.fur"
+msgctxt "dlgSgAbortCherryPickingConfirm.fur:"
 msgid "Your working tree is in 'cherry-picking' state. You may abort it to get out of this state and freshly start over with the cherry-picking afterwards.\\n\\nAborting will clean any local modification \\(by invoking 'git cherry-pick --abort'\\)!"
 msgstr ""
 
-msgctxt "dlgSgAbortCherryPickingConfirm.hdl"
+msgctxt "dlgSgAbortCherryPickingConfirm.hdl:"
 msgid "Do you want to abort the current cherry-pick?"
 msgstr ""
 
-msgctxt "dlgSgAbortCherryPickingConfirm.tle"
+msgctxt "dlgSgAbortCherryPickingConfirm.tle:"
 msgid "Abort"
 msgstr ""
 
@@ -2176,15 +2176,15 @@ msgctxt "dlgSgAbortMergingConfirm.btn:"
 msgid "Abort Merge"
 msgstr ""
 
-msgctxt "dlgSgAbortMergingConfirm.fur"
+msgctxt "dlgSgAbortMergingConfirm.fur:"
 msgid "Your working tree is in 'merging' state. You may abort it to get out of this state and freshly start over with the merge afterwards.\\n\\nAborting will try to reconstruct the pre-merge state \\(by invoking 'git merge --abort'\\)!"
 msgstr ""
 
-msgctxt "dlgSgAbortMergingConfirm.hdl"
+msgctxt "dlgSgAbortMergingConfirm.hdl:"
 msgid "Do you want to abort the current merge?"
 msgstr ""
 
-msgctxt "dlgSgAbortMergingConfirm.tle"
+msgctxt "dlgSgAbortMergingConfirm.tle:"
 msgid "Abort"
 msgstr ""
 
@@ -2196,16 +2196,12 @@ msgstr ""
 # [decode] msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use ブランチ \| リベース \| リベース instead.\n\nAborting will clean any local modification \(by invoking 'git rebase --abort'\)!"
 #, fuzzy
 #| msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use \\u30d6\\u30e9\\u30f3\\u30c1 \\| \\u30ea\\u30d9\\u30fc\\u30b9 \\| \\u30ea\\u30d9\\u30fc\\u30b9 instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
-msgctxt "dlgSgAbortRebasingConfirm.fur"
+msgctxt "dlgSgAbortRebasingConfirm.fur:"
 msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use $1 instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 msgstr ""
 
-msgctxt "dlgSgAbortRebasingConfirm.hdl"
+msgctxt "dlgSgAbortRebasingConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
-msgstr ""
-
-msgctxt "dlgSgAbortRebasingConfirm.tle"
-msgid "Abort"
 msgstr ""
 
 msgctxt "dlgSgAbortRebasingConfirm.tle:"
@@ -2216,7 +2212,7 @@ msgctxt "dlgSgAbortRevertingConfirm.btn:"
 msgid "Abort Revert"
 msgstr ""
 
-msgctxt "dlgSgAbortRevertingConfirm.fur"
+msgctxt "dlgSgAbortRevertingConfirm.fur:"
 msgid "Your working tree is in 'reverting' state. You may abort it to get out of this state and freshly start over with the revert afterwards.\\n\\nAborting will clean any local modification \\(by invoking 'git reset --hard'\\)!"
 msgstr ""
 
@@ -2315,7 +2311,7 @@ msgctxt "dlgSgAbout.tab:"
 msgid "Licensee"
 msgstr ""
 
-msgctxt "dlgSgAbout.tle"
+msgctxt "dlgSgAbout.tle:"
 msgid "About SmartGit"
 msgstr ""
 
@@ -2323,15 +2319,15 @@ msgctxt "dlgSgAiAnnotatorDropAllNotes.btn:"
 msgid "Drop"
 msgstr ""
 
-msgctxt "dlgSgAiAnnotatorDropAllNotes.fur"
+msgctxt "dlgSgAiAnnotatorDropAllNotes.fur:"
 msgid "This will remove all AI-related Git notes from the repository."
 msgstr ""
 
-msgctxt "dlgSgAiAnnotatorDropAllNotes.hdl"
+msgctxt "dlgSgAiAnnotatorDropAllNotes.hdl:"
 msgid "Do you want to drop all AI-related Git notes?"
 msgstr ""
 
-msgctxt "dlgSgAiAnnotatorDropAllNotes.tle"
+msgctxt "dlgSgAiAnnotatorDropAllNotes.tle:"
 msgid "Drop AI Notes"
 msgstr ""
 
@@ -2345,44 +2341,44 @@ msgstr ""
 
 # $1: rootFile , $2: typeName , $3: details
 #| msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to OpenAI are allowed. If allowed, SmartGit may upload repository data required by the AI feature you invoke \\(for example: diffs, commit messages, and related metadata\\).\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
-msgctxt "dlgSgAiApiKeyRepoLlmConsent.fur"
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.fur:"
 msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to $2 are allowed. $3\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
 msgstr ""
 
 #| msgid "Do you allow SmartGit to upload repository data to OpenAI?"
-msgctxt "dlgSgAiApiKeyRepoLlmConsent.hdl"
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.hdl:"
 msgid "Do you allow SmartGit to upload repository data to $1?"
 msgstr ""
 
-msgctxt "dlgSgAiCommitMessageComposeActionSetup.fur"
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.fur:"
 msgid "Click the AI button again to generate your first commit message."
 msgstr ""
 
-msgctxt "dlgSgAiCommitMessageComposeActionSetup.hdl"
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.hdl:"
 msgid "GitHub models are now configured."
 msgstr ""
 
-msgctxt "dlgSgAiCommitMessageComposeActionSetup.tle"
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.tle:"
 msgid "AI Commit Message Compose"
 msgstr ""
 
-msgctxt "dlgSgAiCommitMessageComposeError.fur"
+msgctxt "dlgSgAiCommitMessageComposeError.fur:"
 msgid "No modifications found."
 msgstr ""
 
-msgctxt "dlgSgAiCommitMessageComposeError.hdl"
+msgctxt "dlgSgAiCommitMessageComposeError.hdl:"
 msgid "AI generation of the commit message failed."
 msgstr ""
 
-msgctxt "dlgSgAiCommitMessageComposeError.tle"
+msgctxt "dlgSgAiCommitMessageComposeError.tle:"
 msgid "AI Commit Message Compose"
 msgstr ""
 
-msgctxt "dlgSgAiIntegrationSetup.hdl"
+msgctxt "dlgSgAiIntegrationSetup.hdl:"
 msgid "Configure AI integration"
 msgstr ""
 
-msgctxt "dlgSgAiIntegrationSetup.inf"
+msgctxt "dlgSgAiIntegrationSetup.inf:"
 msgid "SmartGit supports AI-generated commit messages, with more AI features coming. GitHub models can be used out-of-the-box."
 msgstr ""
 
@@ -2402,7 +2398,7 @@ msgctxt "dlgSgAiIntegrationSetup.rbt:"
 msgid "Use GitHub models globally"
 msgstr ""
 
-msgctxt "dlgSgAiIntegrationSetup.tle"
+msgctxt "dlgSgAiIntegrationSetup.tle:"
 msgid "AI Integration"
 msgstr ""
 
@@ -2411,15 +2407,15 @@ msgid "Confirm"
 msgstr ""
 
 # [decode] msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data – either from the working tree or selected commits – to GitHub's servers.\n\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \(see the drop-down menu for configuration\)."
-msgctxt "dlgSgAiIntegrationSetupGitHubSingle.fur"
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.fur:"
 msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data \\u2013 either from the working tree or selected commits \\u2013 to GitHub's servers.\\n\\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \\(see the drop-down menu for configuration\\)."
 msgstr ""
 
-msgctxt "dlgSgAiIntegrationSetupGitHubSingle.hdl"
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.hdl:"
 msgid "Git diffs will be sent to GitHub for AI processing."
 msgstr ""
 
-msgctxt "dlgSgAiIntegrationSetupGitHubSingle.tle"
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.tle:"
 msgid "Confirm GitHub AI Usage"
 msgstr ""
 
@@ -2546,53 +2542,53 @@ msgid "Enable AI integration"
 msgstr ""
 
 #| msgid "The configuration has been saved to '/Users/UserName/Git-projects/....', which is included by '/Users/UserName/Git-projects/....'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
-msgctxt "dlgSgAiSetupConfigurationSuccess.fur"
+msgctxt "dlgSgAiSetupConfigurationSuccess.fur:"
 msgid "The configuration has been saved to '$1', which is included by '$2'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
 msgstr ""
 
-msgctxt "dlgSgAiSetupConfigurationSuccess.hdl"
+msgctxt "dlgSgAiSetupConfigurationSuccess.hdl:"
 msgid "The AI integration has been configured successfully."
 msgstr ""
 
 #| msgid "Object 'message/content' not found."
-msgctxt "dlgSgAiSetupConnectivityFailed.fur"
+msgctxt "dlgSgAiSetupConnectivityFailed.fur:"
 msgid "Object '$1' not found."
 msgstr ""
 
 #| msgid "Connection to 'ollama' failed."
-msgctxt "dlgSgAiSetupConnectivityFailed.hdl"
+msgctxt "dlgSgAiSetupConnectivityFailed.hdl:"
 msgid "Connection to '$1' failed."
 msgstr ""
 
-msgctxt "dlgSgAiSetupLlmConfigurationInvalid.fur"
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.fur:"
 msgid "API URL missing."
 msgstr ""
 
-msgctxt "dlgSgAiSetupLlmConfigurationInvalid.hdl"
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.hdl:"
 msgid "Configuration is invalid."
 msgstr ""
 
-msgctxt "dlgSgApplicationAlreadyRunning.fur%1"
+msgctxt "dlgSgApplicationAlreadyRunning.fur%1:"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
 msgstr ""
 
-msgctxt "dlgSgApplicationAlreadyRunning.hdl"
+msgctxt "dlgSgApplicationAlreadyRunning.hdl:"
 msgid "It seems that SmartGit is already running."
 msgstr ""
 
-msgctxt "dlgSgApplicationAlreadyRunning.tle"
+msgctxt "dlgSgApplicationAlreadyRunning.tle:"
 msgid "SmartGit"
 msgstr ""
 
-msgctxt "dlgSgApplicationUpgradeError.fur"
+msgctxt "dlgSgApplicationUpgradeError.fur:"
 msgid "The process could not be started."
 msgstr ""
 
-msgctxt "dlgSgApplicationUpgradeError.hdl"
+msgctxt "dlgSgApplicationUpgradeError.hdl:"
 msgid "Launching updater directly failed."
 msgstr ""
 
-msgctxt "dlgSgApplicationUpgradeError.tle"
+msgctxt "dlgSgApplicationUpgradeError.tle:"
 msgid "Upgrade"
 msgstr ""
 
@@ -2600,15 +2596,15 @@ msgctxt "dlgSgAuthenticationRemoveAllCredentials.btn:"
 msgid "Remove All"
 msgstr ""
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.fur"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.fur:"
 msgid "You will have to re-enter all authentication details."
 msgstr ""
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.hdl"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.hdl:"
 msgid "Do you want to remove all known credentials?"
 msgstr ""
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.tle"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.tle:"
 msgid "Remove All"
 msgstr ""
 
@@ -2616,7 +2612,7 @@ msgctxt "dlgSgAuthenticationShowPassword.edt:"
 msgid "Password"
 msgstr ""
 
-msgctxt "dlgSgAuthenticationShowPassword.tle%1"
+msgctxt "dlgSgAuthenticationShowPassword.tle%1:"
 msgid "Password for $1"
 msgstr ""
 
@@ -2628,11 +2624,11 @@ msgctxt "dlgSgAzureGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgAzureGenerateToken.hdl"
+msgctxt "dlgSgAzureGenerateToken.hdl:"
 msgid "Enter the generated code"
 msgstr ""
 
-msgctxt "dlgSgAzureGenerateToken.inf"
+msgctxt "dlgSgAzureGenerateToken.inf:"
 msgid "Authenticate at Azure DevOps and enter the generated token."
 msgstr ""
 
@@ -2640,15 +2636,15 @@ msgctxt "dlgSgAzureGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at Azure DevOps and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgAzureGenerateToken.tle"
+msgctxt "dlgSgAzureGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr ""
 
-msgctxt "dlgSgAzureRefreshFailed.hdl"
+msgctxt "dlgSgAzureRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr ""
 
-msgctxt "dlgSgAzureRefreshFailed.tle"
+msgctxt "dlgSgAzureRefreshFailed.tle:"
 msgid "Azure DevOps"
 msgstr ""
 
@@ -2660,15 +2656,15 @@ msgctxt "dlgSgBisectResult.btn:"
 msgid "Leave Bisect"
 msgstr ""
 
-msgctxt "dlgSgBisectResult.fur%1"
+msgctxt "dlgSgBisectResult.fur%1:"
 msgid "$1"
 msgstr ""
 
-msgctxt "dlgSgBisectResult.hdl"
+msgctxt "dlgSgBisectResult.hdl:"
 msgid "Bisect has determined the first bad commit."
 msgstr ""
 
-msgctxt "dlgSgBisectResult.tle"
+msgctxt "dlgSgBisectResult.tle:"
 msgid "Bisect Finished"
 msgstr ""
 
@@ -2680,15 +2676,15 @@ msgctxt "dlgSgBisectStartConfirm.btn:"
 msgid "Start Bisect"
 msgstr ""
 
-msgctxt "dlgSgBisectStartConfirm.fur"
+msgctxt "dlgSgBisectStartConfirm.fur:"
 msgid "You need to mark 1 commit as good and 1 commit as bad before Git can start the binary search."
 msgstr ""
 
-msgctxt "dlgSgBisectStartConfirm.hdl"
+msgctxt "dlgSgBisectStartConfirm.hdl:"
 msgid "Should the bisect be started with a bad commit?"
 msgstr ""
 
-msgctxt "dlgSgBisectStartConfirm.tle"
+msgctxt "dlgSgBisectStartConfirm.tle:"
 msgid "Start Bisect"
 msgstr ""
 
@@ -2700,11 +2696,11 @@ msgctxt "dlgSgBitbucketGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgBitbucketGenerateToken.hdl"
+msgctxt "dlgSgBitbucketGenerateToken.hdl:"
 msgid "Enter the generated code"
 msgstr ""
 
-msgctxt "dlgSgBitbucketGenerateToken.inf"
+msgctxt "dlgSgBitbucketGenerateToken.inf:"
 msgid "Authenticate at Bitbucket and enter the generated token"
 msgstr ""
 
@@ -2712,15 +2708,15 @@ msgctxt "dlgSgBitbucketGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at Bitbucket and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgBitbucketGenerateToken.tle"
+msgctxt "dlgSgBitbucketGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr ""
 
-msgctxt "dlgSgBitbucketRefreshFailed.hdl"
+msgctxt "dlgSgBitbucketRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr ""
 
-msgctxt "dlgSgBitbucketRefreshFailed.tle"
+msgctxt "dlgSgBitbucketRefreshFailed.tle:"
 msgid "Bitbucket"
 msgstr ""
 
@@ -2768,11 +2764,11 @@ msgctxt "dlgSgBranchAddCheckout.hdl:"
 msgid "Create new branch at current branch \\(HEAD\\)"
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckout.inf"
+msgctxt "dlgSgBranchAddCheckout.inf:"
 msgid "Enter the name of the local branch to create."
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckout.tle"
+msgctxt "dlgSgBranchAddCheckout.tle:"
 msgid "Add Branch"
 msgstr ""
 
@@ -2780,27 +2776,27 @@ msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl%1"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl%1:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.tle"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.tle:"
 msgid "Add Branch"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.fur"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.fur:"
 msgid "By default, SmartGit disallows to delete the current branch. To skip this restriction, switch to a different branch or set the low-level property 'branch.delete.allowToDeleteCurrentBranch'."
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.hdl"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.hdl:"
 msgid "You can't delete the current branch."
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.tle"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.tle:"
 msgid "Delete"
 msgstr ""
 
@@ -2836,11 +2832,11 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl%1"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl%1:"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle:"
 msgid "Delete"
 msgstr ""
 
@@ -2876,11 +2872,11 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl%1"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl%1:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle:"
 msgid "Delete"
 msgstr ""
 
@@ -2888,7 +2884,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.btn:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.tle"
+msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.tle:"
 msgid "Delete"
 msgstr ""
 
@@ -2904,11 +2900,11 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk%1"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk%1:"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur:"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
 msgstr ""
 
@@ -2920,11 +2916,11 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl%1"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl%1:"
 msgid "Do you want to delete the branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle:"
 msgid "Delete"
 msgstr ""
 
@@ -2932,15 +2928,15 @@ msgctxt "dlgSgBranchTrackingResetConfirm.btn:"
 msgid "Stop Tracking"
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingResetConfirm.fur"
+msgctxt "dlgSgBranchTrackingResetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingResetConfirm.hdl%2"
+msgctxt "dlgSgBranchTrackingResetConfirm.hdl%2:"
 msgid "Should branch '$1' stop tracking '$2'?"
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingResetConfirm.tle"
+msgctxt "dlgSgBranchTrackingResetConfirm.tle:"
 msgid "Stop Tracking"
 msgstr ""
 
@@ -2949,15 +2945,15 @@ msgctxt "dlgSgBranchTrackingSetConfirm.btn:"
 msgid "Configure"
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingSetConfirm.fur"
+msgctxt "dlgSgBranchTrackingSetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingSetConfirm.hdl%2"
+msgctxt "dlgSgBranchTrackingSetConfirm.hdl%2:"
 msgid "Do you want to configure '$1' to track '$2'?"
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingSetConfirm.tle"
+msgctxt "dlgSgBranchTrackingSetConfirm.tle:"
 msgid "Set Tracked Branch"
 msgstr ""
 
@@ -2965,15 +2961,15 @@ msgctxt "dlgSgBranchesOpenPullRequestsInLog.btn:"
 msgid "Open"
 msgstr ""
 
-msgctxt "dlgSgBranchesOpenPullRequestsInLog.chk"
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgBranchesOpenPullRequestsInLog.fur"
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.fur:"
 msgid "You can see a detailed list of pull requests in the Log's Branches view and review changes in the Graph."
 msgstr ""
 
-msgctxt "dlgSgBranchesOpenPullRequestsInLog.hdl"
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.hdl:"
 msgid "Do you want to review pull requests in the Log?"
 msgstr ""
 
@@ -2993,11 +2989,11 @@ msgctxt "dlgSgBugReportSettings.err:"
 msgid "Sending 'crash footprints' is required for preview builds, because their main purposes is to get as much as possible bugs reported and fixed before release."
 msgstr ""
 
-msgctxt "dlgSgBugReportSettings.hdl"
+msgctxt "dlgSgBugReportSettings.hdl:"
 msgid "Crash Reporting"
 msgstr ""
 
-msgctxt "dlgSgBugReportSettings.inf"
+msgctxt "dlgSgBugReportSettings.inf:"
 msgid "Please help to improve SmartGit's quality by automatically sending 'crash footprints'."
 msgstr ""
 
@@ -3009,7 +3005,7 @@ msgctxt "dlgSgBugReportSettings.lbl:"
 msgid "Sent data contains \\*no potentially sensitive information\\* like user names, email addresses, file contents, file paths or server names."
 msgstr ""
 
-msgctxt "dlgSgBugReportSettings.tle"
+msgctxt "dlgSgBugReportSettings.tle:"
 msgid "SmartGit"
 msgstr ""
 
@@ -3021,15 +3017,15 @@ msgctxt "dlgSgCheckout.btn:"
 msgid "Check Out"
 msgstr ""
 
-msgctxt "dlgSgCheckout.hdl"
+msgctxt "dlgSgCheckout.hdl:"
 msgid "Check out a commit"
 msgstr ""
 
-msgctxt "dlgSgCheckout.inf"
+msgctxt "dlgSgCheckout.inf:"
 msgid "Select the commit to check out. This allows to switch \\(back\\) the working tree to any commit."
 msgstr ""
 
-msgctxt "dlgSgCheckout.tle"
+msgctxt "dlgSgCheckout.tle:"
 msgid "Check Out"
 msgstr ""
 
@@ -3041,15 +3037,15 @@ msgctxt "dlgSgCheckoutFastForwardMerge.btn:"
 msgid "Just Checkout"
 msgstr ""
 
-msgctxt "dlgSgCheckoutFastForwardMerge.fur"
+msgctxt "dlgSgCheckoutFastForwardMerge.fur:"
 msgid "Fast-forward-merging automatically moves the branch forward to the tracked remote branch."
 msgstr ""
 
-msgctxt "dlgSgCheckoutFastForwardMerge.hdl%1"
+msgctxt "dlgSgCheckoutFastForwardMerge.hdl%1:"
 msgid "Do you want to fast-forward-merge remote changes after checking out '$1'?"
 msgstr ""
 
-msgctxt "dlgSgCheckoutFastForwardMerge.tle"
+msgctxt "dlgSgCheckoutFastForwardMerge.tle:"
 msgid "Check Out"
 msgstr ""
 
@@ -3057,19 +3053,19 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.btn:"
 msgid "Checkout"
 msgstr ""
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.chk"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.fur%1"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.fur%1:"
 msgid "This will make '$1' your current branch."
 msgstr ""
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl%1"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl%1:"
 msgid "Do you want to checkout the branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.tle"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.tle:"
 msgid "Check Out"
 msgstr ""
 
@@ -3077,11 +3073,11 @@ msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.btn:"
 msgid "Checkout"
 msgstr ""
 
-msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.fur"
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.fur:"
 msgid "The target branch has a different submodules configuration \\(.gitmodules\\). If you were expecting this change, you can proceed as usual.\\n\\nOtherwise, be aware that significant changes to your submodule configuration can lead to complex working tree states. In some cases, it might be simpler to perform a fresh clone of the target branch."
 msgstr ""
 
-msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.hdl"
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.hdl:"
 msgid "Do you want to check out branch 'main'?"
 msgstr ""
 
@@ -3089,16 +3085,16 @@ msgctxt "dlgSgCheckoutSwitchToWorktree.btn:"
 msgid "Switch"
 msgstr ""
 
-msgctxt "dlgSgCheckoutSwitchToWorktree.fur"
+msgctxt "dlgSgCheckoutSwitchToWorktree.fur:"
 msgid "A worktree repository already exists for the selected branch. Therefore, you can't check out this branch directly, but you can switch to this worktree."
 msgstr ""
 
 #| msgid "Do you want to switch to worktree 'C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations-25.1_windows'?"
-msgctxt "dlgSgCheckoutSwitchToWorktree.hdl"
+msgctxt "dlgSgCheckoutSwitchToWorktree.hdl:"
 msgid "Do you want to switch to worktree '$1'?"
 msgstr ""
 
-msgctxt "dlgSgCheckoutSwitchToWorktree.tle"
+msgctxt "dlgSgCheckoutSwitchToWorktree.tle:"
 msgid "Check Out"
 msgstr ""
 
@@ -3134,7 +3130,7 @@ msgctxt "dlgSgCheckoutTarget.hdl:"
 msgid "Checkout remote branch"
 msgstr ""
 
-msgctxt "dlgSgCheckoutTarget.inf"
+msgctxt "dlgSgCheckoutTarget.inf:"
 msgid "Create and checkout a new local branch for the selected commit"
 msgstr ""
 
@@ -3154,7 +3150,7 @@ msgctxt "dlgSgCheckoutTarget.rbt:"
 msgid "Don't create local branch \\(just work read-only\\)"
 msgstr ""
 
-msgctxt "dlgSgCheckoutTarget.tle"
+msgctxt "dlgSgCheckoutTarget.tle:"
 msgid "Check Out"
 msgstr ""
 
@@ -3182,15 +3178,15 @@ msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr ""
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl%1"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl%1:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.tle"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.tle:"
 msgid "Check Out"
 msgstr ""
 
@@ -3198,7 +3194,7 @@ msgctxt "dlgSgCherryPickConfigurationFile.btn:"
 msgid "Cherry-Pick"
 msgstr ""
 
-msgctxt "dlgSgCherryPickConfigurationFile.fur"
+msgctxt "dlgSgCherryPickConfigurationFile.fur:"
 msgid "Only changes of these files will be cherry-picked \\(without committing\\)."
 msgstr ""
 
@@ -3210,7 +3206,7 @@ msgctxt "dlgSgCherryPickConfigurationFile.hdl:"
 msgid "Do you want to cherry-pick changes of '$1'?"
 msgstr ""
 
-msgctxt "dlgSgCherryPickConfigurationFile.tle"
+msgctxt "dlgSgCherryPickConfigurationFile.tle:"
 msgid "Cherry-Pick"
 msgstr ""
 
@@ -3222,36 +3218,36 @@ msgctxt "dlgSgCherryPickConfirmation.btn:"
 msgid "Cherry-Pick"
 msgstr ""
 
-msgctxt "dlgSgCherryPickConfirmation.chk"
+msgctxt "dlgSgCherryPickConfirmation.chk:"
 msgid "Append source commit ID to commit message"
 msgstr ""
 
 #| msgid "This will cherry-pick the selected commit into the Working Tree."
-msgctxt "dlgSgCherryPickConfirmation.fur"
+msgctxt "dlgSgCherryPickConfirmation.fur:"
 msgid "This will cherry-pick the selected commits into the Working Tree."
 msgstr ""
 
-msgctxt "dlgSgCherryPickConfirmation.hdl"
+msgctxt "dlgSgCherryPickConfirmation.hdl:"
 msgid "Do you want to cherry-pick?"
 msgstr ""
 
-msgctxt "dlgSgCherryPickConfirmation.tle"
+msgctxt "dlgSgCherryPickConfirmation.tle:"
 msgid "Cherry-Pick"
 msgstr ""
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.chk"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.fur"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.fur:"
 msgid "You may need to resolve the conflicts before proceeding."
 msgstr ""
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.hdl"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.hdl:"
 msgid "Cherry-picking failed because of conflicts."
 msgstr ""
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.tle"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.tle:"
 msgid "Cherry Pick"
 msgstr ""
 
@@ -3259,15 +3255,15 @@ msgctxt "dlgSgCherryPickUnpushedCommits.btn:"
 msgid "Cherry-Pick"
 msgstr ""
 
-msgctxt "dlgSgCherryPickUnpushedCommits.fur"
+msgctxt "dlgSgCherryPickUnpushedCommits.fur:"
 msgid "At least one of the selected commits has not been pushed yet, hence cherry-pick is only local and won't be translated to SVN \\(mergeinfo\\)."
 msgstr ""
 
-msgctxt "dlgSgCherryPickUnpushedCommits.hdl"
+msgctxt "dlgSgCherryPickUnpushedCommits.hdl:"
 msgid "Do you want to cherry-pick unpushed commits?"
 msgstr ""
 
-msgctxt "dlgSgCherryPickUnpushedCommits.tle"
+msgctxt "dlgSgCherryPickUnpushedCommits.tle:"
 msgid "Cherry-Pick"
 msgstr ""
 
@@ -3287,11 +3283,11 @@ msgctxt "dlgSgClean.edt:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgClean.hdl"
+msgctxt "dlgSgClean.hdl:"
 msgid "Delete unversioned files"
 msgstr ""
 
-msgctxt "dlgSgClean.inf"
+msgctxt "dlgSgClean.inf:"
 msgid "Select which unversioned files should be deleted."
 msgstr ""
 
@@ -3315,7 +3311,7 @@ msgctxt "dlgSgClean.rbt:"
 msgid "Untracked"
 msgstr ""
 
-msgctxt "dlgSgClean.tle"
+msgctxt "dlgSgClean.tle:"
 msgid "Clean Working Tree"
 msgstr ""
 
@@ -3323,27 +3319,27 @@ msgctxt "dlgSgCleanDeleteFiles.btn:"
 msgid "Delete Files"
 msgstr ""
 
-msgctxt "dlgSgCleanDeleteFiles.fur"
+msgctxt "dlgSgCleanDeleteFiles.fur:"
 msgid "Git reported following files and directories to be deleted:"
 msgstr ""
 
-msgctxt "dlgSgCleanDeleteFiles.hdl"
+msgctxt "dlgSgCleanDeleteFiles.hdl:"
 msgid "Do you want to delete these files?"
 msgstr ""
 
-msgctxt "dlgSgCleanDeleteFiles.tle"
+msgctxt "dlgSgCleanDeleteFiles.tle:"
 msgid "Clean Working Tree"
 msgstr ""
 
-msgctxt "dlgSgCleanNoFilesFound.fur"
+msgctxt "dlgSgCleanNoFilesFound.fur:"
 msgid "Your repository only seems to contain tracked files."
 msgstr ""
 
-msgctxt "dlgSgCleanNoFilesFound.hdl"
+msgctxt "dlgSgCleanNoFilesFound.hdl:"
 msgid "No files found to be deleted."
 msgstr ""
 
-msgctxt "dlgSgCleanNoFilesFound.tle"
+msgctxt "dlgSgCleanNoFilesFound.tle:"
 msgid "Clean Working Tree"
 msgstr ""
 
@@ -3387,7 +3383,7 @@ msgctxt "dlgSgClone.chk:"
 msgid "Map SVN trunk, tags and branches to Git"
 msgstr ""
 
-msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\""
+msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
 msgid "Skip large files \\(\"partial clone\"\\)"
 msgstr ""
 
@@ -3556,7 +3552,7 @@ msgctxt "dlgSgClone.rbt:"
 msgid "Remote repository"
 msgstr ""
 
-msgctxt "dlgSgClone.tle"
+msgctxt "dlgSgClone.tle:"
 msgid "Clone"
 msgstr ""
 
@@ -3572,15 +3568,15 @@ msgctxt "dlgSgClone.ttpPartialWarning:"
 msgid "This functionality depends on the capabilities of your server."
 msgstr ""
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.fur"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.fur:"
 msgid "Please select an empty, local directory for the new repository."
 msgstr ""
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.hdl"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.hdl:"
 msgid "The selected directory is a Git repository."
 msgstr ""
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.tle"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.tle:"
 msgid "Input Validation"
 msgstr ""
 
@@ -3592,15 +3588,15 @@ msgctxt "dlgSgCloneRepositoryType.btn:"
 msgid "SVN"
 msgstr ""
 
-msgctxt "dlgSgCloneRepositoryType.fur"
+msgctxt "dlgSgCloneRepositoryType.fur:"
 msgid "The specified URL protocol is ambiguous and may refer to different types of repositories."
 msgstr ""
 
-msgctxt "dlgSgCloneRepositoryType.hdl"
+msgctxt "dlgSgCloneRepositoryType.hdl:"
 msgid "Select the type of repository you are going to clone."
 msgstr ""
 
-msgctxt "dlgSgCloneRepositoryType.tle"
+msgctxt "dlgSgCloneRepositoryType.tle:"
 msgid "Clone"
 msgstr ""
 
@@ -3612,11 +3608,11 @@ msgctxt "dlgSgCloneSetCredentialHelper.btn:"
 msgid "Set SmartGit as Credential-Helper"
 msgstr ""
 
-msgctxt "dlgSgCloneSetCredentialHelper.fur"
+msgctxt "dlgSgCloneSetCredentialHelper.fur:"
 msgid "If selected, SmartGit will be set as `credential.helper` in the `.git\\\\/config` of newly cloned repositories that are cloned directly from a configured Hosting Provider. Executing remote Git commands \\(e.g. \\*pull\\* or \\*push\\*\\) in the terminal or a shell script will then use the credentials known to SmartGit.\\n\\nThis repository setting will only affect new clones and takes precedence over any `credential.helper` configuration in your user `~\\\\/.gitconfig`.\\n\\nFor already cloned repositories the setting \\*Use SmartGit as credential helper\\* can be changed in \\*Repository \\| Settings\\*.\\n\\n\\*When to select?\\*\\nIf you solely use SmartGit as your GUI client and you use Git from the command line, we suggest selecting this option. It will simplify the authentication process when accessing platforms like GitHub.\\n\\n\\*When not to set?\\*\\nIf you also use other GUI clients, adding this configuration may disrupt the authentication of these tools and should be avoided.\\n\\nIf you do not use Git on command line or other GUI clients, selecting this option serves no purpose and is not recommended."
 msgstr ""
 
-msgctxt "dlgSgCloneSetCredentialHelper.hdl"
+msgctxt "dlgSgCloneSetCredentialHelper.hdl:"
 msgid "Do you want to configure SmartGit as credential helper?"
 msgstr ""
 
@@ -3624,19 +3620,19 @@ msgctxt "dlgSgCloneSetCredentialHelper.mni:"
 msgid "Copy"
 msgstr ""
 
-msgctxt "dlgSgCloneSetCredentialHelper.tle"
+msgctxt "dlgSgCloneSetCredentialHelper.tle:"
 msgid "Clone"
 msgstr ""
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.fur"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.fur:"
 msgid "SmartGit now continues to fetch all other revisions in the background. You may safely start working with the repository now; only log-related operations will be affected by this intermediate state.\\n\\nOnce SmartGit has finished the background part of the clone, it will let you know in the notifications area \\(status bar\\) and you can complete the clone there."
 msgstr ""
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.hdl"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.hdl:"
 msgid "HEAD revision has been successfully cloned."
 msgstr ""
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.tle"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.tle:"
 msgid "Clone"
 msgstr ""
 
@@ -3700,11 +3696,11 @@ msgctxt "dlgSgCommit.err:"
 msgid "Select at least one file to commit."
 msgstr ""
 
-msgctxt "dlgSgCommit.hdl"
+msgctxt "dlgSgCommit.hdl:"
 msgid "Commit local or staged changes"
 msgstr ""
 
-msgctxt "dlgSgCommit.inf"
+msgctxt "dlgSgCommit.inf:"
 msgid "Select the files you want to commit and provide a commit message."
 msgstr ""
 
@@ -3744,7 +3740,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Merge commit \\(multiple parents\\)"
 msgstr ""
 
-msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\""
+msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
 msgid "Simple commit \\(one parent, \"squash\"\\)"
 msgstr ""
 
@@ -3752,7 +3748,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Staged Changes"
 msgstr ""
 
-msgctxt "dlgSgCommit.tle"
+msgctxt "dlgSgCommit.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3768,27 +3764,27 @@ msgctxt "dlgSgCommitAmendAlreadyPushedCommit.btn:"
 msgid "Amend"
 msgstr ""
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.fur"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.fur:"
 msgid "If you amend a pushed commit, you will need to force-push it later. This might overwrite other users' changes."
 msgstr ""
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.hdl"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.hdl:"
 msgid "Do you want to amend an already pushed commit?"
 msgstr ""
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.tle"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.tle:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "dlgSgCommitCantAmend.fur"
+msgctxt "dlgSgCommitCantAmend.fur:"
 msgid "Can't modify an already pushed commit. If you know what you are doing and want to enable it, select the option 'Allow modifying pushed commits' in the preferences."
 msgstr ""
 
-msgctxt "dlgSgCommitCantAmend.hdl"
+msgctxt "dlgSgCommitCantAmend.hdl:"
 msgid "Can't amend commit."
 msgstr ""
 
-msgctxt "dlgSgCommitCantAmend.tle"
+msgctxt "dlgSgCommitCantAmend.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3800,15 +3796,15 @@ msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.btn:"
 msgid "Create Commit"
 msgstr ""
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.fur"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.fur:"
 msgid "The repository is in 'rebasing' state. Instead of creating an additional commit as part of your rebased commits, you will usually just want continue the rebase."
 msgstr ""
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.hdl"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.hdl:"
 msgid "Do you want to continue the rebase or create an additional commit?"
 msgstr ""
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.tle"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -3816,15 +3812,15 @@ msgctxt "dlgSgCommitDirectlyTo.btn:"
 msgid "Commit Anyway"
 msgstr ""
 
-msgctxt "dlgSgCommitDirectlyTo.fur"
+msgctxt "dlgSgCommitDirectlyTo.fur:"
 msgid "You have Git-Flow configured and committing to the Git-Flow master branch should not happen directly but only with the help of the Git-Flow commands and merging.\\n\\nIf in doubt, please contact your administrator."
 msgstr ""
 
-msgctxt "dlgSgCommitDirectlyTo.hdl"
+msgctxt "dlgSgCommitDirectlyTo.hdl:"
 msgid "Do you want to commit directly to 'master'?"
 msgstr ""
 
-msgctxt "dlgSgCommitDirectlyTo.tle"
+msgctxt "dlgSgCommitDirectlyTo.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3844,27 +3840,27 @@ msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.chk:"
 msgid "Include untracked files"
 msgstr ""
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.fur"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.fur:"
 msgid "No file is staged yet. To commit all \\(visible\\) working tree changes, click Commit All. To stage individual changes, click Cancel."
 msgstr ""
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.hdl"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.hdl:"
 msgid "Do you want to commit all \\(visible\\) working tree changes?"
 msgstr ""
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.tle"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.tle:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "dlgSgCommitIndexNoFilesFound.fur"
+msgctxt "dlgSgCommitIndexNoFilesFound.fur:"
 msgid "There is nothing to commit."
 msgstr ""
 
-msgctxt "dlgSgCommitIndexNoFilesFound.hdl"
+msgctxt "dlgSgCommitIndexNoFilesFound.hdl:"
 msgid "There is nothing to commit."
 msgstr ""
 
-msgctxt "dlgSgCommitIndexNoFilesFound.tle"
+msgctxt "dlgSgCommitIndexNoFilesFound.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3876,27 +3872,27 @@ msgctxt "dlgSgCommitMessageContainsComments.btn:"
 msgid "Strip Comments"
 msgstr ""
 
-msgctxt "dlgSgCommitMessageContainsComments.fur"
+msgctxt "dlgSgCommitMessageContainsComments.fur:"
 msgid "The commit message contains lines starting with # which Git would treat as comment \\(and thus strip from the message\\).\\n\\nFor advanced comment-handling you may consider to use Git's config option 'core.commentChar'.\\n\\nIf you always want to keep or strip comment lines, you can configure this in the Preferences."
 msgstr ""
 
-msgctxt "dlgSgCommitMessageContainsComments.hdl"
+msgctxt "dlgSgCommitMessageContainsComments.hdl:"
 msgid "Should comment lines be committed as-is?"
 msgstr ""
 
-msgctxt "dlgSgCommitMessageContainsComments.tle"
+msgctxt "dlgSgCommitMessageContainsComments.tle:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.fur"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.fur:"
 msgid "Neither staged files nor locally changed files were found."
 msgstr ""
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.hdl"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.hdl:"
 msgid "There is nothing to commit."
 msgstr ""
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.tle"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3912,7 +3908,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.chk:"
 msgid "Add 'fixup!' prefix for easier automatic squashing using Interactive Rebase"
 msgstr ""
 
-msgctxt "dlgSgCommitSelectMessageFromLog.hdl"
+msgctxt "dlgSgCommitSelectMessageFromLog.hdl:"
 msgid "Select a commit"
 msgstr ""
 
@@ -3924,7 +3920,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
 msgid "No repository selected."
 msgstr ""
 
-msgctxt "dlgSgCommitSelectMessageFromLog.inf"
+msgctxt "dlgSgCommitSelectMessageFromLog.inf:"
 msgid "Choose the commit whose message should be used."
 msgstr ""
 
@@ -3984,7 +3980,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.tbt:"
 msgid "Interpret the search pattern as regular expression."
 msgstr ""
 
-msgctxt "dlgSgCommitSelectMessageFromLog.tle"
+msgctxt "dlgSgCommitSelectMessageFromLog.tle:"
 msgid "Select Commit Message"
 msgstr ""
 
@@ -3996,15 +3992,15 @@ msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.btn:"
 msgid "Commit File"
 msgstr ""
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.fur"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.fur:"
 msgid "You either can commit the single selected file or all \\(visible\\) changed files."
 msgstr ""
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.hdl"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.hdl:"
 msgid "What do you want to commit?"
 msgstr ""
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.tle"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -4012,15 +4008,15 @@ msgctxt "dlgSgCommitToDetachedHead.btn:"
 msgid "Commit Anyway"
 msgstr ""
 
-msgctxt "dlgSgCommitToDetachedHead.fur"
+msgctxt "dlgSgCommitToDetachedHead.fur:"
 msgid "The repository HEAD currently does not point to a branch, but directly refers to a commit \\(SHA\\). When committing, the newly created commit will only be reachable by its SHA and hence may get lost easily.\\n\\nInstead of committing now, you should first create a branch for your current HEAD and commit afterwards."
 msgstr ""
 
-msgctxt "dlgSgCommitToDetachedHead.hdl"
+msgctxt "dlgSgCommitToDetachedHead.hdl:"
 msgid "Do you want to commit to a detached HEAD?"
 msgstr ""
 
-msgctxt "dlgSgCommitToDetachedHead.tle"
+msgctxt "dlgSgCommitToDetachedHead.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -4032,27 +4028,27 @@ msgctxt "dlgSgCompareTwoFiles.btn:"
 msgid "Compare with Repository"
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFiles.fur"
+msgctxt "dlgSgCompareTwoFiles.fur:"
 msgid "The files can be compared to their repository content or to each other."
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFiles.hdl"
+msgctxt "dlgSgCompareTwoFiles.hdl:"
 msgid "Should the selected two files be compared with each other?"
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFiles.tle"
+msgctxt "dlgSgCompareTwoFiles.tle:"
 msgid "Compare"
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.fur"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.fur:"
 msgid "To prevent overwriting intentional mixed line-endings, editing and saving is disabled."
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl:"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle%3"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle%3:"
 msgid "\\[$1\\] - \\[$2\\] - $3"
 msgstr ""
 
@@ -4060,15 +4056,15 @@ msgctxt "dlgSgConflictResolverExternalStarted.btn:"
 msgid "Mark Resolved"
 msgstr ""
 
-msgctxt "dlgSgConflictResolverExternalStarted.fur"
+msgctxt "dlgSgConflictResolverExternalStarted.fur:"
 msgid "The external conflict solver has been started. After you have resolved the conflict, you may now mark the file as resolved."
 msgstr ""
 
-msgctxt "dlgSgConflictResolverExternalStarted.hdl"
+msgctxt "dlgSgConflictResolverExternalStarted.hdl:"
 msgid "Do you want to mark the file as resolved?"
 msgstr ""
 
-msgctxt "dlgSgConflictResolverExternalStarted.tle"
+msgctxt "dlgSgConflictResolverExternalStarted.tle:"
 msgid "External Conflict Solver"
 msgstr ""
 
@@ -4080,15 +4076,15 @@ msgctxt "dlgSgConflictSolverMarkResolved.btn:"
 msgid "Mark Resolved"
 msgstr ""
 
-msgctxt "dlgSgConflictSolverMarkResolved.fur"
+msgctxt "dlgSgConflictSolverMarkResolved.fur:"
 msgid "To complete a conflict resolution, the file needs to be marked as resolved \\(git stage\\). Until marked as resolved, the file remains in conflicted state and you can try other conflict resolutions."
 msgstr ""
 
-msgctxt "dlgSgConflictSolverMarkResolved.hdl"
+msgctxt "dlgSgConflictSolverMarkResolved.hdl:"
 msgid "Do you want to mark the file as resolved?"
 msgstr ""
 
-msgctxt "dlgSgConflictSolverMarkResolved.tle"
+msgctxt "dlgSgConflictSolverMarkResolved.tle:"
 msgid "Mark Resolved"
 msgstr ""
 
@@ -4100,15 +4096,15 @@ msgctxt "dlgSgConflictSolverStageForCommit.btn:"
 msgid "Stage"
 msgstr ""
 
-msgctxt "dlgSgConflictSolverStageForCommit.fur"
+msgctxt "dlgSgConflictSolverStageForCommit.fur:"
 msgid "Staging is necessary to resolve the file's conflict status."
 msgstr ""
 
-msgctxt "dlgSgConflictSolverStageForCommit.hdl"
+msgctxt "dlgSgConflictSolverStageForCommit.hdl:"
 msgid "Do you want to stage the file for commit now?"
 msgstr ""
 
-msgctxt "dlgSgConflictSolverStageForCommit.tle"
+msgctxt "dlgSgConflictSolverStageForCommit.tle:"
 msgid "Stage for Commit"
 msgstr ""
 
@@ -4172,7 +4168,7 @@ msgctxt "dlgSgCustomizeProjectUi.tab:"
 msgid "Toolbar"
 msgstr ""
 
-msgctxt "dlgSgCustomizeProjectUi.tle"
+msgctxt "dlgSgCustomizeProjectUi.tle:"
 msgid "Customize"
 msgstr ""
 
@@ -4184,23 +4180,23 @@ msgctxt "dlgSgDeleteDirTrash.btn:"
 msgid "Move to Trash"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.fur"
+msgctxt "dlgSgDeleteDirTrash.fur:"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.hdl%1"
+msgctxt "dlgSgDeleteDirTrash.hdl%1:"
 msgid "Do you want to delete '$1' recursively?"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.tle"
+msgctxt "dlgSgDeleteDirTrash.tle:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgDeleteFileTrash.hdl%1"
+msgctxt "dlgSgDeleteFileTrash.hdl%1:"
 msgid "Do you want to delete '$1'?"
 msgstr ""
 
-msgctxt "dlgSgDeleteFilesTrash.hdl%1"
+msgctxt "dlgSgDeleteFilesTrash.hdl%1:"
 msgid "Do you want to delete the $1 selected files?"
 msgstr ""
 
@@ -4224,11 +4220,11 @@ msgctxt "dlgSgDiscard.edt:"
 msgid "Revert to"
 msgstr ""
 
-msgctxt "dlgSgDiscard.hdl"
+msgctxt "dlgSgDiscard.hdl:"
 msgid "Discard local or staged changes"
 msgstr ""
 
-msgctxt "dlgSgDiscard.inf"
+msgctxt "dlgSgDiscard.inf:"
 msgid "Select the files for which changes should be discarded and whether to set them back to Index or HEAD state."
 msgstr ""
 
@@ -4268,39 +4264,39 @@ msgctxt "dlgSgDiscard.rbt:"
 msgid "Index"
 msgstr ""
 
-msgctxt "dlgSgDiscard.tle"
+msgctxt "dlgSgDiscard.tle:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardNoFilesFound.fur"
+msgctxt "dlgSgDiscardNoFilesFound.fur:"
 msgid "Neither staged files nor locally changed files were found."
 msgstr ""
 
-msgctxt "dlgSgDiscardNoFilesFound.hdl"
+msgctxt "dlgSgDiscardNoFilesFound.hdl:"
 msgid "There is nothing to discard."
 msgstr ""
 
-msgctxt "dlgSgDiscardNoFilesFound.tle"
+msgctxt "dlgSgDiscardNoFilesFound.tle:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.fur"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.fur:"
 msgid "You have selected to discard only the Index changes of one or more files. However, at least one of the files is also modified in the working tree. It is not possible to discard only Index changes in this case.\\n\\nIf you actually want to discard the working tree changes, select the file in the working tree table."
 msgstr ""
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.hdl"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.hdl:"
 msgid "Discarding Index changes is not possible."
 msgstr ""
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToHead.hdl%1"
+msgctxt "dlgSgDiscardRevertToHead.hdl%1:"
 msgid "Do you want to reset $1 files back to their HEAD state?"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToIndex.hdl%1"
+msgctxt "dlgSgDiscardRevertToIndex.hdl%1:"
 msgid "Do you want to reset $1 files back to their Index state?"
 msgstr ""
 
@@ -4308,24 +4304,12 @@ msgctxt "dlgSgDiscardRevertTo(Head|Index).btn:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertTo(Head|Index).fur"
+msgctxt "dlgSgDiscardRevertTo(Head|Index).fur:"
 msgid "The content might be hard to restore!"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertTo(Head|Index).tle"
+msgctxt "dlgSgDiscardRevertTo(Head|Index).tle:"
 msgid "Discard"
-msgstr ""
-
-# TODO: Review
-# Multiple different messages (msgid) were detected.
-# msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-# msgid "Repository 'XXXXXX' is not valid."
-# msgid "No valid worktree state of the repository."
-# msgid "Server returned HTTP response code: 401 for URL: https://gitlab.com/api/v4/user:\\n\\nToken was revoked. You have to re-authorize from the user."
-#, fuzzy
-#| msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-msgctxt "dlgSgErrorUtilsClientException.fur"
-msgid "Repository '$1' is not valid."
 msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
@@ -4340,6 +4324,13 @@ msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "GIT_DIR for repository at '$1' does not exist."
 msgstr ""
 
+# TODO: Review
+# Multiple different messages (msgid) were detected.
+# msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
+# msgid "Repository 'XXXXXX' is not valid."
+# msgid "No valid worktree state of the repository."
+# msgid "Server returned HTTP response code: 401 for URL: https://gitlab.com/api/v4/user:\\n\\nToken was revoked. You have to re-authorize from the user."
+#, fuzzy
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Repository '$1' is not valid."
 msgstr ""
@@ -4348,11 +4339,11 @@ msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "svn: $1"
 msgstr ""
 
-msgctxt "dlgSgErrorUtilsClientException.hdl"
+msgctxt "dlgSgErrorUtilsClientException.hdl:"
 msgid "Executing a command has failed."
 msgstr ""
 
-msgctxt "dlgSgErrorUtilsClientException.tle"
+msgctxt "dlgSgErrorUtilsClientException.tle:"
 msgid "Command Failed"
 msgstr ""
 
@@ -4360,19 +4351,19 @@ msgctxt "dlgSgExitConfirmation.btn:"
 msgid "Exit Now"
 msgstr ""
 
-msgctxt "dlgSgExitConfirmation.chk"
+msgctxt "dlgSgExitConfirmation.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgExitConfirmation.fur"
+msgctxt "dlgSgExitConfirmation.fur:"
 msgid "By closing the last window you will exit SmartGit."
 msgstr ""
 
-msgctxt "dlgSgExitConfirmation.hdl"
+msgctxt "dlgSgExitConfirmation.hdl:"
 msgid "Do you want to exit SmartGit now?"
 msgstr ""
 
-msgctxt "dlgSgExitConfirmation.tle"
+msgctxt "dlgSgExitConfirmation.tle:"
 msgid "Exit"
 msgstr ""
 
@@ -4380,19 +4371,19 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.btn:"
 msgid "Force Opening"
 msgstr ""
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl%1"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl%1:"
 msgid "Could not open Conflict Solver for '$1', because it seems to be no text file."
 msgstr ""
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle:"
 msgid "Conflict Solver"
 msgstr ""
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.hdl%1"
+msgctxt "dlgSgFileCompareInvokerFailedIO.hdl%1:"
 msgid "'$1' could not be invoked."
 msgstr ""
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.tle"
+msgctxt "dlgSgFileCompareInvokerFailedIO.tle:"
 msgid "Open"
 msgstr ""
 
@@ -4400,23 +4391,19 @@ msgctxt "dlgSgFileCompareNoChanges.btn:"
 msgid "Open"
 msgstr ""
 
-msgctxt "dlgSgFileCompareNoChanges.btn:"
-msgid "Open"
-msgstr ""
-
-msgctxt "dlgSgFileCompareNoChanges.chk"
+msgctxt "dlgSgFileCompareNoChanges.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgFileCompareNoChanges.fur"
+msgctxt "dlgSgFileCompareNoChanges.fur:"
 msgid "Both file contents are byte-wise equal.\\nTo see the file contents anyway, click 'Open'."
 msgstr ""
 
-msgctxt "dlgSgFileCompareNoChanges.hdl"
+msgctxt "dlgSgFileCompareNoChanges.hdl:"
 msgid "Open the file compare though no changes will be shown?"
 msgstr ""
 
-msgctxt "dlgSgFileCompareNoChanges.tle"
+msgctxt "dlgSgFileCompareNoChanges.tle:"
 msgid "File Compare"
 msgstr ""
 
@@ -4424,7 +4411,7 @@ msgctxt "dlgSgFindObject.edt:"
 msgid "Repository Path, Commit ID or Ref"
 msgstr ""
 
-msgctxt "dlgSgFindObject.tle"
+msgctxt "dlgSgFindObject.tle:"
 msgid "Find Object"
 msgstr ""
 
@@ -4432,15 +4419,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.btn:"
 msgid "Fast-Forward"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur%3"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur%3:"
 msgid "The local branch '$1' is behind its tracked branch '$2'. You may fast-forward now or do it manually later, e.g. by checking out the branch '$3'."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl%2:"
 msgid "Should branch '$1' be fast-forwarded to '$2'?"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.tle:"
 msgid "Start Feature"
 msgstr ""
 
@@ -4448,15 +4435,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.btn:"
 msgid "Replace"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur%2:"
 msgid "The local branch '$1' seems to contain more recent but rewritten commits of remote branch '$2'.\\n\\nIf you are not sure whether the local branch is actually more recent than the remote branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl%2:"
 msgid "Should branch '$1' replace remote branch '$2'?"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.tle:"
 msgid "Finish Feature"
 msgstr ""
 
@@ -4464,15 +4451,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur%2:"
 msgid "The remote branch '$1' seems to contain more recent but rewritten commits of local branch '$2'.\\n\\nIf you are not sure whether the remote branch is actually more recent than the local branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl%2:"
 msgid "Should branch '$1' be reset to remote branch '$2'?"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.tle:"
 msgid "Finish Feature"
 msgstr ""
 
@@ -4524,11 +4511,11 @@ msgctxt "dlgSgFlowConfigure.edt:"
 msgid "Version Tags"
 msgstr ""
 
-msgctxt "dlgSgFlowConfigure.hdl"
+msgctxt "dlgSgFlowConfigure.hdl:"
 msgid "Configure the branch naming scheme"
 msgstr ""
 
-msgctxt "dlgSgFlowConfigure.inf"
+msgctxt "dlgSgFlowConfigure.inf:"
 msgid "Configure how your feature, release and hotfix branches should be named."
 msgstr ""
 
@@ -4544,7 +4531,7 @@ msgctxt "dlgSgFlowConfigure.rbt:"
 msgid "Light \\(just feature branches\\)"
 msgstr ""
 
-msgctxt "dlgSgFlowConfigure.tle"
+msgctxt "dlgSgFlowConfigure.tle:"
 msgid "Configure Git-Flow"
 msgstr ""
 
@@ -4556,15 +4543,15 @@ msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.btn:"
 msgid "Switch-Off Git-Flow"
 msgstr ""
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.fur"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.fur:"
 msgid "Git-Flow is already configured for this repository. You may change the Git-Flow configuration or switch-off the Git-Flow features. In both cases, the file ~/.git/config will be modified accordingly."
 msgstr ""
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.hdl"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.hdl:"
 msgid "Do you want to change or switch-off the Git-Flow configuration?"
 msgstr ""
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.tle"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.tle:"
 msgid "Configure Git-Flow"
 msgstr ""
 
@@ -4592,7 +4579,7 @@ msgctxt "dlgSgFlowFeatureFinish.edt:"
 msgid "Commit Message"
 msgstr ""
 
-msgctxt "dlgSgFlowFeatureFinish.hdl"
+msgctxt "dlgSgFlowFeatureFinish.hdl:"
 msgid "Finish current feature"
 msgstr ""
 
@@ -4624,7 +4611,7 @@ msgctxt "dlgSgFlowFeatureFinish.rbt:"
 msgid "Rebase onto '$1'"
 msgstr ""
 
-msgctxt "dlgSgFlowFeatureFinish.tle"
+msgctxt "dlgSgFlowFeatureFinish.tle:"
 msgid "Finish Feature"
 msgstr ""
 
@@ -4648,11 +4635,11 @@ msgctxt "dlgSgFlowFeatureStart.err:"
 msgid "Invalid feature name: The name must not end with a slash or dot."
 msgstr ""
 
-msgctxt "dlgSgFlowFeatureStart.hdl"
+msgctxt "dlgSgFlowFeatureStart.hdl:"
 msgid "Start a new feature"
 msgstr ""
 
-msgctxt "dlgSgFlowFeatureStart.inf%1"
+msgctxt "dlgSgFlowFeatureStart.inf%1:"
 msgid "Enter the name of the new feature branch. This operation will fork a new branch from the '$1' branch."
 msgstr ""
 
@@ -4660,7 +4647,7 @@ msgctxt "dlgSgFlowFeatureStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr ""
 
-msgctxt "dlgSgFlowFeatureStart.tle"
+msgctxt "dlgSgFlowFeatureStart.tle:"
 msgid "Start Feature"
 msgstr ""
 
@@ -4728,7 +4715,7 @@ msgctxt "dlgSgFlowHotfixFinish.inf:"
 msgid "Choose how to finish the hotfix branch '$1'."
 msgstr ""
 
-msgctxt "dlgSgFlowHotfixFinish.tle"
+msgctxt "dlgSgFlowHotfixFinish.tle:"
 msgid "Finish Hotfix"
 msgstr ""
 
@@ -4752,11 +4739,11 @@ msgctxt "dlgSgFlowHotfixStart.edt:"
 msgid "Hotfix Name"
 msgstr ""
 
-msgctxt "dlgSgFlowHotfixStart.hdl"
+msgctxt "dlgSgFlowHotfixStart.hdl:"
 msgid "Start a new hotfix"
 msgstr ""
 
-msgctxt "dlgSgFlowHotfixStart.inf%1"
+msgctxt "dlgSgFlowHotfixStart.inf%1:"
 msgid "Enter the name of the new hotfix branch. This operation will fork a new branch from the '$1' branch."
 msgstr ""
 
@@ -4764,7 +4751,7 @@ msgctxt "dlgSgFlowHotfixStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr ""
 
-msgctxt "dlgSgFlowHotfixStart.tle"
+msgctxt "dlgSgFlowHotfixStart.tle:"
 msgid "Start Hotfix"
 msgstr ""
 
@@ -4776,7 +4763,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.chk:"
 msgid "Fetch latest '$1' commits from remote repository"
 msgstr ""
 
-msgctxt "dlgSgFlowIntegrateDevelop.hdl%1"
+msgctxt "dlgSgFlowIntegrateDevelop.hdl%1:"
 msgid "Integrate commits from '$1'"
 msgstr ""
 
@@ -4800,7 +4787,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.rbt:"
 msgid "Rebase current feature onto '$1'"
 msgstr ""
 
-msgctxt "dlgSgFlowIntegrateDevelop.tle"
+msgctxt "dlgSgFlowIntegrateDevelop.tle:"
 msgid "Integrate Develop"
 msgstr ""
 
@@ -4860,7 +4847,7 @@ msgctxt "dlgSgFlowReleaseFinish.inf:"
 msgid "Choose how to finish the release branch '$1'."
 msgstr ""
 
-msgctxt "dlgSgFlowReleaseFinish.tle"
+msgctxt "dlgSgFlowReleaseFinish.tle:"
 msgid "Finish Release"
 msgstr ""
 
@@ -4884,11 +4871,11 @@ msgctxt "dlgSgFlowReleaseStart.edt:"
 msgid "Release Name"
 msgstr ""
 
-msgctxt "dlgSgFlowReleaseStart.hdl"
+msgctxt "dlgSgFlowReleaseStart.hdl:"
 msgid "Start a new release"
 msgstr ""
 
-msgctxt "dlgSgFlowReleaseStart.inf%1"
+msgctxt "dlgSgFlowReleaseStart.inf%1:"
 msgid "Enter the name of the new release branch. This operation will fork a new branch from the '$1' branch."
 msgstr ""
 
@@ -4896,7 +4883,7 @@ msgctxt "dlgSgFlowReleaseStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr ""
 
-msgctxt "dlgSgFlowReleaseStart.tle"
+msgctxt "dlgSgFlowReleaseStart.tle:"
 msgid "Start Release"
 msgstr ""
 
@@ -4920,11 +4907,11 @@ msgctxt "dlgSgFlowSupportStart.edt:"
 msgid "Support Name"
 msgstr ""
 
-msgctxt "dlgSgFlowSupportStart.hdl"
+msgctxt "dlgSgFlowSupportStart.hdl:"
 msgid "Start a new support"
 msgstr ""
 
-msgctxt "dlgSgFlowSupportStart.inf%1"
+msgctxt "dlgSgFlowSupportStart.inf%1:"
 msgid "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 msgstr ""
 
@@ -4932,7 +4919,7 @@ msgctxt "dlgSgFlowSupportStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr ""
 
-msgctxt "dlgSgFlowSupportStart.tle"
+msgctxt "dlgSgFlowSupportStart.tle:"
 msgid "Start Support"
 msgstr ""
 
@@ -4952,15 +4939,15 @@ msgctxt "dlgSgGarbageCollector.chk:"
 msgid "Optimize repository more aggressively \\(may take a while\\)"
 msgstr ""
 
-msgctxt "dlgSgGarbageCollector.hdl"
+msgctxt "dlgSgGarbageCollector.hdl:"
 msgid "Run Garbage Collector"
 msgstr ""
 
-msgctxt "dlgSgGarbageCollector.inf"
+msgctxt "dlgSgGarbageCollector.inf:"
 msgid "Running the Git garbage collector will prune unreachable objects and optimize the local repository in order to reduce disk space and increase performance."
 msgstr ""
 
-msgctxt "dlgSgGarbageCollector.tle"
+msgctxt "dlgSgGarbageCollector.tle:"
 msgid "Run Garbage Collector"
 msgstr ""
 
@@ -4968,27 +4955,27 @@ msgctxt "dlgSgGarbageCollectorDeleteAllStashes.btn:"
 msgid "Delete Stashes"
 msgstr ""
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.fur"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.fur:"
 msgid "Expiring the reflog now will also delete all stashes."
 msgstr ""
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.hdl"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.hdl:"
 msgid "Do you want to also delete all stashes?"
 msgstr ""
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle:"
 msgid "Run Garbage Collector"
 msgstr ""
 
-msgctxt "dlgSgGitConfigEditConfigNotFound.fur"
+msgctxt "dlgSgGitConfigEditConfigNotFound.fur:"
 msgid "The file $1config could not be opened for editing."
 msgstr ""
 
-msgctxt "dlgSgGitConfigEditConfigNotFound.hdl"
+msgctxt "dlgSgGitConfigEditConfigNotFound.hdl:"
 msgid "The file config was not found."
 msgstr ""
 
-msgctxt "dlgSgGitConfigEditConfigNotFound.tle"
+msgctxt "dlgSgGitConfigEditConfigNotFound.tle:"
 msgid "Edit Config"
 msgstr ""
 
@@ -5013,17 +5000,17 @@ msgid "Title"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgGitHubCommitMessageSelect.hdl"
+msgctxt "dlgSgGitHubCommitMessageSelect.hdl:"
 msgid "Select commit message by GitHub issue"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgGitHubCommitMessageSelect.inf"
+msgctxt "dlgSgGitHubCommitMessageSelect.inf:"
 msgid "The selected issue summary will be used as commit message."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgGitHubCommitMessageSelect.tle"
+msgctxt "dlgSgGitHubCommitMessageSelect.tle:"
 msgid "Select Issue"
 msgstr ""
 
@@ -5047,11 +5034,11 @@ msgctxt "dlgSgGitHubGenerateToken.edt:"
 msgid "Password"
 msgstr ""
 
-msgctxt "dlgSgGitHubGenerateToken.hdl"
+msgctxt "dlgSgGitHubGenerateToken.hdl:"
 msgid "Generate a new API token for GitHub"
 msgstr ""
 
-msgctxt "dlgSgGitHubGenerateToken.inf"
+msgctxt "dlgSgGitHubGenerateToken.inf:"
 msgid "Authenticate at GitHub and grant access to SmartGit."
 msgstr ""
 
@@ -5067,7 +5054,7 @@ msgctxt "dlgSgGitHubGenerateToken.rbt:"
 msgid "Authenticate with your GitHub account and password"
 msgstr ""
 
-msgctxt "dlgSgGitHubGenerateToken.tle"
+msgctxt "dlgSgGitHubGenerateToken.tle:"
 msgid "Generate API Token"
 msgstr ""
 
@@ -5087,15 +5074,15 @@ msgctxt "dlgSgGitHubPullRequestCreate.edt:"
 msgid "Title and Description"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestCreate.hdl"
+msgctxt "dlgSgGitHubPullRequestCreate.hdl:"
 msgid "Create a Pull Request"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestCreate.inf"
+msgctxt "dlgSgGitHubPullRequestCreate.inf:"
 msgid "Send pull request to another repository or branch."
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestCreate.tle"
+msgctxt "dlgSgGitHubPullRequestCreate.tle:"
 msgid "Create Pull Request"
 msgstr ""
 
@@ -5111,11 +5098,11 @@ msgctxt "dlgSgGitHubPullRequestMerge.edt:"
 msgid "Commit Message"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestMerge.hdl"
+msgctxt "dlgSgGitHubPullRequestMerge.hdl:"
 msgid "Merge a Pull Request"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestMerge.inf"
+msgctxt "dlgSgGitHubPullRequestMerge.inf:"
 msgid "Choose how to merge the selected Pull Request."
 msgstr ""
 
@@ -5143,7 +5130,7 @@ msgctxt "dlgSgGitHubPullRequestMerge.rbt:"
 msgid "Merge to Local Repository"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestMerge.tle"
+msgctxt "dlgSgGitHubPullRequestMerge.tle:"
 msgid "Merge Pull Request"
 msgstr ""
 
@@ -5159,11 +5146,11 @@ msgctxt "dlgSgGitLabGenerateToken.edt:"
 msgid "Token"
 msgstr ""
 
-msgctxt "dlgSgGitLabGenerateToken.hdl"
+msgctxt "dlgSgGitLabGenerateToken.hdl:"
 msgid "Generate a new API token for GitLab"
 msgstr ""
 
-msgctxt "dlgSgGitLabGenerateToken.inf"
+msgctxt "dlgSgGitLabGenerateToken.inf:"
 msgid "Paste the OAuth code from your browser."
 msgstr ""
 
@@ -5171,7 +5158,7 @@ msgctxt "dlgSgGitLabGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at GitLab and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgGitLabGenerateToken.tle"
+msgctxt "dlgSgGitLabGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr ""
 
@@ -5187,39 +5174,39 @@ msgctxt "dlgSgGitLabMergeRequestCreate.edt:"
 msgid "Title and Description"
 msgstr ""
 
-msgctxt "dlgSgGitLabMergeRequestCreate.hdl"
+msgctxt "dlgSgGitLabMergeRequestCreate.hdl:"
 msgid "Create a Merge Request"
 msgstr ""
 
-msgctxt "dlgSgGitLabMergeRequestCreate.inf"
+msgctxt "dlgSgGitLabMergeRequestCreate.inf:"
 msgid "Send merge request to another repository or branch."
 msgstr ""
 
-msgctxt "dlgSgGitLabMergeRequestCreate.tle"
+msgctxt "dlgSgGitLabMergeRequestCreate.tle:"
 msgid "Create Merge Request"
 msgstr ""
 
-msgctxt "dlgSgGitLabRefreshFailed.fur"
+msgctxt "dlgSgGitLabRefreshFailed.fur:"
 msgid "Your SmartGit Hosting Provider configuration for GitLab is probably invalid.\\n\\nReview your settings in the Preferences."
 msgstr ""
 
-msgctxt "dlgSgGitLabRefreshFailed.hdl"
+msgctxt "dlgSgGitLabRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr ""
 
-msgctxt "dlgSgGitLabRefreshFailed.tle"
+msgctxt "dlgSgGitLabRefreshFailed.tle:"
 msgid "GitLab"
 msgstr ""
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.fur"
+msgctxt "dlgSgGitLabSettingsInvalidToken.fur:"
 msgid "Use a Personal Access Token from your GitLab account."
 msgstr ""
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.hdl"
+msgctxt "dlgSgGitLabSettingsInvalidToken.hdl:"
 msgid "Please enter a Personal Access Token for your GitLab account."
 msgstr ""
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.tle"
+msgctxt "dlgSgGitLabSettingsInvalidToken.tle:"
 msgid "Input Validation"
 msgstr ""
 
@@ -5231,15 +5218,15 @@ msgctxt "dlgSgGitNoteAdd.edt:"
 msgid "Category"
 msgstr ""
 
-msgctxt "dlgSgGitNoteAdd.hdl"
+msgctxt "dlgSgGitNoteAdd.hdl:"
 msgid "Add a note to a commit"
 msgstr ""
 
-msgctxt "dlgSgGitNoteAdd.inf"
+msgctxt "dlgSgGitNoteAdd.inf:"
 msgid "Provider the text which should be added to the selected commit."
 msgstr ""
 
-msgctxt "dlgSgGitNoteAdd.tle"
+msgctxt "dlgSgGitNoteAdd.tle:"
 msgid "Add Note"
 msgstr ""
 
@@ -5251,32 +5238,32 @@ msgctxt "dlgSgHeadMessageListenerReplaceMessage.btn:"
 msgid "Replace This Time"
 msgstr ""
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.chk"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.chk:"
 msgid "Never replace if a message is already entered"
 msgstr ""
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.fur"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.fur:"
 msgid "If the commit message input field is empty, the HEAD commit's message will be re-used automatically."
 msgstr ""
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.hdl"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.hdl:"
 msgid "Replace entered commit message with the HEAD commit's message?"
 msgstr ""
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle:"
 msgid "Commit"
 msgstr ""
 
 #| msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
-msgctxt "dlgSgHistoryCommitCantBeModified.fur"
+msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
 msgid "To modify commits of a different branch, you need to first check out this branch."
 msgstr ""
 
-msgctxt "dlgSgHistoryCommitCantBeModified.hdl"
+msgctxt "dlgSgHistoryCommitCantBeModified.hdl:"
 msgid "At least one selected commit can't be modified."
 msgstr ""
 
-msgctxt "dlgSgHistoryCommitCantBeModified.tle"
+msgctxt "dlgSgHistoryCommitCantBeModified.tle:"
 msgid "Modify Commit"
 msgstr ""
 
@@ -5308,15 +5295,15 @@ msgctxt "dlgSgHistoryEditAuthor.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditAuthor.hdl"
+msgctxt "dlgSgHistoryEditAuthor.hdl:"
 msgid "Edit commit author"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditAuthor.inf"
+msgctxt "dlgSgHistoryEditAuthor.inf:"
 msgid "Enter the new commit author and its email address."
 msgstr ""
 
-msgctxt "dlgSgHistoryEditAuthor.tle"
+msgctxt "dlgSgHistoryEditAuthor.tle:"
 msgid "Edit Author"
 msgstr ""
 
@@ -5328,15 +5315,15 @@ msgctxt "dlgSgHistoryEditChooseCommitMessage.btn:"
 msgid "From Failed Command"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditChooseCommitMessage.fur"
+msgctxt "dlgSgHistoryEditChooseCommitMessage.fur:"
 msgid "A previous Edit Message command invocation failed for this commit. Decide whether to use the commit message from the failed run or the commit's message."
 msgstr ""
 
-msgctxt "dlgSgHistoryEditChooseCommitMessage.hdl"
+msgctxt "dlgSgHistoryEditChooseCommitMessage.hdl:"
 msgid "Which commit message you like to use?"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditChooseCommitMessage.tle"
+msgctxt "dlgSgHistoryEditChooseCommitMessage.tle:"
 msgid "Edit Message"
 msgstr ""
 
@@ -5360,11 +5347,11 @@ msgctxt "dlgSgHistoryEditMessage.edt:"
 msgid "Commit Message"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditMessage.hdl"
+msgctxt "dlgSgHistoryEditMessage.hdl:"
 msgid "Edit commit message"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditMessage.inf"
+msgctxt "dlgSgHistoryEditMessage.inf:"
 msgid "Enter the new commit message."
 msgstr ""
 
@@ -5400,7 +5387,7 @@ msgctxt "dlgSgHistoryEditMessage.mni:"
 msgid "Rewrap"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditMessage.tle"
+msgctxt "dlgSgHistoryEditMessage.tle:"
 msgid "Edit Message"
 msgstr ""
 
@@ -5408,19 +5395,19 @@ msgctxt "dlgSgHistoryModifyConfirm.btn:"
 msgid "Modify"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifyConfirm.chk"
+msgctxt "dlgSgHistoryModifyConfirm.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifyConfirm.fur"
+msgctxt "dlgSgHistoryModifyConfirm.fur:"
 msgid "This allows you to step by step walk from the selected commit to HEAD and modify them by amend-committing."
 msgstr ""
 
-msgctxt "dlgSgHistoryModifyConfirm.hdl"
+msgctxt "dlgSgHistoryModifyConfirm.hdl:"
 msgid "Do you want to modify the commits?"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifyConfirm.tle"
+msgctxt "dlgSgHistoryModifyConfirm.tle:"
 msgid "Modify Commit"
 msgstr ""
 
@@ -5432,15 +5419,15 @@ msgctxt "dlgSgHistoryModifySplitConfirm.btn:"
 msgid "Split"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifySplitConfirm.fur"
+msgctxt "dlgSgHistoryModifySplitConfirm.fur:"
 msgid "'Modify' will stop after the commit.\\n\\n'Split' will put the changes into the Index. You may discard some changes that should go into the second commit.\\n\\nAfter you've done the changes, process the remaining commits by continuing the rebase."
 msgstr ""
 
-msgctxt "dlgSgHistoryModifySplitConfirm.hdl%1"
+msgctxt "dlgSgHistoryModifySplitConfirm.hdl%1:"
 msgid "Do you want to modify or split commit $1?"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifySplitConfirm.tle"
+msgctxt "dlgSgHistoryModifySplitConfirm.tle:"
 msgid "Modify or Split Commit"
 msgstr ""
 
@@ -5448,15 +5435,15 @@ msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.btn:"
 msgid "Force Push"
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl%1"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl%1:"
 msgid "Do you want to replace the remote branch by commit $1?"
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.tle"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.tle:"
 msgid "Push Up To"
 msgstr ""
 
@@ -5464,15 +5451,15 @@ msgctxt "dlgSgHistoryPushCommitsUpToCommit.btn:"
 msgid "Push"
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur:"
 msgid "All commits up to the selected commit will be pushed to the remote repository."
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl%1"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl%1:"
 msgid "Do you want to push changes up to commit $1?"
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.tle"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.tle:"
 msgid "Push Up To"
 msgstr ""
 
@@ -5480,11 +5467,11 @@ msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.btn:"
 msgid "Modify Pushed Commits"
 msgstr ""
 
-msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.fur"
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.fur:"
 msgid "Commits which are already pushed are known to other users and may have been used by them to build theirs commits upon. When modifying such commits, these users may run into unexpected conflicts later."
 msgstr ""
 
-msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl"
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl:"
 msgid "Do you want to modify commits which are already pushed?"
 msgstr ""
 
@@ -5525,19 +5512,19 @@ msgctxt "dlgSgHistorySplitConfirm.btn:"
 msgid "Split"
 msgstr ""
 
-msgctxt "dlgSgHistorySplitConfirm.chk"
+msgctxt "dlgSgHistorySplitConfirm.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgHistorySplitConfirm.fur"
+msgctxt "dlgSgHistorySplitConfirm.fur:"
 msgid "This will put the commit's changes into the Index. Unstage those changes that should go into a second commit, then commit the staged changes. Commit the remaining changes in a second \\(or third\\) commit.\\n\\nAfter you are done, process the remaining commits by continuing the rebase."
 msgstr ""
 
-msgctxt "dlgSgHistorySplitConfirm.hdl"
+msgctxt "dlgSgHistorySplitConfirm.hdl:"
 msgid "Do you want to split the selected commit into multiple commits?"
 msgstr ""
 
-msgctxt "dlgSgHistorySplitConfirm.tle"
+msgctxt "dlgSgHistorySplitConfirm.tle:"
 msgid "Split Commit"
 msgstr ""
 
@@ -5569,11 +5556,11 @@ msgctxt "dlgSgHistorySquash.edt:"
 msgid "Commit Message"
 msgstr ""
 
-msgctxt "dlgSgHistorySquash.hdl"
+msgctxt "dlgSgHistorySquash.hdl:"
 msgid "Squash multiple commits"
 msgstr ""
 
-msgctxt "dlgSgHistorySquash.inf"
+msgctxt "dlgSgHistorySquash.inf:"
 msgid "The selected commits will be replaced by one squashed commit containing all changes of the individual commits."
 msgstr ""
 
@@ -5585,7 +5572,7 @@ msgctxt "dlgSgHistorySquash.mni:"
 msgid "Log"
 msgstr ""
 
-msgctxt "dlgSgHistorySquash.tle"
+msgctxt "dlgSgHistorySquash.tle:"
 msgid "Squash Commits"
 msgstr ""
 
@@ -5707,10 +5694,6 @@ msgid "Configure a new hosting provider account"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgHostingProviderAdd.inf"
-msgid "Set or select the options according to your account."
-msgstr ""
-
 msgctxt "dlgSgHostingProviderAdd.inf:"
 msgid "Set or select the options according to your account."
 msgstr ""
@@ -5775,7 +5758,7 @@ msgctxt "dlgSgHostingProviderAdd.lbl:"
 msgid "You can review Azure DevOps applications in the Authorizations section located at the bottom left of your \\[https://aex.dev.azure.com/me profile\\]."
 msgstr ""
 
-msgctxt "dlgSgHostingProviderAdd.tle"
+msgctxt "dlgSgHostingProviderAdd.tle:"
 msgid "Add Hosting Provider"
 msgstr ""
 
@@ -5879,11 +5862,11 @@ msgctxt "dlgSgHostingProviderEdit.err:"
 msgid "The provided SSL client certificate path is invalid."
 msgstr ""
 
-msgctxt "dlgSgHostingProviderEdit.hdl%1"
+msgctxt "dlgSgHostingProviderEdit.hdl%1:"
 msgid "Configure $1 account"
 msgstr ""
 
-msgctxt "dlgSgHostingProviderEdit.inf%1"
+msgctxt "dlgSgHostingProviderEdit.inf%1:"
 msgid "Please specify your credentials to connect to $1."
 msgstr ""
 
@@ -5987,7 +5970,7 @@ msgctxt "dlgSgHostingProviderSelectRepository.mni:"
 msgid "Repository"
 msgstr ""
 
-msgctxt "dlgSgHostingProviderSelectRepository.tle"
+msgctxt "dlgSgHostingProviderSelectRepository.tle:"
 msgid "GitHub Projects"
 msgstr ""
 
@@ -5995,15 +5978,15 @@ msgctxt "dlgSgHostingProvider(Add|Edit).lbl:"
 msgid "Optional SSL configuration"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur%3"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur%3:"
 msgid "The OAuth-access token could not be requested. Most likely your $1 configuration has changed and SmartGit's stored OAuth credentials are invalid.\\n\\nTo resolve, recreate the $2 hosting provider in the Preferences.\\n\\nDetails:\\n\\n$3"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl%1"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl%1:"
 msgid "$1 OAuth-authentication failed"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.tle"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.tle:"
 msgid "HTTP authentication"
 msgstr ""
 
@@ -6023,15 +6006,15 @@ msgctxt "dlgSgHttpPasswordCredentials.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordCredentials.hdl%1"
+msgctxt "dlgSgHttpPasswordCredentials.hdl%1:"
 msgid "Login to '$1'"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordCredentials.inf"
+msgctxt "dlgSgHttpPasswordCredentials.inf:"
 msgid "Provide the user name and password for authenticating to the repository."
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordCredentials.tle"
+msgctxt "dlgSgHttpPasswordCredentials.tle:"
 msgid "Login"
 msgstr ""
 
@@ -6039,15 +6022,15 @@ msgctxt "dlgSgIgnoreChanged.btn:"
 msgid "Discard Changes"
 msgstr ""
 
-msgctxt "dlgSgIgnoreChanged.fur"
+msgctxt "dlgSgIgnoreChanged.fur:"
 msgid "The changes will be discarded when proceeding!"
 msgstr ""
 
-msgctxt "dlgSgIgnoreChanged.hdl"
+msgctxt "dlgSgIgnoreChanged.hdl:"
 msgid "Are you sure to remove changed files?"
 msgstr ""
 
-msgctxt "dlgSgIgnoreChanged.tle"
+msgctxt "dlgSgIgnoreChanged.tle:"
 msgid "Ignore"
 msgstr ""
 
@@ -6071,15 +6054,15 @@ msgctxt "dlgSgIgnoreDirectoryConfirm.edt:"
 msgid "Ignore File"
 msgstr ""
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.fur"
+msgctxt "dlgSgIgnoreDirectoryConfirm.fur:"
 msgid "The directory name will be added to the ignore file. If the ignore file does not exist, it will be created."
 msgstr ""
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.hdl%1"
+msgctxt "dlgSgIgnoreDirectoryConfirm.hdl%1:"
 msgid "Do you want to ignore directory '$1'?"
 msgstr ""
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.tle"
+msgctxt "dlgSgIgnoreDirectoryConfirm.tle:"
 msgid "Ignore"
 msgstr ""
 
@@ -6087,11 +6070,11 @@ msgctxt "dlgSgIgnoreEdit.btn:"
 msgid "Edit"
 msgstr ""
 
-msgctxt "dlgSgIgnoreEdit.hdl"
+msgctxt "dlgSgIgnoreEdit.hdl:"
 msgid "Edit Git ignore file"
 msgstr ""
 
-msgctxt "dlgSgIgnoreEdit.inf"
+msgctxt "dlgSgIgnoreEdit.inf:"
 msgid "Select the Git ignore file to edit."
 msgstr ""
 
@@ -6103,7 +6086,7 @@ msgctxt "dlgSgIgnoreEdit.mni:"
 msgid "Reveal"
 msgstr ""
 
-msgctxt "dlgSgIgnoreEdit.tle"
+msgctxt "dlgSgIgnoreEdit.tle:"
 msgid "Edit Ignore File"
 msgstr ""
 
@@ -6139,11 +6122,11 @@ msgctxt "dlgSgIgnoreFile.err:"
 msgid "The pattern must match all selected file names. For instance, '$1' is not matched."
 msgstr ""
 
-msgctxt "dlgSgIgnoreFile.hdl"
+msgctxt "dlgSgIgnoreFile.hdl:"
 msgid "Mark files to be ignored"
 msgstr ""
 
-msgctxt "dlgSgIgnoreFile.inf"
+msgctxt "dlgSgIgnoreFile.inf:"
 msgid "Choose whether to ignore only the selected file or all files matching the specified pattern. Tracked files will be removed \\(stopped from tracking\\)."
 msgstr ""
 
@@ -6159,7 +6142,7 @@ msgctxt "dlgSgIgnoreFile.rbt:"
 msgid "Ignore explicitly \\(e.g. 'Makefile'\\)"
 msgstr ""
 
-msgctxt "dlgSgIgnoreFile.tle"
+msgctxt "dlgSgIgnoreFile.tle:"
 msgid "Ignore"
 msgstr ""
 
@@ -6167,11 +6150,11 @@ msgctxt "dlgSgIgnoreFile.wrn:"
 msgid "Because of performance reasons it is recommended to ignore by pattern - if possible."
 msgstr ""
 
-msgctxt "dlgSgIndexEditorMixedLineEndings.fur"
+msgctxt "dlgSgIndexEditorMixedLineEndings.fur:"
 msgid "At least one of the file contents contains mixed \\(inconsistent\\) line-endings. To prevent overwriting intentional mixed line-endings, editing and saving is disabled."
 msgstr ""
 
-msgctxt "dlgSgIndexEditorMixedLineEndings.hdl"
+msgctxt "dlgSgIndexEditorMixedLineEndings.hdl:"
 msgid "The file is not editable because of mixed line-endings."
 msgstr ""
 
@@ -6183,15 +6166,15 @@ msgctxt "dlgSgIndexEditorSaveOrDiscard.btn:"
 msgid "Save"
 msgstr ""
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.fur"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.fur:"
 msgid "Your changes will be lost, if you don't save them now."
 msgstr ""
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.hdl"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.hdl:"
 msgid "Do you want to save your changes?"
 msgstr ""
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.tle"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.tle:"
 msgid "Close"
 msgstr ""
 
@@ -6203,27 +6186,27 @@ msgctxt "dlgSgJournalDoubleClick.btn:"
 msgid "Open Log"
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.fur%1"
+msgctxt "dlgSgJournalDoubleClick.fur%1:"
 msgid "Select either to check out '$1' or to open the Log for the selected commit."
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.hdl%1"
+msgctxt "dlgSgJournalDoubleClick.hdl%1:"
 msgid "Do you want to check out '$1'?"
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.tle"
+msgctxt "dlgSgJournalDoubleClick.tle:"
 msgid "Journal"
 msgstr ""
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.fur"
+msgctxt "dlgSgJournalFormCommitCantBeModified.fur:"
 msgid "Not part of your head's first-parent history"
 msgstr ""
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.hdl"
+msgctxt "dlgSgJournalFormCommitCantBeModified.hdl:"
 msgid "At least one selected commit can't be modified."
 msgstr ""
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.tle"
+msgctxt "dlgSgJournalFormCommitCantBeModified.tle:"
 msgid "Edit Author"
 msgstr ""
 
@@ -6231,15 +6214,15 @@ msgctxt "dlgSgLfsInstallConfirm.btn:"
 msgid "Install"
 msgstr ""
 
-msgctxt "dlgSgLfsInstallConfirm.fur"
+msgctxt "dlgSgLfsInstallConfirm.fur:"
 msgid "This will configure hooks and filters required for LFS."
 msgstr ""
 
-msgctxt "dlgSgLfsInstallConfirm.hdl"
+msgctxt "dlgSgLfsInstallConfirm.hdl:"
 msgid "Would you like to initialize this repository for Large File Support \\(LFS\\)?"
 msgstr ""
 
-msgctxt "dlgSgLfsInstallConfirm.tle"
+msgctxt "dlgSgLfsInstallConfirm.tle:"
 msgid "LFS Install"
 msgstr ""
 
@@ -6247,15 +6230,15 @@ msgctxt "dlgSgLfsPruneConfirm.btn:"
 msgid "Prune"
 msgstr ""
 
-msgctxt "dlgSgLfsPruneConfirm.fur"
+msgctxt "dlgSgLfsPruneConfirm.fur:"
 msgid "This will call the remote to ensure that any LFS files to be deleted have copies on the remote before actually deleting them."
 msgstr ""
 
-msgctxt "dlgSgLfsPruneConfirm.hdl"
+msgctxt "dlgSgLfsPruneConfirm.hdl:"
 msgid "Would you like to delete old LFS files from the local storage?"
 msgstr ""
 
-msgctxt "dlgSgLfsPruneConfirm.tle"
+msgctxt "dlgSgLfsPruneConfirm.tle:"
 msgid "LFS Prune"
 msgstr ""
 
@@ -6267,15 +6250,15 @@ msgctxt "dlgSgLfsTrack.err:"
 msgid "File '$1' does not match the specified pattern."
 msgstr ""
 
-msgctxt "dlgSgLfsTrack.hdl"
+msgctxt "dlgSgLfsTrack.hdl:"
 msgid "Mark a file or pattern as tracked"
 msgstr ""
 
-msgctxt "dlgSgLfsTrack.inf"
+msgctxt "dlgSgLfsTrack.inf:"
 msgid "Specify the file name pattern that should be handled by Large File Support \\(LFS\\)."
 msgstr ""
 
-msgctxt "dlgSgLfsTrack.tle"
+msgctxt "dlgSgLfsTrack.tle:"
 msgid "LFS Track"
 msgstr ""
 
@@ -6283,27 +6266,27 @@ msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.btn:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur%1"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur%1:"
 msgid "You are about to apply lines from the Index to the working tree file '$1'. The modifications will be saved immediately."
 msgstr ""
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.hdl"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.hdl:"
 msgid "Do you really want to revert changes in the working tree file?"
 msgstr ""
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.tle"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.tle:"
 msgid "Revert Working Tree File"
 msgstr ""
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.fur"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.fur:"
 msgid "It's not possible to perform the requested operation on an empty repository."
 msgstr ""
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.hdl"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.hdl:"
 msgid "The repository is empty."
 msgstr ""
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.tle"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.tle:"
 msgid "Save Stash"
 msgstr ""
 
@@ -6319,7 +6302,7 @@ msgctxt "dlgSgLogCheckoutFileAs.edt:"
 msgid "Target File"
 msgstr ""
 
-msgctxt "dlgSgLogCheckoutFileAs.hdl"
+msgctxt "dlgSgLogCheckoutFileAs.hdl:"
 msgid "Save the repository file"
 msgstr ""
 
@@ -6331,11 +6314,11 @@ msgctxt "dlgSgLogCheckoutFileAs.inf:"
 msgid "Select whether to save the file state Before or After the selected commit."
 msgstr ""
 
-msgctxt "dlgSgLogCheckoutFileAs.tle"
+msgctxt "dlgSgLogCheckoutFileAs.tle:"
 msgid "Save File As"
 msgstr ""
 
-msgctxt "dlgSgLogCommentDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogCommentDeleteConfirm.hdl%1:"
 msgid "Do you really want to delete comment '$1'?"
 msgstr ""
 
@@ -6343,15 +6326,15 @@ msgctxt "dlgSgLogComment(|s)DeleteConfirm.btn:"
 msgid "Delete Comment"
 msgstr ""
 
-msgctxt "dlgSgLogComment(|s)DeleteConfirm.fur"
+msgctxt "dlgSgLogComment(|s)DeleteConfirm.fur:"
 msgid "Comments can't be restored after deletion."
 msgstr ""
 
-msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle"
+msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle:"
 msgid "Delete Comment"
 msgstr ""
 
-msgctxt "dlgSgLogCommentsDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogCommentsDeleteConfirm.hdl%1:"
 msgid "Do you really want to delete $1 comments?"
 msgstr ""
 
@@ -6363,15 +6346,15 @@ msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.btn:"
 msgid "Compare With Each Other"
 msgstr ""
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.fur"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.fur:"
 msgid "You may compare the selected files against each other or open up two separate compares for each file against its previous state."
 msgstr ""
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.hdl"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.hdl:"
 msgid "Do you want to compare the selected files against each other?"
 msgstr ""
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.tle"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.tle:"
 msgid "Compare"
 msgstr ""
 
@@ -6387,15 +6370,15 @@ msgctxt "dlgSgLogCompareWithWorkingTree.edt:"
 msgid "Working Tree File"
 msgstr ""
 
-msgctxt "dlgSgLogCompareWithWorkingTree.hdl"
+msgctxt "dlgSgLogCompareWithWorkingTree.hdl:"
 msgid "Compare repository file with local file"
 msgstr ""
 
-msgctxt "dlgSgLogCompareWithWorkingTree.inf"
+msgctxt "dlgSgLogCompareWithWorkingTree.inf:"
 msgid "Select whether to compare with the repository file as it was Before or After the selected commit."
 msgstr ""
 
-msgctxt "dlgSgLogCompareWithWorkingTree.tle"
+msgctxt "dlgSgLogCompareWithWorkingTree.tle:"
 msgid "Compare with Working Tree"
 msgstr ""
 
@@ -6403,11 +6386,11 @@ msgctxt "dlgSgLogGraphRootSwitch.chk:"
 msgid "Include tracked remote branches"
 msgstr ""
 
-msgctxt "dlgSgLogGraphRootSwitch.hdl"
+msgctxt "dlgSgLogGraphRootSwitch.hdl:"
 msgid "Select shown branches"
 msgstr ""
 
-msgctxt "dlgSgLogGraphRootSwitch.inf"
+msgctxt "dlgSgLogGraphRootSwitch.inf:"
 msgid "Select the branches for which to show commits in the graph."
 msgstr ""
 
@@ -6415,7 +6398,7 @@ msgctxt "dlgSgLogGraphRootSwitch.mni:"
 msgid "Toggle"
 msgstr ""
 
-msgctxt "dlgSgLogGraphRootSwitch.tle"
+msgctxt "dlgSgLogGraphRootSwitch.tle:"
 msgid "Select Branches"
 msgstr ""
 
@@ -6427,23 +6410,23 @@ msgctxt "dlgSgLogOpenFailedRepository.fur:"
 msgid "Is the repository still valid?"
 msgstr ""
 
-msgctxt "dlgSgLogOpenFailedRepository.hdl"
+msgctxt "dlgSgLogOpenFailedRepository.hdl:"
 msgid "Repository could not be opened."
 msgstr ""
 
-msgctxt "dlgSgLogOpenFailedRepository.tle"
+msgctxt "dlgSgLogOpenFailedRepository.tle:"
 msgid "Log"
 msgstr ""
 
-msgctxt "dlgSgLogOpenFailedSubmodule.fur"
+msgctxt "dlgSgLogOpenFailedSubmodule.fur:"
 msgid "Is the repository still valid?"
 msgstr ""
 
-msgctxt "dlgSgLogOpenFailedSubmodule.hdl"
+msgctxt "dlgSgLogOpenFailedSubmodule.hdl:"
 msgid "Submodule could not be opened."
 msgstr ""
 
-msgctxt "dlgSgLogOpenFailedSubmodule.tle"
+msgctxt "dlgSgLogOpenFailedSubmodule.tle:"
 msgid "Log"
 msgstr ""
 
@@ -6455,15 +6438,15 @@ msgctxt "dlgSgLogOpenNewWindow.btn:"
 msgid "New Window"
 msgstr ""
 
-msgctxt "dlgSgLogOpenNewWindow.fur"
+msgctxt "dlgSgLogOpenNewWindow.fur:"
 msgid "There is already an existing Log window which can be revealed."
 msgstr ""
 
-msgctxt "dlgSgLogOpenNewWindow.hdl"
+msgctxt "dlgSgLogOpenNewWindow.hdl:"
 msgid "Do you want to open a new Log window?"
 msgstr ""
 
-msgctxt "dlgSgLogOpenNewWindow.tle"
+msgctxt "dlgSgLogOpenNewWindow.tle:"
 msgid "Log"
 msgstr ""
 
@@ -6475,15 +6458,15 @@ msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.btn:"
 msgid "Submodule Log"
 msgstr ""
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.fur"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.fur:"
 msgid "The history of submodule updates will show changes to the submodule link \\('GITLINK'\\) from the parent repository's perspective. The Log for the submodule repository will show all commits which have occurred in the submodule repository itself."
 msgstr ""
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.hdl"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.hdl:"
 msgid "Do you want to show the history of submodule updates or the Log for the submodule repository?"
 msgstr ""
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.tle"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.tle:"
 msgid "Open Log"
 msgstr ""
 
@@ -6491,15 +6474,15 @@ msgctxt "dlgSgLogRefActionsDeleteConfirm.btn:"
 msgid "Delete Branch"
 msgstr ""
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.fur"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr ""
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl%1:"
 msgid "Do you really want to delete the local branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.tle"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.tle:"
 msgid "Delete Local Branch"
 msgstr ""
 
@@ -6511,15 +6494,15 @@ msgctxt "dlgSgLogRefreshRepositoryInvalid.btn:"
 msgid "Remove Repository"
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.fur%1"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.fur%1:"
 msgid "This could mean that the repository at\\n\\n$1was removed or renamed outside SmartGit."
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl%1"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl%1:"
 msgid "The opened repository '$1' became invalid."
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.tle"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.tle:"
 msgid "Refresh"
 msgstr ""
 
@@ -6539,11 +6522,11 @@ msgctxt "dlgSgMerge.btn:"
 msgid "Squash-Merge"
 msgstr ""
 
-msgctxt "dlgSgMerge.hdl"
+msgctxt "dlgSgMerge.hdl:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "dlgSgMerge.inf"
+msgctxt "dlgSgMerge.inf:"
 msgid "Select the branch or commit to merge and how they should be merged into the Working Tree."
 msgstr ""
 
@@ -6559,7 +6542,7 @@ msgctxt "dlgSgMerge.mni:"
 msgid "Refresh"
 msgstr ""
 
-msgctxt "dlgSgMerge.tle"
+msgctxt "dlgSgMerge.tle:"
 msgid "Merge"
 msgstr ""
 
@@ -6567,15 +6550,15 @@ msgctxt "dlgSgMergeConfirmNoCommit.btn:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "dlgSgMergeConfirmNoCommit.fur"
+msgctxt "dlgSgMergeConfirmNoCommit.fur:"
 msgid "The selected revisions\\(s\\) will be merged to the working tree.\\n\\nNote that merging directly to the GitFlow-master branch is not recommended. Instead, you should start a hotfix."
 msgstr ""
 
-msgctxt "dlgSgMergeConfirmNoCommit.hdl"
+msgctxt "dlgSgMergeConfirmNoCommit.hdl:"
 msgid "Do you want to perform the merge?"
 msgstr ""
 
-msgctxt "dlgSgMergeConfirmNoCommit.tle"
+msgctxt "dlgSgMergeConfirmNoCommit.tle:"
 msgid "Merge"
 msgstr ""
 
@@ -6595,7 +6578,7 @@ msgctxt "dlgSgMergeHowToMerge.btn:"
 msgid "Squash-Merge"
 msgstr ""
 
-msgctxt "dlgSgMergeHowToMerge.fur"
+msgctxt "dlgSgMergeHowToMerge.fur:"
 msgid "If there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
 msgstr ""
 
@@ -6607,19 +6590,19 @@ msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from tag '$1'?"
 msgstr ""
 
-msgctxt "dlgSgMergeHowToMerge.tle"
+msgctxt "dlgSgMergeHowToMerge.tle:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "dlgSgMergeNoop.fur"
+msgctxt "dlgSgMergeNoop.fur:"
 msgid "Merging a commit's own history into itself is technically allowed by Git but it's a no-op and will not give a new commit nor any other meaningful changes."
 msgstr ""
 
-msgctxt "dlgSgMergeNoop.hdl"
+msgctxt "dlgSgMergeNoop.hdl:"
 msgid "There is nothing to merge."
 msgstr ""
 
-msgctxt "dlgSgMergeNoop.tle"
+msgctxt "dlgSgMergeNoop.tle:"
 msgid "Merge"
 msgstr ""
 
@@ -6631,15 +6614,15 @@ msgctxt "dlgSgOpenRepository.err:"
 msgid "Please specify the root directory of a Git repository."
 msgstr ""
 
-msgctxt "dlgSgOpenRepository.hdl"
+msgctxt "dlgSgOpenRepository.hdl:"
 msgid "Add existing or create new repository"
 msgstr ""
 
-msgctxt "dlgSgOpenRepository.inf"
+msgctxt "dlgSgOpenRepository.inf:"
 msgid "Specify the local Git repository to open. To create a new repository, specify an empty directory."
 msgstr ""
 
-msgctxt "dlgSgOpenRepository.tle"
+msgctxt "dlgSgOpenRepository.tle:"
 msgid "Add or Create Repository"
 msgstr ""
 
@@ -6647,15 +6630,15 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.btn:"
 msgid "Initialize"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.fur"
+msgctxt "dlgSgOpenRepositoryInitializeGit.fur:"
 msgid "The specified directory does not appear to be a valid Git repository."
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.hdl%1"
+msgctxt "dlgSgOpenRepositoryInitializeGit.hdl%1:"
 msgid "Should '$1' be initialized as a new Git repository?"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.tle"
+msgctxt "dlgSgOpenRepositoryInitializeGit.tle:"
 msgid "Add or Create Repository"
 msgstr ""
 
@@ -6667,27 +6650,27 @@ msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
 msgid "Outer Repository"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryOuterOrInner.fur"
+msgctxt "dlgSgOpenRepositoryOuterOrInner.fur:"
 msgid "At the specified path nested repositories were found.\\nInner repository: $1\\nOuter repository: $2"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryOuterOrInner.hdl"
+msgctxt "dlgSgOpenRepositoryOuterOrInner.hdl:"
 msgid "Do you want to open the outer or inner repository?"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryOuterOrInner.tle"
+msgctxt "dlgSgOpenRepositoryOuterOrInner.tle:"
 msgid "Add or Create Repository"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur%1"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur%1:"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr ""
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.hdl"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.hdl:"
 msgid "Can't open SVN working copy, please re-clone with SmartGit."
 msgstr ""
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.tle"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.tle:"
 msgid "Add or Create Repository"
 msgstr ""
 
@@ -6841,6 +6824,7 @@ msgstr ""
 
 # Needs review (Place holder)
 # msgid "Command Rebase HEAD \\(pot-wip/v24.1-wsl\\) to 4d7f618e failed!"
+#| msgid "Command Rebase HEAD \\(BranchName\\) to fa50210c failed!"
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase HEAD \\($1\\) to $2 failed!"
 msgstr ""
@@ -6849,11 +6833,6 @@ msgstr ""
 # msgid "Command Rebase HEAD \\(pot-wip/v24.1-wsl\\) to 79193904 produced warnings."
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase HEAD \\($1\\) to $2 produced warnings."
-msgstr ""
-
-#| msgid "Command Rebase HEAD \\(BranchName\\) to fa50210c failed!"
-msgctxt "dlgSgOutput.lbl:"
-msgid "Command Rebase HEAD \\($1\\) to $2 failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -6986,19 +6965,19 @@ msgid "Output"
 msgstr ""
 
 #| msgid "repository 'https://smartgit.userecho.com/communities/1/topics/395-clone-first-clone-just-the-head-and-then-fetch-the-other-commits-in-background/' not found."
-msgctxt "dlgSgPingRepositoryFailed.fur"
+msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "repository '$1' not found."
 msgstr ""
 
-msgctxt "dlgSgPingRepositoryFailed.fur%1"
+msgctxt "dlgSgPingRepositoryFailed.fur%1:"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr ""
 
-msgctxt "dlgSgPingRepositoryFailed.hdl%1"
+msgctxt "dlgSgPingRepositoryFailed.hdl%1:"
 msgid "Could not connect to the repository '$1'."
 msgstr ""
 
-msgctxt "dlgSgPingRepositoryFailed.tle"
+msgctxt "dlgSgPingRepositoryFailed.tle:"
 msgid "Clone"
 msgstr ""
 
@@ -8292,7 +8271,7 @@ msgctxt "dlgSgPreferences.tab:"
 msgid "User"
 msgstr ""
 
-msgctxt "dlgSgPreferences.tle"
+msgctxt "dlgSgPreferences.tle:"
 msgid "Preferences"
 msgstr ""
 
@@ -8360,7 +8339,7 @@ msgctxt "dlgSgProcessKiller.lbl:"
 msgid "SmartGit is waiting for the following process to finish."
 msgstr ""
 
-msgctxt "dlgSgProcessKiller.tle"
+msgctxt "dlgSgProcessKiller.tle:"
 msgid "Process Not Responding"
 msgstr ""
 
@@ -8372,15 +8351,15 @@ msgctxt "dlgSgProviderCommentEdit.edt:"
 msgid "Text"
 msgstr ""
 
-msgctxt "dlgSgProviderCommentEdit.hdl"
+msgctxt "dlgSgProviderCommentEdit.hdl:"
 msgid "Edit GitHub comment"
 msgstr ""
 
-msgctxt "dlgSgProviderCommentEdit.inf"
+msgctxt "dlgSgProviderCommentEdit.inf:"
 msgid "Enter the text of the comment."
 msgstr ""
 
-msgctxt "dlgSgProviderCommentEdit.tle"
+msgctxt "dlgSgProviderCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr ""
 
@@ -8396,16 +8375,16 @@ msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.edt:"
 msgid "Provider"
 msgstr ""
 
-msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.hdl"
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.hdl:"
 msgid "Select which GitHub account to use"
 msgstr ""
 
-msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.inf"
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.inf:"
 msgid "Select which account you want to use for connecting to '$1'."
 msgstr ""
 
 # Verify that there’s no issue, since the `msgctxt` does not end with “:” and contains a proper noun.
-msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.tle"
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.tle:"
 msgid "Select GitHub account"
 msgstr ""
 
@@ -8417,11 +8396,11 @@ msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.hdl%1"
+msgctxt "dlgSgProviderGenerateToken.hdl%1:"
 msgid "Generate a new API token for $1"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.inf"
+msgctxt "dlgSgProviderGenerateToken.inf:"
 msgid "Authenticate at GitLab and grant access to SmartGit."
 msgstr ""
 
@@ -8433,19 +8412,19 @@ msgctxt "dlgSgProviderGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at GitLab and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.tle"
+msgctxt "dlgSgProviderGenerateToken.tle:"
 msgid "Generate API Token"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.fur"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.fur:"
 msgid "The repository is no GitHub-fork and there are no other remotes which are forks of this repository."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.hdl"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.hdl:"
 msgid "No target repositories found."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.tle"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.tle:"
 msgid "Create Pull Request"
 msgstr ""
 
@@ -8457,15 +8436,15 @@ msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.btn:"
 msgid "Skip"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.fur"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.fur:"
 msgid "You have local commits which are not yet present in the server-side Provider repository. Unless you push them now, these local commits will not be included in the merge request."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.hdl"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.hdl:"
 msgid "Do you want to push your local commits first?"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.tle"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.tle:"
 msgid "Create Merge Request"
 msgstr ""
 
@@ -8473,15 +8452,15 @@ msgctxt "dlgSgProviderPullRequestDropConfirmMr.btn:"
 msgid "Drop"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur:"
 msgid "The merge request itself will not be deleted on the server."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl%1"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl%1:"
 msgid "Do you really want to drop the local commits of merge request $1?"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.tle"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.tle:"
 msgid "Drop Merge Request"
 msgstr ""
 
@@ -8489,15 +8468,15 @@ msgctxt "dlgSgProviderPullRequestDropConfirmPr.btn:"
 msgid "Drop"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur:"
 msgid "The pull request itself will not be deleted on the server."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl%1"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl%1:"
 msgid "Do you want to drop the local commits of pull request $1?"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.tle"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.tle:"
 msgid "Drop Pull Request"
 msgstr ""
 
@@ -8509,15 +8488,15 @@ msgctxt "dlgSgProviderPullRequestRetractMr.edt:"
 msgid "Comment"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractMr.hdl"
+msgctxt "dlgSgProviderPullRequestRetractMr.hdl:"
 msgid "Retract Merge Request"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractMr.inf"
+msgctxt "dlgSgProviderPullRequestRetractMr.inf:"
 msgid "Enter the comment which will be logged with the closed merge request."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractMr.tle"
+msgctxt "dlgSgProviderPullRequestRetractMr.tle:"
 msgid "Retract Merge Request"
 msgstr ""
 
@@ -8529,15 +8508,15 @@ msgctxt "dlgSgProviderPullRequestRetractPr.edt:"
 msgid "Comment"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractPr.hdl"
+msgctxt "dlgSgProviderPullRequestRetractPr.hdl:"
 msgid "Retract Pull Request"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractPr.inf"
+msgctxt "dlgSgProviderPullRequestRetractPr.inf:"
 msgid "Enter the comment which will be logged with the closed pull request."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractPr.tle"
+msgctxt "dlgSgProviderPullRequestRetractPr.tle:"
 msgid "Retract Pull Request"
 msgstr ""
 
@@ -8569,7 +8548,7 @@ msgctxt "dlgSgPull.edt:"
 msgid "Fetch From"
 msgstr ""
 
-msgctxt "dlgSgPull.hdl"
+msgctxt "dlgSgPull.hdl:"
 msgid "Pull commits from a remote repository"
 msgstr ""
 
@@ -8581,7 +8560,7 @@ msgctxt "dlgSgPull.inf:"
 msgid "Select the remote repository to pull. In contrast to Fetch Only, Pull will also incorporate the fetched changes \\(expand the options below to configure\\)."
 msgstr ""
 
-msgctxt "dlgSgPull.tle"
+msgctxt "dlgSgPull.tle:"
 msgid "Pull"
 msgstr ""
 
@@ -8593,11 +8572,11 @@ msgctxt "dlgSgPullConfiguration.chk:"
 msgid "Remember as default for other repositories"
 msgstr ""
 
-msgctxt "dlgSgPullConfiguration.hdl"
+msgctxt "dlgSgPullConfiguration.hdl:"
 msgid "Configure how to pull"
 msgstr ""
 
-msgctxt "dlgSgPullConfiguration.inf"
+msgctxt "dlgSgPullConfiguration.inf:"
 msgid "Specify whether to merge or rebase on Pull for the current repository."
 msgstr ""
 
@@ -8617,7 +8596,7 @@ msgctxt "dlgSgPullConfiguration.rbt:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgPullConfiguration.tle"
+msgctxt "dlgSgPullConfiguration.tle:"
 msgid "Configure Pull"
 msgstr ""
 
@@ -8629,15 +8608,15 @@ msgctxt "dlgSgPullMergeInsteadOfRebase.btn:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.fur%1"
+msgctxt "dlgSgPullMergeInsteadOfRebase.fur%1:"
 msgid "Amongst the changes to rebase there is merge-commit $1. Rebasing merge-commits can easily cause troubles."
 msgstr ""
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.hdl"
+msgctxt "dlgSgPullMergeInsteadOfRebase.hdl:"
 msgid "Do you want to merge your local changes instead of rebasing?"
 msgstr ""
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.tle"
+msgctxt "dlgSgPullMergeInsteadOfRebase.tle:"
 msgid "Pull"
 msgstr ""
 
@@ -8645,15 +8624,15 @@ msgctxt "dlgSgPullNoRemoteRepository.btn:"
 msgid "Add Remote"
 msgstr ""
 
-msgctxt "dlgSgPullNoRemoteRepository.fur"
+msgctxt "dlgSgPullNoRemoteRepository.fur:"
 msgid "You first need to add a remote repository to pull from."
 msgstr ""
 
-msgctxt "dlgSgPullNoRemoteRepository.hdl"
+msgctxt "dlgSgPullNoRemoteRepository.hdl:"
 msgid "No remote repository has been found."
 msgstr ""
 
-msgctxt "dlgSgPullNoRemoteRepository.tle"
+msgctxt "dlgSgPullNoRemoteRepository.tle:"
 msgid "Pull"
 msgstr ""
 
@@ -8673,15 +8652,15 @@ msgctxt "dlgSgPullOrJustFetch.chk:"
 msgid "Update existing and fetch new tags"
 msgstr ""
 
-msgctxt "dlgSgPullOrJustFetch.fur"
+msgctxt "dlgSgPullOrJustFetch.fur:"
 msgid "You can change the Pull behavior in the Repository Settings."
 msgstr ""
 
-msgctxt "dlgSgPullOrJustFetch.hdl%1"
+msgctxt "dlgSgPullOrJustFetch.hdl%1:"
 msgid "Do you want to pull or just fetch $1 repositories?"
 msgstr ""
 
-msgctxt "dlgSgPullOrJustFetch.tle"
+msgctxt "dlgSgPullOrJustFetch.tle:"
 msgid "Pull"
 msgstr ""
 
@@ -8689,11 +8668,11 @@ msgctxt "dlgSgPullSubmoduleUpdate.btn:"
 msgid "Pull"
 msgstr ""
 
-msgctxt "dlgSgPullSubmoduleUpdate.fur"
+msgctxt "dlgSgPullSubmoduleUpdate.fur:"
 msgid "The git infrastructure for this submodule will be initialized and all commits will be pulled."
 msgstr ""
 
-msgctxt "dlgSgPullSubmoduleUpdate.tle"
+msgctxt "dlgSgPullSubmoduleUpdate.tle:"
 msgid "Pull Submodule"
 msgstr ""
 
@@ -8701,19 +8680,19 @@ msgctxt "dlgSgPushConfirmSingleBranch.btn:"
 msgid "Push"
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleBranch.chk"
+msgctxt "dlgSgPushConfirmSingleBranch.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleBranch.fur%1"
+msgctxt "dlgSgPushConfirmSingleBranch.fur%1:"
 msgid "1 branch will be pushed to '$1'."
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleBranch.hdl%1"
+msgctxt "dlgSgPushConfirmSingleBranch.hdl%1:"
 msgid "Do you want to push branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleBranch.tle"
+msgctxt "dlgSgPushConfirmSingleBranch.tle:"
 msgid "Push"
 msgstr ""
 
@@ -8721,19 +8700,19 @@ msgctxt "dlgSgPushConfirmSingleTag.btn:"
 msgid "Push"
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleTag.chk"
+msgctxt "dlgSgPushConfirmSingleTag.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleTag.fur"
+msgctxt "dlgSgPushConfirmSingleTag.fur:"
 msgid "$1 tag will be pushed to '$2'."
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleTag.hdl"
+msgctxt "dlgSgPushConfirmSingleTag.hdl:"
 msgid "Do you want to push tag '$1'?"
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleTag.tle"
+msgctxt "dlgSgPushConfirmSingleTag.tle:"
 msgid "Push"
 msgstr ""
 
@@ -8741,15 +8720,15 @@ msgctxt "dlgSgPushForced.btn:"
 msgid "Force Push"
 msgstr ""
 
-msgctxt "dlgSgPushForced.fur"
+msgctxt "dlgSgPushForced.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr ""
 
-msgctxt "dlgSgPushForced.hdl%1"
+msgctxt "dlgSgPushForced.hdl%1:"
 msgid "Do you want to force-push \\(replace\\) the remote branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgPushForced.tle"
+msgctxt "dlgSgPushForced.tle:"
 msgid "Push"
 msgstr ""
 
@@ -8757,15 +8736,15 @@ msgctxt "dlgSgPushForcedSvn.btn:"
 msgid "Force Push"
 msgstr ""
 
-msgctxt "dlgSgPushForcedSvn.fur"
+msgctxt "dlgSgPushForcedSvn.fur:"
 msgid "You are about to replace the remote branch. Revisions of that branch might not be \\(easily\\) accessible anymore."
 msgstr ""
 
-msgctxt "dlgSgPushForcedSvn.hdl"
+msgctxt "dlgSgPushForcedSvn.hdl:"
 msgid "Do you want to force-push \\(replace\\) the remote branch?"
 msgstr ""
 
-msgctxt "dlgSgPushForcedSvn.tle"
+msgctxt "dlgSgPushForcedSvn.tle:"
 msgid "Push"
 msgstr ""
 
@@ -8773,19 +8752,19 @@ msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.btn:"
 msgid "Push"
 msgstr ""
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.chk"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.chk:"
 msgid "Overwrite remote changes"
 msgstr ""
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.fur"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.fur:"
 msgid "You are about to replace the remote branch, which contains commits that you haven't seen at all. Maybe you want to merge/rebase onto the remote changes before?"
 msgstr ""
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.hdl"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.hdl:"
 msgid "Do you really want to overwrite the remote branch?"
 msgstr ""
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.tle"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.tle:"
 msgid "Push"
 msgstr ""
 
@@ -8793,39 +8772,39 @@ msgctxt "dlgSgPushToAddRemote.btn:"
 msgid "Add Remote"
 msgstr ""
 
-msgctxt "dlgSgPushToAddRemote.fur"
+msgctxt "dlgSgPushToAddRemote.fur:"
 msgid "There is no remote repository configured yet. To push, you first need to configure that. After having added the remote, invoke Push again."
 msgstr ""
 
-msgctxt "dlgSgPushToAddRemote.hdl"
+msgctxt "dlgSgPushToAddRemote.hdl:"
 msgid "Do you want to add a remote?"
 msgstr ""
 
-msgctxt "dlgSgPushToAddRemote.tle"
+msgctxt "dlgSgPushToAddRemote.tle:"
 msgid "Push To"
 msgstr ""
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.fur"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.fur:"
 msgid "There is no other Git-remote to which branches of the selected remote could be pushed."
 msgstr ""
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.hdl"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.hdl:"
 msgid "No more Git remote found."
 msgstr ""
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.tle"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.tle:"
 msgid "Push To"
 msgstr ""
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.fur"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.fur:"
 msgid "You can only push tags or local branches."
 msgstr ""
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.hdl"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.hdl:"
 msgid "No tags or local branches to push."
 msgstr ""
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.tle"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.tle:"
 msgid "Push To"
 msgstr ""
 
@@ -8869,7 +8848,7 @@ msgctxt "dlgSgPushToRef.hdl:"
 msgid "Push local commits to a remote repository"
 msgstr ""
 
-msgctxt "dlgSgPushToRef.inf"
+msgctxt "dlgSgPushToRef.inf:"
 msgid "Select the target repository where to push the ref\\(s\\)."
 msgstr ""
 
@@ -8881,7 +8860,7 @@ msgctxt "dlgSgPushToRef.rbt:"
 msgid "Tracked or matching branch"
 msgstr ""
 
-msgctxt "dlgSgPushToRef.tle"
+msgctxt "dlgSgPushToRef.tle:"
 msgid "Push To"
 msgstr ""
 
@@ -8901,15 +8880,15 @@ msgctxt "dlgSgPushToRemote.edt:"
 msgid "Target Repository"
 msgstr ""
 
-msgctxt "dlgSgPushToRemote.hdl%1"
+msgctxt "dlgSgPushToRemote.hdl%1:"
 msgid "Push '$1' branches to another remote"
 msgstr ""
 
-msgctxt "dlgSgPushToRemote.inf%1"
+msgctxt "dlgSgPushToRemote.inf%1:"
 msgid "All branches of '$1' \\(as locally represented by the corresponding remote branches\\) will be pushed to the target repository."
 msgstr ""
 
-msgctxt "dlgSgPushToRemote.tle"
+msgctxt "dlgSgPushToRemote.tle:"
 msgid "Push To"
 msgstr ""
 
@@ -8917,15 +8896,15 @@ msgctxt "dlgSgPushToRemoteRemoveTargetBranches.btn:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.fur"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.fur:"
 msgid "Removed branches and their commits in the target remote which will be lost afterwards."
 msgstr ""
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.hdl"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.hdl:"
 msgid "Do you really want to remove target remote branches?"
 msgstr ""
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.tle"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.tle:"
 msgid "Push To"
 msgstr ""
 
@@ -8933,19 +8912,19 @@ msgctxt "dlgSgPushToRemoteResetTargetBranches.btn:"
 msgid "Force Push"
 msgstr ""
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.chk"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.fur"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.fur:"
 msgid "Forcing push will overwrite branches and their commits in the target remote which will be lost afterwards."
 msgstr ""
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.hdl"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.hdl:"
 msgid "Do you really want to reset the target remote branches?"
 msgstr ""
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.tle"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.tle:"
 msgid "Push To"
 msgstr ""
 
@@ -8957,15 +8936,15 @@ msgctxt "dlgSgPushTrackingConfigureSingle.btn:"
 msgid "Skip"
 msgstr ""
 
-msgctxt "dlgSgPushTrackingConfigureSingle.fur"
+msgctxt "dlgSgPushTrackingConfigureSingle.fur:"
 msgid "For your current branch tracking \\(its corresponding remote branch\\) has not been configured yet. Configuring tracking will keep your local branches in sync with the remote branches."
 msgstr ""
 
-msgctxt "dlgSgPushTrackingConfigureSingle.hdl%1"
+msgctxt "dlgSgPushTrackingConfigureSingle.hdl%1:"
 msgid "Do you want to configure tracking for '$1' branch?"
 msgstr ""
 
-msgctxt "dlgSgPushTrackingConfigureSingle.tle"
+msgctxt "dlgSgPushTrackingConfigureSingle.tle:"
 msgid "Push"
 msgstr ""
 
@@ -8977,15 +8956,15 @@ msgctxt "dlgSgRebase.btn:"
 msgid "Rebase HEAD to"
 msgstr ""
 
-msgctxt "dlgSgRebase.hdl"
+msgctxt "dlgSgRebase.hdl:"
 msgid "Rebase HEAD to"
 msgstr ""
 
-msgctxt "dlgSgRebase.inf"
+msgctxt "dlgSgRebase.inf:"
 msgid "Select the commit to which the HEAD commits should be rebased."
 msgstr ""
 
-msgctxt "dlgSgRebase.tle"
+msgctxt "dlgSgRebase.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8993,15 +8972,15 @@ msgctxt "dlgSgRebaseConfirmUnreachable.btn:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseConfirmUnreachable.fur"
+msgctxt "dlgSgRebaseConfirmUnreachable.fur:"
 msgid "You only might be able to access this commit using the 'Recyclable Commits' option of the Branches view."
 msgstr ""
 
-msgctxt "dlgSgRebaseConfirmUnreachable.hdl%1"
+msgctxt "dlgSgRebaseConfirmUnreachable.hdl%1:"
 msgid "The Commit $1 would become unreachable by refs."
 msgstr ""
 
-msgctxt "dlgSgRebaseConfirmUnreachable.tle"
+msgctxt "dlgSgRebaseConfirmUnreachable.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9009,19 +8988,19 @@ msgctxt "dlgSgRebaseContinueAfterSplittingCommit.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur%1"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur%1:"
 msgid "The splitting of commit $1 still is in progress and all changes of this commit have been applied."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.hdl"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.hdl:"
 msgid "Do you want to continue after splitting the commit?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.tle"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9029,31 +9008,31 @@ msgctxt "dlgSgRebaseContinueConfirm.btn:"
 msgid "Continue Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConfirm.chk"
+msgctxt "dlgSgRebaseContinueConfirm.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConfirm.fur"
+msgctxt "dlgSgRebaseContinueConfirm.fur:"
 msgid "Continue the rebase operation after having resolved all conflicts."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConfirm.hdl"
+msgctxt "dlgSgRebaseContinueConfirm.hdl:"
 msgid "Do you want to continue the rebase?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConfirm.tle"
+msgctxt "dlgSgRebaseContinueConfirm.tle:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConflicts.fur"
+msgctxt "dlgSgRebaseContinueConflicts.fur:"
 msgid "Please resolve all conflicts before continuing the rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConflicts.hdl"
+msgctxt "dlgSgRebaseContinueConflicts.hdl:"
 msgid "Can't continue rebase with conflicts."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConflicts.tle"
+msgctxt "dlgSgRebaseContinueConflicts.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9061,19 +9040,19 @@ msgctxt "dlgSgRebaseContinueNothingToCommitContinue.btn:"
 msgid "Continue Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.chk"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.fur:"
 msgid "The repository is in 'rebasing' state and there is nothing to commit, so you may just continue the Rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.hdl:"
 msgid "Do you want to continue the rebase?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9084,22 +9063,22 @@ msgid "Continue \\(Resume\\)"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.chk"
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.chk:"
 msgid "Don't show again"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.fur:"
 msgid "Clicking 'Continue' will resume the rebase, e.g. to finish after having modified the commit\\(s\\)."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.hdl:"
 msgid "Do you want to continue the modify-commit-rebase?"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.tle:"
 msgid "Modify Commit"
 msgstr ""
 
@@ -9109,22 +9088,22 @@ msgid "Step"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.chk"
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.chk:"
 msgid "Don't show again"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.fur:"
 msgid "Clicking 'Step' will continue the rebase and stop at the next commit. Use it to step through all pending commits, e.g. to verify whether they successfully build."
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.hdl:"
 msgid "Do you want to step to the next commit?"
 msgstr ""
 
 #, fuzzy
-msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.tle:"
 msgid "Modify Commit"
 msgstr ""
 
@@ -9132,15 +9111,15 @@ msgctxt "dlgSgRebaseContinueNothingToCommitSkip.btn:"
 msgid "Skip Commit"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.fur:"
 msgid "The repository is in 'rebasing' state, but there is nothing to commit, so you may just skip this rebased commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.hdl:"
 msgid "Do you want to skip this rebased commit?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9152,15 +9131,15 @@ msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.btn:"
 msgid "Preserve"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.fur"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.fur:"
 msgid "Your working tree contains untracked files. You may either choose to preserve them in the working tree or include them for the rebased commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.hdl"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.hdl:"
 msgid "Do you want to preserve untracked files in your working tree?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.tle"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9168,15 +9147,15 @@ msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.fur"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.fur:"
 msgid "Rebase Continue will store all working tree changes in the commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.hdl"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.hdl:"
 msgid "Do you want the working tree changes to be part of the new commit?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.tle"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9184,15 +9163,15 @@ msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.fur"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.fur:"
 msgid "Rebase Continue will store both, staged changes and the working tree changes, in the new commit!\\n\\nIf the staged changes should go to a seperate commit, first commit them, and then invoke Continue again."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.hdl"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.hdl:"
 msgid "Do you want the working tree changes to be applied, too?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.tle"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9204,31 +9183,31 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.btn:"
 msgid "Put Changes into Index"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur%1"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur%1:"
 msgid "The splitting of commit $1 still is in progress, but not all changes of this commit have been applied.\\n\\nIf this is intentional, you can continue. Otherwise, you should click 'Put Changes into Index' and review your changes."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.hdl"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.hdl:"
 msgid "Do you want to continue splitting the commit without applying all changes?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur%1"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur%1:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) onto the selected commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl%1"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl%1:"
 msgid "Do you want to rebase '$1' onto the selected commit?"
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur%2"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur%2:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) to '$2'."
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl%2"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl%2:"
 msgid "Do you want to rebase '$1' to '$2'?"
 msgstr ""
 
@@ -9240,7 +9219,7 @@ msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).btn:"
 msgid "Rebase Interactively"
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).tle"
+msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).tle:"
 msgid "Rebase HEAD to Selected Commit"
 msgstr ""
 
@@ -9284,11 +9263,11 @@ msgctxt "dlgSgRebaseInteractive.col:"
 msgid "Message"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractive.hdl"
+msgctxt "dlgSgRebaseInteractive.hdl:"
 msgid "Rewrite History"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractive.inf"
+msgctxt "dlgSgRebaseInteractive.inf:"
 msgid "Reorder or squash commits according to your needs."
 msgstr ""
 
@@ -9304,19 +9283,19 @@ msgctxt "dlgSgRebaseInteractive.mni:"
 msgid "To Top Commit"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractive.tle"
+msgctxt "dlgSgRebaseInteractive.tle:"
 msgid "Rebase Interactive"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.fur"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.fur:"
 msgid "You need to select the first commit in the current branch's history that should be modified. All commits between this commit and HEAD must have exactly one parent."
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.hdl"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.hdl:"
 msgid "Changing the initial commit is not supported by the interactive rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.tle"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.tle:"
 msgid "Rebase Interactive"
 msgstr ""
 
@@ -9328,15 +9307,15 @@ msgctxt "dlgSgRebaseInteractiveMessage.edt:"
 msgid "New Message"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveMessage.hdl"
+msgctxt "dlgSgRebaseInteractiveMessage.hdl:"
 msgid "Edit commit message"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveMessage.inf"
+msgctxt "dlgSgRebaseInteractiveMessage.inf:"
 msgid "Provide the new message for the commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveMessage.tle"
+msgctxt "dlgSgRebaseInteractiveMessage.tle:"
 msgid "Edit Message"
 msgstr ""
 
@@ -9344,39 +9323,39 @@ msgctxt "dlgSgRebaseInteractiveRemoveCommit.btn:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur:"
 msgid "It might become hard or impossible to recover the commit again."
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl%1"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl%1:"
 msgid "Do you want to remove the selected commit $1?"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.tle"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.tle:"
 msgid "Remove Commit"
 msgstr ""
 
-msgctxt "dlgSgRebaseNoop.fur"
+msgctxt "dlgSgRebaseNoop.fur:"
 msgid "Rebasing a commit onto itself is technically allowed by Git but it's a no-op and will not give a new commit nor any other meaningful changes."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoop.hdl"
+msgctxt "dlgSgRebaseNoop.hdl:"
 msgid "There is nothing to rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoop.tle"
+msgctxt "dlgSgRebaseNoop.tle:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "dlgSgRebaseNoopSelf.fur"
+msgctxt "dlgSgRebaseNoopSelf.fur:"
 msgid "Rebasing a commit onto itself is allowed by Git but will not create a new commit or any meaningful changes."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoopSelf.hdl"
+msgctxt "dlgSgRebaseNoopSelf.hdl:"
 msgid "There is nothing to rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoopSelf.tle"
+msgctxt "dlgSgRebaseNoopSelf.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9388,15 +9367,15 @@ msgctxt "dlgSgRebaseTagCommit.btn:"
 msgid "Skip Tag"
 msgstr ""
 
-msgctxt "dlgSgRebaseTagCommit.fur"
+msgctxt "dlgSgRebaseTagCommit.fur:"
 msgid "After the rebase, the remaining commit won't be reachable anymore."
 msgstr ""
 
-msgctxt "dlgSgRebaseTagCommit.hdl%1"
+msgctxt "dlgSgRebaseTagCommit.hdl%1:"
 msgid "Should commit $1 be tagged?"
 msgstr ""
 
-msgctxt "dlgSgRebaseTagCommit.tle"
+msgctxt "dlgSgRebaseTagCommit.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9404,15 +9383,15 @@ msgctxt "dlgSgRebasingAbortConfirm.btn:"
 msgid "Abort Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebasingAbortConfirm.fur"
+msgctxt "dlgSgRebasingAbortConfirm.fur:"
 msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase HEAD To instead.\\n\\nAborting will clean any local modification \\(by invoking 'git reset --hard'\\)!"
 msgstr ""
 
-msgctxt "dlgSgRebasingAbortConfirm.hdl"
+msgctxt "dlgSgRebasingAbortConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
 msgstr ""
 
-msgctxt "dlgSgRebasingAbortConfirm.tle"
+msgctxt "dlgSgRebasingAbortConfirm.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -9424,11 +9403,11 @@ msgctxt "dlgSgRecursiveStage.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRecursiveStage.hdl"
+msgctxt "dlgSgRecursiveStage.hdl:"
 msgid "Save working tree changes in the Index for later commit"
 msgstr ""
 
-msgctxt "dlgSgRecursiveStage.inf"
+msgctxt "dlgSgRecursiveStage.inf:"
 msgid "Select the files to stage to the Index."
 msgstr ""
 
@@ -9444,7 +9423,7 @@ msgctxt "dlgSgRecursiveStage.mni:"
 msgid "Toggle"
 msgstr ""
 
-msgctxt "dlgSgRecursiveStage.tle"
+msgctxt "dlgSgRecursiveStage.tle:"
 msgid "Stage"
 msgstr ""
 
@@ -9456,15 +9435,15 @@ msgctxt "dlgSgRecursiveUnstage.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRecursiveUnstage.hdl"
+msgctxt "dlgSgRecursiveUnstage.hdl:"
 msgid "Revert staged changes from the Index to the working tree"
 msgstr ""
 
-msgctxt "dlgSgRecursiveUnstage.inf"
+msgctxt "dlgSgRecursiveUnstage.inf:"
 msgid "Select the files to unstage from the Index."
 msgstr ""
 
-msgctxt "dlgSgRecursiveUnstage.tle"
+msgctxt "dlgSgRecursiveUnstage.tle:"
 msgid "Unstage"
 msgstr ""
 
@@ -9480,15 +9459,15 @@ msgctxt "dlgSgRemoteDeleteConfirm.btn:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgRemoteDeleteConfirm.fur"
+msgctxt "dlgSgRemoteDeleteConfirm.fur:"
 msgid "This will just delete the link to the remote repository."
 msgstr ""
 
-msgctxt "dlgSgRemoteDeleteConfirm.hdl%1"
+msgctxt "dlgSgRemoteDeleteConfirm.hdl%1:"
 msgid "Do you want to delete the remote repository '$1'?"
 msgstr ""
 
-msgctxt "dlgSgRemoteDeleteConfirm.tle"
+msgctxt "dlgSgRemoteDeleteConfirm.tle:"
 msgid "Delete Remote Repository"
 msgstr ""
 
@@ -9500,27 +9479,27 @@ msgctxt "dlgSgRemoteFetchMore.col:"
 msgid "Branch"
 msgstr ""
 
-msgctxt "dlgSgRemoteFetchMore.hdl"
+msgctxt "dlgSgRemoteFetchMore.hdl:"
 msgid "Fetch remote branches"
 msgstr ""
 
-msgctxt "dlgSgRemoteFetchMore.inf"
+msgctxt "dlgSgRemoteFetchMore.inf:"
 msgid "Select the branches to fetch from the remote repository."
 msgstr ""
 
-msgctxt "dlgSgRemoteFetchMore.tle"
+msgctxt "dlgSgRemoteFetchMore.tle:"
 msgid "Fetch More"
 msgstr ""
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.fur"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.fur:"
 msgid "All branches which are present in the remote repository are already locally present as well."
 msgstr ""
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.hdl"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.hdl:"
 msgid "There are no more remote branches to fetch."
 msgstr ""
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.tle"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.tle:"
 msgid "Fetch More"
 msgstr ""
 
@@ -9532,15 +9511,15 @@ msgctxt "dlgSgRemoteProperties.edt:"
 msgid "URL or Path"
 msgstr ""
 
-msgctxt "dlgSgRemoteProperties.hdl"
+msgctxt "dlgSgRemoteProperties.hdl:"
 msgid "Configure remote properties"
 msgstr ""
 
-msgctxt "dlgSgRemoteProperties.inf"
+msgctxt "dlgSgRemoteProperties.inf:"
 msgid "Change the URL and other properties for the remote."
 msgstr ""
 
-msgctxt "dlgSgRemoteProperties.tle"
+msgctxt "dlgSgRemoteProperties.tle:"
 msgid "Remote Properties"
 msgstr ""
 
@@ -9548,15 +9527,15 @@ msgctxt "dlgSgRemoteSelect.edt:"
 msgid "Remote"
 msgstr ""
 
-msgctxt "dlgSgRemoteSelect.hdl"
+msgctxt "dlgSgRemoteSelect.hdl:"
 msgid "Initialize remote review database"
 msgstr ""
 
-msgctxt "dlgSgRemoteSelect.inf"
+msgctxt "dlgSgRemoteSelect.inf:"
 msgid "Select the remote repository for which you want to initialize the review database."
 msgstr ""
 
-msgctxt "dlgSgRemoteSelect.tle"
+msgctxt "dlgSgRemoteSelect.tle:"
 msgid "Initialize Remote"
 msgstr ""
 
@@ -9572,15 +9551,15 @@ msgctxt "dlgSgRemoteSetDepth.err:"
 msgid "Please enter a valid commit count."
 msgstr ""
 
-msgctxt "dlgSgRemoteSetDepth.hdl"
+msgctxt "dlgSgRemoteSetDepth.hdl:"
 msgid "Set repository depth"
 msgstr ""
 
-msgctxt "dlgSgRemoteSetDepth.inf"
+msgctxt "dlgSgRemoteSetDepth.inf:"
 msgid "Use a large number \\(e.g. 100000\\) to set an unlimited depth."
 msgstr ""
 
-msgctxt "dlgSgRemoteSetDepth.tle"
+msgctxt "dlgSgRemoteSetDepth.tle:"
 msgid "Set Depth"
 msgstr ""
 
@@ -9600,11 +9579,11 @@ msgctxt "dlgSgRemotesAdd.edt:"
 msgid "URL or Path"
 msgstr ""
 
-msgctxt "dlgSgRemotesAdd.hdl"
+msgctxt "dlgSgRemotesAdd.hdl:"
 msgid "Add a remote repository"
 msgstr ""
 
-msgctxt "dlgSgRemotesAdd.inf"
+msgctxt "dlgSgRemotesAdd.inf:"
 msgid "Enter the URL and a short name for the remote repository."
 msgstr ""
 
@@ -9640,19 +9619,19 @@ msgctxt "dlgSgRemotesAdd.mni:"
 msgid "Select Local Repository"
 msgstr ""
 
-msgctxt "dlgSgRemotesAdd.tle"
+msgctxt "dlgSgRemotesAdd.tle:"
 msgid "Add Remote Repository"
 msgstr ""
 
-msgctxt "dlgSgRemotesNoRemoteDetected.fur%1"
+msgctxt "dlgSgRemotesNoRemoteDetected.fur%1:"
 msgid "To perform the operation the repository configuration for $1 must contain one uniquely determined remote."
 msgstr ""
 
-msgctxt "dlgSgRemotesNoRemoteDetected.hdl"
+msgctxt "dlgSgRemotesNoRemoteDetected.hdl:"
 msgid "No remote detected."
 msgstr ""
 
-msgctxt "dlgSgRemotesNoRemoteDetected.tle"
+msgctxt "dlgSgRemotesNoRemoteDetected.tle:"
 msgid "Push Up To"
 msgstr ""
 
@@ -9672,15 +9651,15 @@ msgctxt "dlgSgRemove.col:"
 msgid "Name"
 msgstr ""
 
-msgctxt "dlgSgRemove.hdl"
+msgctxt "dlgSgRemove.hdl:"
 msgid "Remove files from the repository"
 msgstr ""
 
-msgctxt "dlgSgRemove.inf"
+msgctxt "dlgSgRemove.inf:"
 msgid "Select the files you want to remove from the repository or working tree \\(stopped from tracking\\)."
 msgstr ""
 
-msgctxt "dlgSgRemove.tle"
+msgctxt "dlgSgRemove.tle:"
 msgid "Remove"
 msgstr ""
 
@@ -9696,15 +9675,15 @@ msgctxt "dlgSgRenameBranch.err:"
 msgid "The name must not end with a slash or dot."
 msgstr ""
 
-msgctxt "dlgSgRenameBranch.hdl"
+msgctxt "dlgSgRenameBranch.hdl:"
 msgid "Rename branch"
 msgstr ""
 
-msgctxt "dlgSgRenameBranch.inf%1"
+msgctxt "dlgSgRenameBranch.inf%1:"
 msgid "Enter the new name for the branch '$1'."
 msgstr ""
 
-msgctxt "dlgSgRenameBranch.tle"
+msgctxt "dlgSgRenameBranch.tle:"
 msgid "Rename"
 msgstr ""
 
@@ -9720,15 +9699,15 @@ msgctxt "dlgSgRenameFile.err:"
 msgid "No valid path specified."
 msgstr ""
 
-msgctxt "dlgSgRenameFile.hdl"
+msgctxt "dlgSgRenameFile.hdl:"
 msgid "Move or Rename the file"
 msgstr ""
 
-msgctxt "dlgSgRenameFile.inf"
+msgctxt "dlgSgRenameFile.inf:"
 msgid "Enter the new path and name of the file."
 msgstr ""
 
-msgctxt "dlgSgRenameFile.tle"
+msgctxt "dlgSgRenameFile.tle:"
 msgid "Move or Rename"
 msgstr ""
 
@@ -9740,15 +9719,15 @@ msgctxt "dlgSgRenameRemote.edt:"
 msgid "Name"
 msgstr ""
 
-msgctxt "dlgSgRenameRemote.hdl"
+msgctxt "dlgSgRenameRemote.hdl:"
 msgid "Change the name of an existing remote"
 msgstr ""
 
-msgctxt "dlgSgRenameRemote.inf"
+msgctxt "dlgSgRenameRemote.inf:"
 msgid "Provide the new name of the selected remote."
 msgstr ""
 
-msgctxt "dlgSgRenameRemote.tle"
+msgctxt "dlgSgRenameRemote.tle:"
 msgid "Rename Remote Repository"
 msgstr ""
 
@@ -9760,15 +9739,15 @@ msgctxt "dlgSgRenameRepository.edt:"
 msgid "Name"
 msgstr ""
 
-msgctxt "dlgSgRenameRepository.hdl"
+msgctxt "dlgSgRenameRepository.hdl:"
 msgid "Rename repository"
 msgstr ""
 
-msgctxt "dlgSgRenameRepository.inf"
+msgctxt "dlgSgRenameRepository.inf:"
 msgid "Provide the new name for the repository. The repository directory will not be renamed."
 msgstr ""
 
-msgctxt "dlgSgRenameRepository.tle"
+msgctxt "dlgSgRenameRepository.tle:"
 msgid "Rename"
 msgstr ""
 
@@ -9788,11 +9767,11 @@ msgctxt "dlgSgRepositoriesSearch.edt:"
 msgid "Search In"
 msgstr ""
 
-msgctxt "dlgSgRepositoriesSearch.hdl"
+msgctxt "dlgSgRepositoriesSearch.hdl:"
 msgid "Search existing local repositories"
 msgstr ""
 
-msgctxt "dlgSgRepositoriesSearch.inf"
+msgctxt "dlgSgRepositoriesSearch.inf:"
 msgid "Select a root directory where the search should start and click 'Start Search'."
 msgstr ""
 
@@ -9828,7 +9807,7 @@ msgctxt "dlgSgRepositoriesSearch.mni:"
 msgid "Toggle"
 msgstr ""
 
-msgctxt "dlgSgRepositoriesSearch.tle"
+msgctxt "dlgSgRepositoriesSearch.tle:"
 msgid "Search for Repositories"
 msgstr ""
 
@@ -9840,15 +9819,15 @@ msgctxt "dlgSgRepositoryAddGroup.edt:"
 msgid "Group Name"
 msgstr ""
 
-msgctxt "dlgSgRepositoryAddGroup.hdl"
+msgctxt "dlgSgRepositoryAddGroup.hdl:"
 msgid "Enter the group name"
 msgstr ""
 
-msgctxt "dlgSgRepositoryAddGroup.inf"
+msgctxt "dlgSgRepositoryAddGroup.inf:"
 msgid "After having created the group, you can move repositories inside it."
 msgstr ""
 
-msgctxt "dlgSgRepositoryAddGroup.tle"
+msgctxt "dlgSgRepositoryAddGroup.tle:"
 msgid "Add Group"
 msgstr ""
 
@@ -9865,15 +9844,15 @@ msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Exit"
 msgstr ""
 
-msgctxt "dlgSgRepositoryClose.fur"
+msgctxt "dlgSgRepositoryClose.fur:"
 msgid "Note that currently running Git processes might not be interrupted."
 msgstr ""
 
-msgctxt "dlgSgRepositoryClose.hdl"
+msgctxt "dlgSgRepositoryClose.hdl:"
 msgid "Do you really want to close now?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryClose.tle"
+msgctxt "dlgSgRepositoryClose.tle:"
 msgid "Close"
 msgstr ""
 
@@ -9881,19 +9860,19 @@ msgctxt "dlgSgRepositoryFrameCloseWithoutPush.btn:"
 msgid "Close Now"
 msgstr ""
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.chk"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.fur"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.fur:"
 msgid "You have pushable commits. Maybe you want to push them before closing this window."
 msgstr ""
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.hdl"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.hdl:"
 msgid "Do you want to close without having pushed commits?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.tle"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.tle:"
 msgid "Close"
 msgstr ""
 
@@ -9901,91 +9880,91 @@ msgctxt "dlgSgRepositoryOpen.btn:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlgSgRepositoryOpen.fur"
+msgctxt "dlgSgRepositoryOpen.fur:"
 msgid "If it is relocated, remove it and add its new location."
 msgstr ""
 
-msgctxt "dlgSgRepositoryOpen.hdl%1"
+msgctxt "dlgSgRepositoryOpen.hdl%1:"
 msgid "Do you want to remove the missing repository '$1'?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryOpen.tle"
+msgctxt "dlgSgRepositoryOpen.tle:"
 msgid "Repository Opening"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveFailed1.fur"
+msgctxt "dlgSgRepositoryRemoveFailed1.fur:"
 msgid "This could happen if the repository is open in another window or currently commands are executed."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveFailed1.hdl%1"
+msgctxt "dlgSgRepositoryRemoveFailed1.hdl%1:"
 msgid "The repository '$1' could not be removed."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveFailed1.tle"
+msgctxt "dlgSgRepositoryRemoveFailed1.tle:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl%1"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl%1:"
 msgid "Do you want to remove $1 groups?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl%1"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl%1:"
 msgid "Do you want to remove $1 repositories?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl%2:"
 msgid "Do you want to remove $1 repositories and $2 groups?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl%2:"
 msgid "Do you want to remove $1 repositories and the group \"$2\"?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl%1"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl%1:"
 msgid "Do you want to remove the group \"$1\"?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl%1"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl%1:"
 msgid "Do you want to remove the repository \"$1\"?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl%2:"
 msgid "Do you want to remove the repository \"$1\" and $2 groups?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl%2:"
 msgid "Do you want to remove the repository \"$1\" and the group \"$2\"?"
 msgstr ""
 
@@ -10065,13 +10044,13 @@ msgctxt "dlgSgRepositorySettings.err:"
 msgid "Please enter a valid, comma-separated list of regular expressions."
 msgstr ""
 
-msgctxt "dlgSgRepositorySettings.hdl"
+msgctxt "dlgSgRepositorySettings.hdl:"
 msgid "Edit the repository settings"
 msgstr ""
 
 #, fuzzy
 #| msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
-msgctxt "dlgSgRepositorySettings.inf"
+msgctxt "dlgSgRepositorySettings.inf:"
 msgid "Here you can edit the Git settings for the repository. The default settings can be found in the Preferences."
 msgstr ""
 
@@ -10111,7 +10090,7 @@ msgctxt "dlgSgRepositorySettings.tab:"
 msgid "User"
 msgstr ""
 
-msgctxt "dlgSgRepositorySettings.tle"
+msgctxt "dlgSgRepositorySettings.tle:"
 msgid "Repository Settings"
 msgstr ""
 
@@ -10160,7 +10139,7 @@ msgctxt "dlgSgResetAdv.chk:"
 msgid "Thoroughly fix line-endings according to .gitattributes"
 msgstr ""
 
-msgctxt "dlgSgResetAdv.hdl%1"
+msgctxt "dlgSgResetAdv.hdl%1:"
 msgid "Reset to commit $1"
 msgstr ""
 
@@ -10208,7 +10187,7 @@ msgctxt "dlgSgResetAdv.rbt:"
 msgid "Reset the Index but not the working tree - 'mixed'"
 msgstr ""
 
-msgctxt "dlgSgResetAdv.tle"
+msgctxt "dlgSgResetAdv.tle:"
 msgid "Reset"
 msgstr ""
 
@@ -10216,15 +10195,15 @@ msgctxt "dlgSgResetConfirm.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgResetConfirm.fur"
+msgctxt "dlgSgResetConfirm.fur:"
 msgid "Current staged and local changes will be lost!"
 msgstr ""
 
-msgctxt "dlgSgResetConfirm.hdl%1"
+msgctxt "dlgSgResetConfirm.hdl%1:"
 msgid "Do you want to reset the HEAD to commit $1?"
 msgstr ""
 
-msgctxt "dlgSgResetConfirm.tle"
+msgctxt "dlgSgResetConfirm.tle:"
 msgid "Reset"
 msgstr ""
 
@@ -10240,11 +10219,11 @@ msgctxt "dlgSgResolve.edt:"
 msgid "Content"
 msgstr ""
 
-msgctxt "dlgSgResolve.hdl"
+msgctxt "dlgSgResolve.hdl:"
 msgid "Resolve Conflict"
 msgstr ""
 
-msgctxt "dlgSgResolve.inf"
+msgctxt "dlgSgResolve.inf:"
 msgid "Select which content to use for the resolved file\\(s\\)."
 msgstr ""
 
@@ -10256,23 +10235,23 @@ msgctxt "dlgSgResolve.rbt:"
 msgid "Open Conflict Solver"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"ours\", $2\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"theirs\", $2\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\""
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebase target \\(\"theirs\", $1\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.tle"
+msgctxt "dlgSgResolve.tle:"
 msgid "Resolve"
 msgstr ""
 
@@ -10280,15 +10259,15 @@ msgctxt "dlgSgResolveManuallyModifiedSingle.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.fur%1"
+msgctxt "dlgSgResolveManuallyModifiedSingle.fur:"
 msgid "$1 seems to contain manual conflict resolutions. They will be lost when continuing."
 msgstr ""
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.hdl"
+msgctxt "dlgSgResolveManuallyModifiedSingle.hdl:"
 msgid "Do you want to overwrite your manual conflict resolution?"
 msgstr ""
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.tle"
+msgctxt "dlgSgResolveManuallyModifiedSingle.tle:"
 msgid "Resolve"
 msgstr ""
 
@@ -10296,11 +10275,11 @@ msgctxt "dlgSgResolveSubmodule.btn:"
 msgid "Resolve"
 msgstr ""
 
-msgctxt "dlgSgResolveSubmodule.hdl"
+msgctxt "dlgSgResolveSubmodule.hdl:"
 msgid "Resolve Conflict"
 msgstr ""
 
-msgctxt "dlgSgResolveSubmodule.inf"
+msgctxt "dlgSgResolveSubmodule.inf:"
 msgid "Select to which submodule commit you want to resolve."
 msgstr ""
 
@@ -10312,7 +10291,7 @@ msgctxt "dlgSgResolveSubmodule.rbt:"
 msgid "Leave submodule pointer as is"
 msgstr ""
 
-msgctxt "dlgSgResolveSubmodule.tle"
+msgctxt "dlgSgResolveSubmodule.tle:"
 msgid "Resolve"
 msgstr ""
 
@@ -10324,15 +10303,15 @@ msgctxt "dlgSgRevealCommitLocalOrTracked.btn:"
 msgid "Reveal Tracked"
 msgstr ""
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.chk"
+msgctxt "dlgSgRevealCommitLocalOrTracked.chk:"
 msgid "Always reveal local branch"
 msgstr ""
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.fur%2"
+msgctxt "dlgSgRevealCommitLocalOrTracked.fur:"
 msgid "Select whether to reveal '$1' or '$2'."
 msgstr ""
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.hdl"
+msgctxt "dlgSgRevealCommitLocalOrTracked.hdl:"
 msgid "Do you want to reveal the local or the tracked branch?"
 msgstr ""
 
@@ -10352,15 +10331,15 @@ msgctxt "dlgSgRevertAndCommitConfirmSingle.btn:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.fur"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.fur:"
 msgid "This will undo the changes introduced with the selected commit."
 msgstr ""
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.hdl"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.hdl:"
 msgid "Do you want to revert the selected commit?"
 msgstr ""
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.tle"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.tle:"
 msgid "Revert"
 msgstr ""
 
@@ -10368,7 +10347,7 @@ msgctxt "dlgSgRevertConfigurationFile.btn:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "dlgSgRevertConfigurationFile.fur"
+msgctxt "dlgSgRevertConfigurationFile.fur:"
 msgid "Only changes of these files will be reverted \\(without committing\\)."
 msgstr ""
 
@@ -10376,35 +10355,35 @@ msgctxt "dlgSgRevertConfigurationFile.hdl:"
 msgid "Do you want to revert changes of '$1'?"
 msgstr ""
 
-msgctxt "dlgSgRevertConfigurationFile.tle"
+msgctxt "dlgSgRevertConfigurationFile.tle:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "dlgSgRevertInProgress.fur"
+msgctxt "dlgSgRevertInProgress.fur:"
 msgid "You have to finish the Revert before you can continue. To finish the Revert use Commit, to abort use Discard."
 msgstr ""
 
-msgctxt "dlgSgRevertInProgress.hdl"
+msgctxt "dlgSgRevertInProgress.hdl:"
 msgid "There is currently a Revert in progress."
 msgstr ""
 
-msgctxt "dlgSgRevertInProgress.tle"
+msgctxt "dlgSgRevertInProgress.tle:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.chk"
+msgctxt "dlgSgRevertNotAllConflictsResolved.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.fur"
+msgctxt "dlgSgRevertNotAllConflictsResolved.fur:"
 msgid "You may need to resolve the conflicts before proceeding."
 msgstr ""
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.hdl"
+msgctxt "dlgSgRevertNotAllConflictsResolved.hdl:"
 msgid "Reverting failed because of conflicts."
 msgstr ""
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.tle"
+msgctxt "dlgSgRevertNotAllConflictsResolved.tle:"
 msgid "Revert"
 msgstr ""
 
@@ -10412,11 +10391,11 @@ msgctxt "dlgSgReviewCommentAdd.btn:"
 msgid "Add"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentAdd.hdl"
+msgctxt "dlgSgReviewCommentAdd.hdl:"
 msgid "Add comment"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentAdd.tle"
+msgctxt "dlgSgReviewCommentAdd.tle:"
 msgid "Add Comment"
 msgstr ""
 
@@ -10424,11 +10403,11 @@ msgctxt "dlgSgReviewCommentEdit.btn:"
 msgid "Edit"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentEdit.hdl"
+msgctxt "dlgSgReviewCommentEdit.hdl:"
 msgid "Edit comment"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentEdit.tle"
+msgctxt "dlgSgReviewCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr ""
 
@@ -10436,11 +10415,11 @@ msgctxt "dlgSgReviewCommentReply.btn:"
 msgid "Reply"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentReply.hdl"
+msgctxt "dlgSgReviewCommentReply.hdl:"
 msgid "Reply to selected comment"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentReply.tle"
+msgctxt "dlgSgReviewCommentReply.tle:"
 msgid "Reply To Comment"
 msgstr ""
 
@@ -10448,7 +10427,7 @@ msgctxt "dlgSgReviewComment(Add|Edit|Reply).edt:"
 msgid "Text"
 msgstr ""
 
-msgctxt "dlgSgReviewComment(Add|Edit|Reply).inf"
+msgctxt "dlgSgReviewComment(Add|Edit|Reply).inf:"
 msgid "Enter the text of the comment."
 msgstr ""
 
@@ -10456,15 +10435,15 @@ msgctxt "dlgSgReviewConfigureDisposeDatabase.btn:"
 msgid "Dispose"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.fur"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.fur:"
 msgid "This will disable the Reviewing system and unpushed local data will be lost."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.hdl"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.hdl:"
 msgid "Do you really want to dispose all local review data?"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.tle"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.tle:"
 msgid "Dispose Database"
 msgstr ""
 
@@ -10472,15 +10451,15 @@ msgctxt "dlgSgReviewConfigureForGitHub.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureForGitHub.fur"
+msgctxt "dlgSgReviewConfigureForGitHub.fur:"
 msgid "This repository is connected to a GitHub server. GitHub comes with its own reviewing concepts, like commit comments and pull requests. Hence, you probably do not want to have SmartGit's review database in addition to GitHub's existing capabilities."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureForGitHub.hdl"
+msgctxt "dlgSgReviewConfigureForGitHub.hdl:"
 msgid "Do you really want to configure SmartGit's review database for your GitHub repository?"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureForGitHub.tle"
+msgctxt "dlgSgReviewConfigureForGitHub.tle:"
 msgid "Configure Review System"
 msgstr ""
 
@@ -10488,15 +10467,15 @@ msgctxt "dlgSgReviewConfigureIntializeNew.btn:"
 msgid "Initialize"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureIntializeNew.fur"
+msgctxt "dlgSgReviewConfigureIntializeNew.fur:"
 msgid "This will create a new Review database in the current repository which may be pushed to other remotes later."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureIntializeNew.hdl"
+msgctxt "dlgSgReviewConfigureIntializeNew.hdl:"
 msgid "Do you want to initialize a new Review database?"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureIntializeNew.tle"
+msgctxt "dlgSgReviewConfigureIntializeNew.tle:"
 msgid "Configure Review System"
 msgstr ""
 
@@ -10512,15 +10491,15 @@ msgctxt "dlgSgReviewConfigureWhat.btn:"
 msgid "Initialize a Remote"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureWhat.fur"
+msgctxt "dlgSgReviewConfigureWhat.fur:"
 msgid "The user database allows to define aliases \\(e.g. @mike\\) that make addressing teammates easier in review comments."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureWhat.hdl"
+msgctxt "dlgSgReviewConfigureWhat.hdl:"
 msgid "Select what you want to configure."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureWhat.tle"
+msgctxt "dlgSgReviewConfigureWhat.tle:"
 msgid "Configure Review Database"
 msgstr ""
 
@@ -10528,15 +10507,15 @@ msgctxt "dlgSgReviewPullRequestClose.edt:"
 msgid "Comment"
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestClose.hdl"
+msgctxt "dlgSgReviewPullRequestClose.hdl:"
 msgid "Close Pull Request"
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestClose.inf"
+msgctxt "dlgSgReviewPullRequestClose.inf:"
 msgid "Enter the comment which will be logged when closing the pull request."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestClose.tle"
+msgctxt "dlgSgReviewPullRequestClose.tle:"
 msgid "Close Pull Request"
 msgstr ""
 
@@ -10556,11 +10535,11 @@ msgctxt "dlgSgReviewPullRequestCreate.err:"
 msgid "Unknown user '$1'."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestCreate.hdl"
+msgctxt "dlgSgReviewPullRequestCreate.hdl:"
 msgid "Create a Pull Request"
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestCreate.inf"
+msgctxt "dlgSgReviewPullRequestCreate.inf:"
 msgid "A Pull Request suggests the integration of one branch into another."
 msgstr ""
 
@@ -10572,7 +10551,7 @@ msgctxt "dlgSgReviewPullRequestCreate.lbl:"
 msgid "The pull request will be highlighted to those users which are listed as assignees."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestCreate.tle"
+msgctxt "dlgSgReviewPullRequestCreate.tle:"
 msgid "Create Pull Request"
 msgstr ""
 
@@ -10592,15 +10571,15 @@ msgctxt "dlgSgReviewPullRequestState.err:"
 msgid "Unknown user '$1'."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestState.hdl"
+msgctxt "dlgSgReviewPullRequestState.hdl:"
 msgid "Assign Pull Request"
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestState.inf"
+msgctxt "dlgSgReviewPullRequestState.inf:"
 msgid "Enter the user\\(s\\) to which the Pull Request should be assigned to."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestState.tle"
+msgctxt "dlgSgReviewPullRequestState.tle:"
 msgid "Assign"
 msgstr ""
 
@@ -10636,7 +10615,7 @@ msgctxt "dlgSgReviewUserAddEdit.hdl:"
 msgid "Edit User"
 msgstr ""
 
-msgctxt "dlgSgReviewUserAddEdit.inf"
+msgctxt "dlgSgReviewUserAddEdit.inf:"
 msgid "Enter the user's name and email address \\(as used for Git\\), one or more space- or comma-separated aliases and optional contact details."
 msgstr ""
 
@@ -10692,7 +10671,7 @@ msgctxt "dlgSgReviewUsersEdit.hdl:"
 msgid "Edit review database users"
 msgstr ""
 
-msgctxt "dlgSgReviewUsersEdit.inf"
+msgctxt "dlgSgReviewUsersEdit.inf:"
 msgid "Users can have aliases which are used in comment texts and they have optional contact details."
 msgstr ""
 
@@ -10712,15 +10691,15 @@ msgctxt "dlgSgRollbackToCommit.btn:"
 msgid "Rollback"
 msgstr ""
 
-msgctxt "dlgSgRollbackToCommit.fur"
+msgctxt "dlgSgRollbackToCommit.fur:"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr ""
 
-msgctxt "dlgSgRollbackToCommit.hdl%1"
+msgctxt "dlgSgRollbackToCommit.hdl%1:"
 msgid "Do you want to rollback the Index to the state of commit $1?"
 msgstr ""
 
-msgctxt "dlgSgRollbackToCommit.tle"
+msgctxt "dlgSgRollbackToCommit.tle:"
 msgid "Rollback To"
 msgstr ""
 
@@ -10732,7 +10711,7 @@ msgctxt "dlgSgRollbackToFiles.btn:"
 msgid "Rollback"
 msgstr ""
 
-msgctxt "dlgSgRollbackToFiles.fur"
+msgctxt "dlgSgRollbackToFiles.fur:"
 msgid "All differences of the selected files between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr ""
 
@@ -10740,7 +10719,7 @@ msgctxt "dlgSgRollbackToFiles.hdl:"
 msgid "Do you want to rollback the selected files to the state of commit $1?"
 msgstr ""
 
-msgctxt "dlgSgRollbackToFiles.tle"
+msgctxt "dlgSgRollbackToFiles.tle:"
 msgid "Rollback To"
 msgstr ""
 
@@ -10764,7 +10743,7 @@ msgctxt "dlgSgSelectBranch.inf:"
 msgid "Select which auxiliary branch should be shown in addition to the current branch."
 msgstr ""
 
-msgctxt "dlgSgSelectBranch.tle"
+msgctxt "dlgSgSelectBranch.tle:"
 msgid "Set Tracked Branch"
 msgstr ""
 
@@ -10996,10 +10975,6 @@ msgctxt "dlgSgSetup.rbt:"
 msgid "Working tree \\(file oriented\\)"
 msgstr ""
 
-msgctxt "dlgSgSetup.tle"
-msgid "Setup SmartGit 24.1.3"
-msgstr ""
-
 msgctxt "dlgSgSetup.tle:"
 msgid "Setup SmartGit $1"
 msgstr ""
@@ -11013,15 +10988,15 @@ msgid "Use Standard Window"
 msgstr ""
 
 #| msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
-msgctxt "dlgSgSetupStdWnd.fur"
+msgctxt "dlgSgSetupStdWnd.fur:"
 msgid "We recommend the Standard window for \\*new SmartGit users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 msgstr ""
 
-msgctxt "dlgSgSetupStdWnd.hdl"
+msgctxt "dlgSgSetupStdWnd.hdl:"
 msgid "Do you want to use the Standard Window?"
 msgstr ""
 
-msgctxt "dlgSgSetupStdWnd.tle%1"
+msgctxt "dlgSgSetupStdWnd.tle%1:"
 msgid "Setup SmartGit $1"
 msgstr ""
 
@@ -11029,11 +11004,11 @@ msgctxt "dlgSgShowLocalChanges.btn:"
 msgid "Compare"
 msgstr ""
 
-msgctxt "dlgSgShowLocalChanges.hdl%1"
+msgctxt "dlgSgShowLocalChanges.hdl%1:"
 msgid "File $1 modified in Index and working tree"
 msgstr ""
 
-msgctxt "dlgSgShowLocalChanges.inf"
+msgctxt "dlgSgShowLocalChanges.inf:"
 msgid "Select the file states to compare."
 msgstr ""
 
@@ -11049,7 +11024,7 @@ msgctxt "dlgSgShowLocalChanges.rbt:"
 msgid "Index vs. Working Tree"
 msgstr ""
 
-msgctxt "dlgSgShowLocalChanges.tle"
+msgctxt "dlgSgShowLocalChanges.tle:"
 msgid "Show Changes"
 msgstr ""
 
@@ -11073,27 +11048,27 @@ msgctxt "dlgSgSplitOffFiles.edt:"
 msgid "Commit Message"
 msgstr ""
 
-msgctxt "dlgSgSplitOffFiles.hdl"
+msgctxt "dlgSgSplitOffFiles.hdl:"
 msgid "Move files to a second commit"
 msgstr ""
 
-msgctxt "dlgSgSplitOffFiles.inf"
+msgctxt "dlgSgSplitOffFiles.inf:"
 msgid "Provide the message for the second commit that should contain the changes from the selected files."
 msgstr ""
 
-msgctxt "dlgSgSplitOffFiles.tle"
+msgctxt "dlgSgSplitOffFiles.tle:"
 msgid "Split Off Files"
 msgstr ""
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.fur"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.fur:"
 msgid "By splitting off all files, the resulting commit would become empty."
 msgstr ""
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.hdl"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.hdl:"
 msgid "You can't split off all files from a commit"
 msgstr ""
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.tle"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -11125,11 +11100,11 @@ msgctxt "dlgSgSshCredentials.edt:"
 msgid "Private Key File"
 msgstr ""
 
-msgctxt "dlgSgSshCredentials.hdl"
+msgctxt "dlgSgSshCredentials.hdl:"
 msgid "SSH Credentials"
 msgstr ""
 
-msgctxt "dlgSgSshCredentials.inf%2"
+msgctxt "dlgSgSshCredentials.inf%2:"
 msgid "Provide the credentials for authenticating to the SSH server '$1' as user '$2'."
 msgstr ""
 
@@ -11145,7 +11120,7 @@ msgctxt "dlgSgSshCredentials.rbt:"
 msgid "Private Key"
 msgstr ""
 
-msgctxt "dlgSgSshCredentials.tle"
+msgctxt "dlgSgSshCredentials.tle:"
 msgid "SSH Authentication"
 msgstr ""
 
@@ -11157,27 +11132,27 @@ msgctxt "dlgSgStageConflict.btn:"
 msgid "Stage Anyway"
 msgstr ""
 
-msgctxt "dlgSgStageConflict.fur"
+msgctxt "dlgSgStageConflict.fur:"
 msgid "The file contains conflict markers which indicate that you have not resolved all conflicts."
 msgstr ""
 
-msgctxt "dlgSgStageConflict.hdl%1"
+msgctxt "dlgSgStageConflict.hdl%1:"
 msgid "Should $1 really be staged?"
 msgstr ""
 
-msgctxt "dlgSgStageConflict.tle"
+msgctxt "dlgSgStageConflict.tle:"
 msgid "Stage"
 msgstr ""
 
-msgctxt "dlgSgStageNoFilesFound.fur"
+msgctxt "dlgSgStageNoFilesFound.fur:"
 msgid "Could not find files with modified working tree, untracked or missing files."
 msgstr ""
 
-msgctxt "dlgSgStageNoFilesFound.hdl"
+msgctxt "dlgSgStageNoFilesFound.hdl:"
 msgid "No files found that could be staged."
 msgstr ""
 
-msgctxt "dlgSgStageNoFilesFound.tle"
+msgctxt "dlgSgStageNoFilesFound.tle:"
 msgid "Stage"
 msgstr ""
 
@@ -11197,15 +11172,15 @@ msgctxt "dlgSgStartupExpired.btn:"
 msgid "Exit"
 msgstr ""
 
-msgctxt "dlgSgStartupExpired.fur"
+msgctxt "dlgSgStartupExpired.fur:"
 msgid "Please download and install a new one or a release version."
 msgstr ""
 
-msgctxt "dlgSgStartupExpired.hdl"
+msgctxt "dlgSgStartupExpired.hdl:"
 msgid "This beta version expired."
 msgstr ""
 
-msgctxt "dlgSgStartupExpired.tle"
+msgctxt "dlgSgStartupExpired.tle:"
 msgid "Beta Version Expired"
 msgstr ""
 
@@ -11229,15 +11204,15 @@ msgctxt "dlgSgStashAll.edt:"
 msgid "Message"
 msgstr ""
 
-msgctxt "dlgSgStashAll.hdl"
+msgctxt "dlgSgStashAll.hdl:"
 msgid "Stash Index and Working Tree changes"
 msgstr ""
 
-msgctxt "dlgSgStashAll.inf"
+msgctxt "dlgSgStashAll.inf:"
 msgid "The saved stash can be applied later. By default, Index and Working Tree are cleaned, but you may keep the Index or both."
 msgstr ""
 
-msgctxt "dlgSgStashAll.tle"
+msgctxt "dlgSgStashAll.tle:"
 msgid "Save Stash"
 msgstr ""
 
@@ -11261,11 +11236,11 @@ msgctxt "dlgSgStashApply.hdl:"
 msgid "Apply the latest saved stash"
 msgstr ""
 
-msgctxt "dlgSgStashApply.inf"
+msgctxt "dlgSgStashApply.inf:"
 msgid "Decide how to apply the stash to the Index or working tree."
 msgstr ""
 
-msgctxt "dlgSgStashApply.tle"
+msgctxt "dlgSgStashApply.tle:"
 msgid "Apply Stash"
 msgstr ""
 
@@ -11273,15 +11248,15 @@ msgctxt "dlgSgStashApplyWithoutRestoringIndex.btn:"
 msgid "Try Without Restoring Index"
 msgstr ""
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.fur"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.fur:"
 msgid "Restoring the index failed while applying the patch."
 msgstr ""
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.hdl"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.hdl:"
 msgid "Should the stash been applied without restoring the index?"
 msgstr ""
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.tle"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.tle:"
 msgid "Apply Stash"
 msgstr ""
 
@@ -11293,7 +11268,7 @@ msgctxt "dlgSgStashOnDemandConfirmation.btn:"
 msgid "Save Stash"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandConfirmation.chk"
+msgctxt "dlgSgStashOnDemandConfirmation.chk:"
 msgid "Automatically save stash"
 msgstr ""
 
@@ -11373,13 +11348,13 @@ msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "What to do with the working tree or Index changes?"
 msgstr ""
 
-#| msgid "Reset"
-msgctxt "dlgSgStashOnDemandConfirmation.tle"
-msgid "Edit Message"
-msgstr ""
-
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Checkout"
+msgstr ""
+
+#| msgid "Reset"
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Edit Message"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
@@ -11390,28 +11365,28 @@ msgctxt "dlgSgStashOnDemandDiscardConfirmation.btn:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandDiscardConfirmation.fur"
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.fur:"
 msgid "It might be hard or impossible to restore them!"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandDiscardConfirmation.hdl"
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.hdl:"
 msgid "Do you really want to discard the local changes?"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandDiscardConfirmation.tle"
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.tle:"
 msgid "Reset"
 msgstr ""
 
 #| msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
 msgid "Once you have concluded the Reorder Commits, you should manually apply the latest stash to get your local changes back into the working tree."
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl:"
 msgid "Your local changes have been stashed away, but could not be reapplied."
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.tle"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.tle:"
 msgid "Pull"
 msgstr ""
 
@@ -11419,15 +11394,15 @@ msgctxt "dlgSgStashOnDemandProceedWithoutStashing.btn:"
 msgid "Proceed"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.fur"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.fur:"
 msgid "Auto-stashing changes is not possible due to technical reasons. Changes will be discarded!"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.hdl"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.hdl:"
 msgid "Do you want to proceed without stashing changes?"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.tle"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.tle:"
 msgid "Reset"
 msgstr ""
 
@@ -11439,15 +11414,15 @@ msgctxt "dlgSgStashRename.edt:"
 msgid "Message"
 msgstr ""
 
-msgctxt "dlgSgStashRename.hdl"
+msgctxt "dlgSgStashRename.hdl:"
 msgid "Rename Stash"
 msgstr ""
 
-msgctxt "dlgSgStashRename.inf"
+msgctxt "dlgSgStashRename.inf:"
 msgid "Enter the new message for the stash"
 msgstr ""
 
-msgctxt "dlgSgStashRename.tle"
+msgctxt "dlgSgStashRename.tle:"
 msgid "Rename"
 msgstr ""
 
@@ -11459,15 +11434,15 @@ msgctxt "dlgSgStashesDropConfirm.btn:"
 msgid "Drop Stashes"
 msgstr ""
 
-msgctxt "dlgSgStashesDropConfirm.fur"
+msgctxt "dlgSgStashesDropConfirm.fur:"
 msgid "The stashed changes will be lost."
 msgstr ""
 
-msgctxt "dlgSgStashesDropConfirm.hdl"
+msgctxt "dlgSgStashesDropConfirm.hdl:"
 msgid "Do you want to drop the selected stash?"
 msgstr ""
 
-msgctxt "dlgSgStashesDropConfirm.tle"
+msgctxt "dlgSgStashesDropConfirm.tle:"
 msgid "Drop Stash"
 msgstr ""
 
@@ -11585,7 +11560,7 @@ msgctxt "dlgSgSubmoduleAdd.rbt:"
 msgid "Remote repository"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleAdd.tle"
+msgctxt "dlgSgSubmoduleAdd.tle:"
 msgid "Add Submodule"
 msgstr ""
 
@@ -11593,19 +11568,19 @@ msgctxt "dlgSgSubmoduleDeinitConfirm.btn:"
 msgid "Deinit"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.chk"
+msgctxt "dlgSgSubmoduleDeinitConfirm.chk:"
 msgid "Force \\(for modified submodules\\)"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.fur"
+msgctxt "dlgSgSubmoduleDeinitConfirm.fur:"
 msgid "The submodule will be skipped from the working tree. To get rid from the \\(remote\\) repository, you have to use Unregister instead."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.hdl%1"
+msgctxt "dlgSgSubmoduleDeinitConfirm.hdl%1:"
 msgid "Do you want to deinit submodule '$1'?"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.tle"
+msgctxt "dlgSgSubmoduleDeinitConfirm.tle:"
 msgid "Deinit Submodule"
 msgstr ""
 
@@ -11617,15 +11592,15 @@ msgctxt "dlgSgSubmoduleInitAll.chk:"
 msgid "Pull submodule repositories"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitAll.hdl"
+msgctxt "dlgSgSubmoduleInitAll.hdl:"
 msgid "Initialize all submodules"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitAll.inf"
+msgctxt "dlgSgSubmoduleInitAll.inf:"
 msgid "Submodule entries will be added to .git/config. You may customize the URLs afterwards or pull immediately."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitAll.tle"
+msgctxt "dlgSgSubmoduleInitAll.tle:"
 msgid "Initialize Submodule"
 msgstr ""
 
@@ -11641,15 +11616,15 @@ msgctxt "dlgSgSubmoduleInitGit.edt:"
 msgid "URL"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitGit.hdl"
+msgctxt "dlgSgSubmoduleInitGit.hdl:"
 msgid "Set submodule URL"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitGit.inf"
+msgctxt "dlgSgSubmoduleInitGit.inf:"
 msgid "You can customize the submodule's clone URL used in .git/config for your local setup."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitGit.tle"
+msgctxt "dlgSgSubmoduleInitGit.tle:"
 msgid "Initialize Submodule"
 msgstr ""
 
@@ -11657,15 +11632,15 @@ msgctxt "dlgSgSubmoduleRegister.edt:"
 msgid "URL"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleRegister.hdl"
+msgctxt "dlgSgSubmoduleRegister.hdl:"
 msgid "Register nested root as submodule"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleRegister.inf"
+msgctxt "dlgSgSubmoduleRegister.inf:"
 msgid "Select the URL for the submodule to register."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleRegister.tle"
+msgctxt "dlgSgSubmoduleRegister.tle:"
 msgid "Register Submodule"
 msgstr ""
 
@@ -11673,15 +11648,15 @@ msgctxt "dlgSgSubmoduleResetConfirm.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetConfirm.fur"
+msgctxt "dlgSgSubmoduleResetConfirm.fur:"
 msgid "The corresponding commit will be checked out, so the submodule content will match the content of the registered commit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetConfirm.hdl%1"
+msgctxt "dlgSgSubmoduleResetConfirm.hdl%1:"
 msgid "Do you want to reset submodule '$1' to the commit registered in the repository?"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetConfirm.tle"
+msgctxt "dlgSgSubmoduleResetConfirm.tle:"
 msgid "Reset Submodule"
 msgstr ""
 
@@ -11689,15 +11664,15 @@ msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.fur"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.fur:"
 msgid "The submodule HEAD is not reachable from any ref. After resetting, it will be hard to access this commit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.hdl"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.hdl:"
 msgid "Do you want to perform the reset even though you will loose access to the current HEAD commit?"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.tle"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.tle:"
 msgid "Reset Submodule"
 msgstr ""
 
@@ -11713,27 +11688,27 @@ msgctxt "dlgSgSubmoduleSync.chk:"
 msgid "Pull submodule repository"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSync.hdl"
+msgctxt "dlgSgSubmoduleSync.hdl:"
 msgid "Synchronize all submodules"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSync.inf"
+msgctxt "dlgSgSubmoduleSync.inf:"
 msgid "Submodule entries will be updated in .git/config. You may customize the URLs afterwards or pull immediately."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSync.tle"
+msgctxt "dlgSgSubmoduleSync.tle:"
 msgid "Synchronize Submodules"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSyncConfigured.fur"
+msgctxt "dlgSgSubmoduleSyncConfigured.fur:"
 msgid "You may now pull individual submodules or on the root directory to clone the configured repositories."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSyncConfigured.hdl"
+msgctxt "dlgSgSubmoduleSyncConfigured.hdl:"
 msgid "Submodules have been configured."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSyncConfigured.tle"
+msgctxt "dlgSgSubmoduleSyncConfigured.tle:"
 msgid "Synchronize Submodules"
 msgstr ""
 
@@ -11741,15 +11716,15 @@ msgctxt "dlgSgSubmoduleUnregisterConfirm.btn:"
 msgid "Unregister"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleUnregisterConfirm.fur"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.fur:"
 msgid "All relevant files will be adjusted. Afterwards you will only need to perform a commit to finish the operation. To just skip the submodule from the working tree, use Deinit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleUnregisterConfirm.hdl"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.hdl:"
 msgid "Do you want to unregister submodule '$1'?"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleUnregisterConfirm.tle"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.tle:"
 msgid "Unregister Submodule"
 msgstr ""
 
@@ -11851,7 +11826,7 @@ msgctxt "dlgSgSubtreeAdd.rbt:"
 msgid "Remote repository"
 msgstr ""
 
-msgctxt "dlgSgSubtreeAdd.tle"
+msgctxt "dlgSgSubtreeAdd.tle:"
 msgid "Add Subtree"
 msgstr ""
 
@@ -11871,19 +11846,19 @@ msgctxt "dlgSgSvnClientCertificate.edt:"
 msgid "Passphrase"
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.hdl"
+msgctxt "dlgSgSvnClientCertificate.hdl:"
 msgid "Client Certificate"
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.inf%1"
+msgctxt "dlgSgSvnClientCertificate.inf%1:"
 msgid "Provide the client certificate for authentication to the SVN repository '$1'."
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.tle"
+msgctxt "dlgSgSvnClientCertificate.tle:"
 msgid "SVN Authentication"
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\""
+msgctxt "dlgSgSvnClientCertificate.wrn:"
 msgid "Authentication to the SVN repository '$1' failed with error: $2'"
 msgstr ""
 
@@ -11915,7 +11890,7 @@ msgctxt "dlgSgSvnSslFingerprintChanged.lbl:"
 msgid "This might indicate a security problem! When in doubt, contact your server administrator."
 msgstr ""
 
-msgctxt "dlgSgSvnSslFingerprintChanged.tle"
+msgctxt "dlgSgSvnSslFingerprintChanged.tle:"
 msgid "SVN Authentication"
 msgstr ""
 
@@ -11923,19 +11898,19 @@ msgctxt "dlgSgSyncConfirm.btn:"
 msgid "Synchronize"
 msgstr ""
 
-msgctxt "dlgSgSyncConfirm.chk"
+msgctxt "dlgSgSyncConfirm.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgSyncConfirm.fur"
+msgctxt "dlgSgSyncConfirm.fur:"
 msgid "First, local changes will be pushed, then possible remote changes pulled. The advantage over a normal push is that if it fails because of remote changes, they will be pulled automatically."
 msgstr ""
 
-msgctxt "dlgSgSyncConfirm.hdl"
+msgctxt "dlgSgSyncConfirm.hdl:"
 msgid "Do you want to proceed with sync?"
 msgstr ""
 
-msgctxt "dlgSgSyncConfirm.tle"
+msgctxt "dlgSgSyncConfirm.tle:"
 msgid "Synchronize"
 msgstr ""
 
@@ -11963,15 +11938,15 @@ msgctxt "dlgSgTagAdd.err:"
 msgid "The name must not end with a slash or dot."
 msgstr ""
 
-msgctxt "dlgSgTagAdd.hdl"
+msgctxt "dlgSgTagAdd.hdl:"
 msgid "Add tag to selected commit"
 msgstr ""
 
-msgctxt "dlgSgTagAdd.inf"
+msgctxt "dlgSgTagAdd.inf:"
 msgid "Enter the name of the tag to create. If entering a message, an annotated tag is created."
 msgstr ""
 
-msgctxt "dlgSgTagAdd.tle"
+msgctxt "dlgSgTagAdd.tle:"
 msgid "Add Tag"
 msgstr ""
 
@@ -11979,15 +11954,15 @@ msgctxt "dlgSgTagAddOverwrite.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgSgTagAddOverwrite.fur"
+msgctxt "dlgSgTagAddOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different tag name."
 msgstr ""
 
-msgctxt "dlgSgTagAddOverwrite.hdl%1"
+msgctxt "dlgSgTagAddOverwrite.hdl%1:"
 msgid "The tag '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
-msgctxt "dlgSgTagAddOverwrite.tle"
+msgctxt "dlgSgTagAddOverwrite.tle:"
 msgid "Add Tag"
 msgstr ""
 
@@ -11995,23 +11970,23 @@ msgctxt "dlgSgTagDeleteConfirmSingle.btn:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk:"
 msgid "Delete from all remotes"
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk%1"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk%1:"
 msgid "Delete from remote '$1'"
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.fur"
+msgctxt "dlgSgTagDeleteConfirmSingle.fur:"
 msgid "You will not be able to restore it."
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.hdl%1"
+msgctxt "dlgSgTagDeleteConfirmSingle.hdl%1:"
 msgid "Do you want to delete the tag '$1'?"
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.tle"
+msgctxt "dlgSgTagDeleteConfirmSingle.tle:"
 msgid "Delete"
 msgstr ""
 
@@ -12035,11 +12010,11 @@ msgctxt "dlgSgToolAdd.err:"
 msgid "The options 'Can be used by the Open command' and 'Show output and wait until finished' cannot both be set."
 msgstr ""
 
-msgctxt "dlgSgToolAdd.hdl"
+msgctxt "dlgSgToolAdd.hdl:"
 msgid "Add external tool"
 msgstr ""
 
-msgctxt "dlgSgToolAdd.tle"
+msgctxt "dlgSgToolAdd.tle:"
 msgid "Add"
 msgstr ""
 
@@ -12055,11 +12030,11 @@ msgctxt "dlgSgToolEdit.err:"
 msgid "Select the command which should be invoked."
 msgstr ""
 
-msgctxt "dlgSgToolEdit.hdl"
+msgctxt "dlgSgToolEdit.hdl:"
 msgid "Edit external tool"
 msgstr ""
 
-msgctxt "dlgSgToolEdit.tle"
+msgctxt "dlgSgToolEdit.tle:"
 msgid "Edit"
 msgstr ""
 
@@ -12103,7 +12078,7 @@ msgctxt "dlgSgTool(Add|Edit).edt:"
 msgid "Menu Item Name"
 msgstr ""
 
-msgctxt "dlgSgTool(Add|Edit).inf"
+msgctxt "dlgSgTool(Add|Edit).inf:"
 msgid "Define the name of the tool menu item, the command which should be executed and configure its arguments. The used variables define on what selection the tool may be used."
 msgstr ""
 
@@ -12207,23 +12182,23 @@ msgctxt "dlgSgUndoLastCommitConfirm.fur:"
 msgid "Undoing an already pushed commit might cause serious problems!\\n\\nMessage: $1"
 msgstr ""
 
-msgctxt "dlgSgUndoLastCommitConfirm.hdl"
+msgctxt "dlgSgUndoLastCommitConfirm.hdl:"
 msgid "Do you want to undo the last local commit?"
 msgstr ""
 
-msgctxt "dlgSgUndoLastCommitConfirm.tle"
+msgctxt "dlgSgUndoLastCommitConfirm.tle:"
 msgid "Undo Last Commit"
 msgstr ""
 
-msgctxt "dlgSgUnstageNoFilesFound.fur"
+msgctxt "dlgSgUnstageNoFilesFound.fur:"
 msgid "Could not find files with staged changes."
 msgstr ""
 
-msgctxt "dlgSgUnstageNoFilesFound.hdl"
+msgctxt "dlgSgUnstageNoFilesFound.hdl:"
 msgid "No files found that could be unstaged."
 msgstr ""
 
-msgctxt "dlgSgUnstageNoFilesFound.tle"
+msgctxt "dlgSgUnstageNoFilesFound.tle:"
 msgid "Unstage"
 msgstr ""
 
@@ -12231,11 +12206,11 @@ msgctxt "dlgSgWelcome.chk:"
 msgid "Show this dialog if no repository was opened"
 msgstr ""
 
-msgctxt "dlgSgWelcome.hdl"
+msgctxt "dlgSgWelcome.hdl:"
 msgid "What do you want to do?"
 msgstr ""
 
-msgctxt "dlgSgWelcome.inf"
+msgctxt "dlgSgWelcome.inf:"
 msgid "Select whether to open a new, local repository, clone a \\(remote\\) repository or open an existing repository."
 msgstr ""
 
@@ -12251,7 +12226,7 @@ msgctxt "dlgSgWelcome.rbt:"
 msgid "Reopen previously used repository:"
 msgstr ""
 
-msgctxt "dlgSgWelcome.tle"
+msgctxt "dlgSgWelcome.tle:"
 msgid "Welcome to SmartGit"
 msgstr ""
 
@@ -12263,39 +12238,39 @@ msgctxt "dlgSgWorktreeAdd.edt:"
 msgid "Directory"
 msgstr ""
 
-msgctxt "dlgSgWorktreeAdd.hdl"
+msgctxt "dlgSgWorktreeAdd.hdl:"
 msgid "Create another worktree from this repository"
 msgstr ""
 
-msgctxt "dlgSgWorktreeAdd.inf"
+msgctxt "dlgSgWorktreeAdd.inf:"
 msgid "Select the branch and directory to use for the new worktree."
 msgstr ""
 
-msgctxt "dlgSgWorktreeAdd.tle"
+msgctxt "dlgSgWorktreeAdd.tle:"
 msgid "Add Worktree"
 msgstr ""
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.fur"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.fur:"
 msgid "You only can create worktrees for existing local branches that don't yet have an associated worktree."
 msgstr ""
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.hdl"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.hdl:"
 msgid "No \\(more\\) local branches available."
 msgstr ""
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.tle"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.tle:"
 msgid "Add Worktree"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneNoWorktree.fur"
+msgctxt "dlgSgWorktreePruneNoWorktree.fur:"
 msgid "All your worktrees are still available."
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneNoWorktree.hdl"
+msgctxt "dlgSgWorktreePruneNoWorktree.hdl:"
 msgid "No worktree to prune."
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneNoWorktree.tle"
+msgctxt "dlgSgWorktreePruneNoWorktree.tle:"
 msgid "Prune Obsolete Worktrees"
 msgstr ""
 
@@ -12303,15 +12278,15 @@ msgctxt "dlgSgWorktreePruneWorktrees.btn:"
 msgid "Prune Worktrees"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneWorktrees.fur"
+msgctxt "dlgSgWorktreePruneWorktrees.fur:"
 msgid "Git reported following worktrees as obsolete:"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneWorktrees.hdl"
+msgctxt "dlgSgWorktreePruneWorktrees.hdl:"
 msgid "Do you want to prune following worktrees?"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneWorktrees.tle"
+msgctxt "dlgSgWorktreePruneWorktrees.tle:"
 msgid "Prune Obsolete Worktrees"
 msgstr ""
 
@@ -12331,15 +12306,15 @@ msgctxt "dlgShPushTrackingLocalSvnBranches.btn:"
 msgid "Push onto Existing"
 msgstr ""
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.fur"
+msgctxt "dlgShPushTrackingLocalSvnBranches.fur:"
 msgid "You are going to push local branches back to the SVN repository. These branches may either be pushed as new branches or onto their existing SVN counterparts \\(recommended in most cases\\)."
 msgstr ""
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.hdl"
+msgctxt "dlgShPushTrackingLocalSvnBranches.hdl:"
 msgid "Do you want to push local branches as new SVN branches?"
 msgstr ""
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.tle"
+msgctxt "dlgShPushTrackingLocalSvnBranches.tle:"
 msgid "Push"
 msgstr ""
 
@@ -12347,19 +12322,19 @@ msgctxt "dlgStdDiscardConfirmUntrackedFiles.btn:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgStdDiscardConfirmUntrackedFiles.chk"
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgStdDiscardConfirmUntrackedFiles.fur"
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.fur:"
 msgid "You are about to delete untracked files permanently. This action cannot be undone."
 msgstr ""
 
-msgctxt "dlgStdDiscardConfirmUntrackedFiles.hdl"
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.hdl:"
 msgid "Do you want to delete untracked files?"
 msgstr ""
 
-msgctxt "dlgStdDiscardConfirmUntrackedFiles.tle"
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.tle:"
 msgid "Discard"
 msgstr ""
 
@@ -12371,15 +12346,15 @@ msgctxt "dlgTxtEditor.fileModified.btn:"
 msgid "Reload"
 msgstr ""
 
-msgctxt "dlgTxtEditor.fileModified.fur"
+msgctxt "dlgTxtEditor.fileModified.fur:"
 msgid "Unless you want to see the old file state, it is recommended to reload."
 msgstr ""
 
-msgctxt "dlgTxtEditor.fileModified.hdl"
+msgctxt "dlgTxtEditor.fileModified.hdl:"
 msgid "The file $1 was changed. Reload it?"
 msgstr ""
 
-msgctxt "dlgTxtEditor.fileModified.tle"
+msgctxt "dlgTxtEditor.fileModified.tle:"
 msgid "Editor"
 msgstr ""
 
@@ -12443,11 +12418,11 @@ msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).btn:"
 msgid "Move to Trash"
 msgstr ""
 
-msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).fur"
+msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).fur:"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr ""
 
-msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).tle"
+msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).tle:"
 msgid "Delete"
 msgstr ""
 
@@ -12455,11 +12430,11 @@ msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgReposito
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).chk"
+msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).tle"
+msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).tle:"
 msgid "Remove"
 msgstr ""
 
@@ -12643,8 +12618,9 @@ msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
 msgstr ""
 
+#| msgid "SmartGit 25.1.054 Preview needs to be restarted now for the changes to take effect."
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
-msgid "SmartGit 25.1.054 Preview needs to be restarted now for the changes to take effect."
+msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
 msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
@@ -12883,7 +12859,7 @@ msgctxt "ttpBranches:"
 msgid "<b>Incoming</b> from repository <b>$1</b> branch <b>$2</b> to branch <b>$3</b>"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\""
+msgctxt "ttpBranches:"
 msgid "<b>Last Updated By: </b>$1"
 msgstr ""
 
@@ -12891,11 +12867,11 @@ msgctxt "ttpBranches:"
 msgid "<b>Local Branch:\\t</b>$1"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>On:\\t</b>$1\""
+msgctxt "ttpBranches:"
 msgid "<b>On: </b>$1"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\""
+msgctxt "ttpBranches:"
 msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
 msgstr ""
 
@@ -13171,27 +13147,27 @@ msgctxt "wnd.mni:"
 msgid "SmartGit Website"
 msgstr ""
 
-msgctxt "wnd.mniBisectTryCommit"
+msgctxt "wnd.mniBisectTryCommit:"
 msgid "Try Commit"
 msgstr ""
 
-msgctxt "wnd.mniFixCaseChange"
+msgctxt "wnd.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr ""
 
-msgctxt "wnd.mniIntegrateMain"
+msgctxt "wnd.mniIntegrateMain:"
 msgid "Integrate Main"
 msgstr ""
 
-msgctxt "wnd.mniShowInMyHistory"
+msgctxt "wnd.mniShowInMyHistory:"
 msgid "Show in My History"
 msgstr ""
 
-msgctxt "wnd.mniWindow-maximize"
+msgctxt "wnd.mniWindow-maximize:"
 msgid "Zoom"
 msgstr ""
 
-msgctxt "wnd.mniWindowMaximizeRestore"
+msgctxt "wnd.mniWindowMaximizeRestore:"
 msgid "Maximize View"
 msgstr ""
 
@@ -13243,83 +13219,83 @@ msgctxt "wndAnnotate.mni:"
 msgid "Show Changes"
 msgstr ""
 
-msgctxt "wndAnnotate.mniCommit-first"
+msgctxt "wndAnnotate.mniCommit-first:"
 msgid "Go to First Commit"
 msgstr ""
 
-msgctxt "wndAnnotate.mniCommit-last"
+msgctxt "wndAnnotate.mniCommit-last:"
 msgid "Go to Last Commit"
 msgstr ""
 
-msgctxt "wndAnnotate.mniCommit-next"
+msgctxt "wndAnnotate.mniCommit-next:"
 msgid "Go to Next Commit"
 msgstr ""
 
-msgctxt "wndAnnotate.mniCommit-preceding-line"
+msgctxt "wndAnnotate.mniCommit-preceding-line:"
 msgid "Go to Preceding Commit"
 msgstr ""
 
-msgctxt "wndAnnotate.mniCommit-previous"
+msgctxt "wndAnnotate.mniCommit-previous:"
 msgid "Go to Previous Commit"
 msgstr ""
 
-msgctxt "wndAnnotate.mniCompare"
+msgctxt "wndAnnotate.mniCompare:"
 msgid "Show Changes"
 msgstr ""
 
-msgctxt "wndAnnotate.mniCustomize"
+msgctxt "wndAnnotate.mniCustomize:"
 msgid "Customize"
 msgstr ""
 
-msgctxt "wndAnnotate.mniEdit-copy"
+msgctxt "wndAnnotate.mniEdit-copy:"
 msgid "Copy"
 msgstr ""
 
-msgctxt "wndAnnotate.mniFile-close"
+msgctxt "wndAnnotate.mniFile-close:"
 msgid "Close"
 msgstr ""
 
-msgctxt "wndAnnotate.mniGoto-line"
+msgctxt "wndAnnotate.mniGoto-line:"
 msgid "Go to Line"
 msgstr ""
 
-msgctxt "wndAnnotate.mniLog"
+msgctxt "wndAnnotate.mniLog:"
 msgid "Log"
 msgstr ""
 
-msgctxt "wndAnnotate.mniSearch-find"
+msgctxt "wndAnnotate.mniSearch-find:"
 msgid "Find"
 msgstr ""
 
-msgctxt "wndAnnotate.mniSearch-next"
+msgctxt "wndAnnotate.mniSearch-next:"
 msgid "Find Next"
 msgstr ""
 
-msgctxt "wndAnnotate.mniSearch-previous"
+msgctxt "wndAnnotate.mniSearch-previous:"
 msgid "Find Previous"
 msgstr ""
 
-msgctxt "wndAnnotate.mniSet-syntax"
+msgctxt "wndAnnotate.mniSet-syntax:"
 msgid "Syntax Language"
 msgstr ""
 
-msgctxt "wndAnnotate.mniShowChanges"
+msgctxt "wndAnnotate.mniShowChanges:"
 msgid "Show Changes"
 msgstr ""
 
-msgctxt "wndAnnotate.mniUndo-goto"
+msgctxt "wndAnnotate.mniUndo-goto:"
 msgid "Undo Go To"
 msgstr ""
 
-msgctxt "wndAnnotate.mniView-settings"
+msgctxt "wndAnnotate.mniView-settings:"
 msgid "Settings"
 msgstr ""
 
-msgctxt "wndAnnotate.mniWindowHideView"
+msgctxt "wndAnnotate.mniWindowHideView:"
 msgid "Hide View"
 msgstr ""
 
-msgctxt "wndAnnotate.mniWindowLineHistory"
+msgctxt "wndAnnotate.mniWindowLineHistory:"
 msgid "Line History"
 msgstr ""
 
@@ -13405,43 +13381,43 @@ msgctxt "wndCompare.mni:"
 msgid "Apply Selection to Right"
 msgstr ""
 
-msgctxt "wndCompare.mniRefresh"
+msgctxt "wndCompare.mniRefresh:"
 msgid "Reload"
 msgstr ""
 
-msgctxt "wndCompare.mniView-ignore-whitespaces"
+msgctxt "wndCompare.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr ""
 
-msgctxt "wndCompare.mniView-layout-left-beside-right"
+msgctxt "wndCompare.mniView-layout-left-beside-right:"
 msgid "Left Beside Right"
 msgstr ""
 
-msgctxt "wndCompare.mniView-layout-left-over-right"
+msgctxt "wndCompare.mniView-layout-left-over-right:"
 msgid "Left Above Right"
 msgstr ""
 
-msgctxt "wndCompare.tbtEdit-take-left"
+msgctxt "wndCompare.tbtEdit-take-left:"
 msgid "Take the left block to the right. Depending on the left block, this will insert, replace or delete at the right."
 msgstr ""
 
-msgctxt "wndCompare.tbtEdit-take-right"
+msgctxt "wndCompare.tbtEdit-take-right:"
 msgid "Take the right block to the left. Depending on the right block, this will insert, replace or delete at the left."
 msgstr ""
 
-msgctxt "wndCompare.tbtFile-save"
+msgctxt "wndCompare.tbtFile-save:"
 msgid "Save file modifications."
 msgstr ""
 
-msgctxt "wndCompare.tbtGoto-next-diff"
+msgctxt "wndCompare.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr ""
 
-msgctxt "wndCompare.tbtGoto-previous-diff"
+msgctxt "wndCompare.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr ""
 
-msgctxt "wndCompare.tbtRefresh"
+msgctxt "wndCompare.tbtRefresh:"
 msgid "Reload content from file system and recompare."
 msgstr ""
 
@@ -13461,23 +13437,23 @@ msgctxt "wndConflictSolver.mni:"
 msgid "Apply Selection to Working Tree"
 msgstr ""
 
-msgctxt "wndConflictSolver.mniView-ignore-whitespaces"
+msgctxt "wndConflictSolver.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr ""
 
-msgctxt "wndConflictSolver.mniView-layout-all"
+msgctxt "wndConflictSolver.mniView-layout-all:"
 msgid "All"
 msgstr ""
 
-msgctxt "wndConflictSolver.mniView-layout-left-merge"
+msgctxt "wndConflictSolver.mniView-layout-left-merge:"
 msgid "Left and Merge"
 msgstr ""
 
-msgctxt "wndConflictSolver.mniView-layout-left-right-above-merge"
+msgctxt "wndConflictSolver.mniView-layout-left-right-above-merge:"
 msgid "Left and Right Above Merge"
 msgstr ""
 
-msgctxt "wndConflictSolver.mniView-layout-right-merge"
+msgctxt "wndConflictSolver.mniView-layout-right-merge:"
 msgid "Merge and Right"
 msgstr ""
 
@@ -13529,59 +13505,59 @@ msgctxt "wndConflictSolver.tbr:"
 msgid "Take Right, Left"
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtEdit-take-left"
+msgctxt "wndConflictSolver.tbtEdit-take-left:"
 msgid "Take the left block to the merge result. Depending on the left block, this will insert, replace or delete at the merge result."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtEdit-take-left-right"
+msgctxt "wndConflictSolver.tbtEdit-take-left-right:"
 msgid "Take the left block, then the right one."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtEdit-take-right"
+msgctxt "wndConflictSolver.tbtEdit-take-right:"
 msgid "Take the right block to the merge result. Depending on the right block, this will insert, replace or delete at the merge result."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtEdit-take-right-left"
+msgctxt "wndConflictSolver.tbtEdit-take-right-left:"
 msgid "Take the right block, then the left one."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtFile-open-base"
+msgctxt "wndConflictSolver.tbtFile-open-base:"
 msgid "Open the left and right changes from the common base file."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtFile-save"
+msgctxt "wndConflictSolver.tbtFile-save:"
 msgid "Save file modifications."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtGoto-next-conflict"
+msgctxt "wndConflictSolver.tbtGoto-next-conflict:"
 msgid "Go to next conflict."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtGoto-next-diff"
+msgctxt "wndConflictSolver.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtGoto-previous-conflict"
+msgctxt "wndConflictSolver.tbtGoto-previous-conflict:"
 msgid "Go to previous conflict."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtGoto-previous-diff"
+msgctxt "wndConflictSolver.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtView-layout-all"
+msgctxt "wndConflictSolver.tbtView-layout-all:"
 msgid "Show the left, merge and right file."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtView-layout-left-merge"
+msgctxt "wndConflictSolver.tbtView-layout-left-merge:"
 msgid "Show the left and merge file."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtView-layout-left-right-above-merge"
+msgctxt "wndConflictSolver.tbtView-layout-left-right-above-merge:"
 msgid "Show the left and right files above the merge file."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtView-layout-right-merge"
+msgctxt "wndConflictSolver.tbtView-layout-right-merge:"
 msgid "Show the merge and right file."
 msgstr ""
 
@@ -13863,171 +13839,171 @@ msgctxt "wndDeepgit.mni:"
 msgid "Open Repository Log"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDbBack"
+msgctxt "wndDeepgit.mniDbBack:"
 msgid "Go Back"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgAbout"
+msgctxt "wndDeepgit.mniDgAbout:"
 msgid "About DeepGit"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgBack"
+msgctxt "wndDeepgit.mniDgBack:"
 msgid "Go Back"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgConfigureRefGroups"
+msgctxt "wndDeepgit.mniDgConfigureRefGroups:"
 msgid "Tag-Grouping"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgExtendLineToBlock"
+msgctxt "wndDeepgit.mniDgExtendLineToBlock:"
 msgid "Extend Lines to Blocks"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgFilterAddSelection"
+msgctxt "wndDeepgit.mniDgFilterAddSelection:"
 msgid "Add Selection to Filter"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgFilterReset"
+msgctxt "wndDeepgit.mniDgFilterReset:"
 msgid "Reset Filter"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgFilterSetSelection"
+msgctxt "wndDeepgit.mniDgFilterSetSelection:"
 msgid "Set Selection as Filter"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgFollowInsignificantMerges"
+msgctxt "wndDeepgit.mniDgFollowInsignificantMerges:"
 msgid "Follow Insignificant Merges \\(experimental\\)"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgFollowRenames"
+msgctxt "wndDeepgit.mniDgFollowRenames:"
 msgid "Follow Renames"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgForward"
+msgctxt "wndDeepgit.mniDgForward:"
 msgid "Go Forward"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgHighlightBlameChanges"
+msgctxt "wndDeepgit.mniDgHighlightBlameChanges:"
 msgid "Highlight Changes of Current Blame Commit"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgHighlightOriginChanges"
+msgctxt "wndDeepgit.mniDgHighlightOriginChanges:"
 msgid "Highlight Changes of Current Origin Commit"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgIgnoreWhitespaceOnlyChanges"
+msgctxt "wndDeepgit.mniDgIgnoreWhitespaceOnlyChanges:"
 msgid "Ignore Whitespace Changes"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgLicenseAgreement"
+msgctxt "wndDeepgit.mniDgLicenseAgreement:"
 msgid "License Agreement"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgOptimizeCreationOrigins"
+msgctxt "wndDeepgit.mniDgOptimizeCreationOrigins:"
 msgid "Optimize 'Appeared Here' Origins"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.mniDgPerspectiveBlameOrigin:"
 msgid "Blame+Origins Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveBlameSimple"
+msgctxt "wndDeepgit.mniDgPerspectiveBlameSimple:"
 msgid "Blame Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveCommit"
+msgctxt "wndDeepgit.mniDgPerspectiveCommit:"
 msgid "Log Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveHistory"
+msgctxt "wndDeepgit.mniDgPerspectiveHistory:"
 msgid "Diff Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveOrigins"
+msgctxt "wndDeepgit.mniDgPerspectiveOrigins:"
 msgid "Origins Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgResetInlineHelp"
+msgctxt "wndDeepgit.mniDgResetInlineHelp:"
 msgid "Reshow All Inline Help"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgSetEncoding"
+msgctxt "wndDeepgit.mniDgSetEncoding:"
 msgid "Encoding"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgShowAtRefs"
+msgctxt "wndDeepgit.mniDgShowAtRefs:"
 msgid "Show At Refs"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgShowLinePrefixes"
+msgctxt "wndDeepgit.mniDgShowLinePrefixes:"
 msgid "Show Line Prefixes"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgShowOnRefs"
+msgctxt "wndDeepgit.mniDgShowOnRefs:"
 msgid "Show On Refs"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgToggleLineHistory"
+msgctxt "wndDeepgit.mniDgToggleLineHistory:"
 msgid "Line History"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgViewToolbar"
+msgctxt "wndDeepgit.mniDgViewToolbar:"
 msgid "Show Toolbar"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgWindowHorizontalLayout"
+msgctxt "wndDeepgit.mniDgWindowHorizontalLayout:"
 msgid "Horizontal Blame + Origins Layout"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgWindowVerticalLayout"
+msgctxt "wndDeepgit.mniDgWindowVerticalLayout:"
 msgid "Vertical Blame + Origins Layout"
 msgstr ""
 
-msgctxt "wndDeepgit.mniEdit-copy"
+msgctxt "wndDeepgit.mniEdit-copy:"
 msgid "Copy"
 msgstr ""
 
-msgctxt "wndDeepgit.mniFile-close"
+msgctxt "wndDeepgit.mniFile-close:"
 msgid "Close"
 msgstr ""
 
-msgctxt "wndDeepgit.mniGoto-line"
+msgctxt "wndDeepgit.mniGoto-line:"
 msgid "Go to Line"
 msgstr ""
 
-msgctxt "wndDeepgit.mniGoto-next-diff"
+msgctxt "wndDeepgit.mniGoto-next-diff:"
 msgid "Next Change"
 msgstr ""
 
-msgctxt "wndDeepgit.mniGoto-previous-diff"
+msgctxt "wndDeepgit.mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr ""
 
-msgctxt "wndDeepgit.mniNextChange"
+msgctxt "wndDeepgit.mniNextChange:"
 msgid "Next Change"
 msgstr ""
 
-msgctxt "wndDeepgit.mniOpenFileLog"
+msgctxt "wndDeepgit.mniOpenFileLog:"
 msgid "Open File Log"
 msgstr ""
 
-msgctxt "wndDeepgit.mniOpenRepositoryLog"
+msgctxt "wndDeepgit.mniOpenRepositoryLog:"
 msgid "Open Repository Log"
 msgstr ""
 
-msgctxt "wndDeepgit.mniPreviousChange"
+msgctxt "wndDeepgit.mniPreviousChange:"
 msgid "Previous Change"
 msgstr ""
 
-msgctxt "wndDeepgit.mniSearch-find"
+msgctxt "wndDeepgit.mniSearch-find:"
 msgid "Find"
 msgstr ""
 
-msgctxt "wndDeepgit.mniSearch-next"
+msgctxt "wndDeepgit.mniSearch-next:"
 msgid "Find Next"
 msgstr ""
 
-msgctxt "wndDeepgit.mniSearch-previous"
+msgctxt "wndDeepgit.mniSearch-previous:"
 msgid "Find Previous"
 msgstr ""
 
@@ -14129,59 +14105,59 @@ msgctxt "wndDeepgit.tbt:"
 msgid "Go to previous change."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtBack"
+msgctxt "wndDeepgit.tbtBack:"
 msgid "Go back to previous blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDbBack"
+msgctxt "wndDeepgit.tbtDbBack:"
 msgid "Go back to previous blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgForward"
+msgctxt "wndDeepgit.tbtDgForward:"
 msgid "Go forward to next blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.tbtDgPerspectiveBlameOrigin:"
 msgid "Find where the line originates from in cases where you need to choose from one of possible Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveBlameSimple"
+msgctxt "wndDeepgit.tbtDgPerspectiveBlameSimple:"
 msgid "Find where the line originates from in simple cases when there are no alternative Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveCommit"
+msgctxt "wndDeepgit.tbtDgPerspectiveCommit:"
 msgid "Investigate Log."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveHistory"
+msgctxt "wndDeepgit.tbtDgPerspectiveHistory:"
 msgid "Investigate Diff between file's revisions."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveOrigins"
+msgctxt "wndDeepgit.tbtDgPerspectiveOrigins:"
 msgid "Find out what else happened where the line originates from.\\n\\nIn order to inspect available Origins, they have to be evaluated first. First, select the file you want to investigate using File\\|Open and select a line in it. Then wait until the calculation of possible Origins has finished."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtForward"
+msgctxt "wndDeepgit.tbtForward:"
 msgid "Go forward to next blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.tbtPerspectiveBlameOrigin:"
 msgid "Find where the line originates from in cases where you need to choose from one of possible Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveBlameSimple"
+msgctxt "wndDeepgit.tbtPerspectiveBlameSimple:"
 msgid "Find where the line originates from in simple cases when there are no alternative Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveCommit"
+msgctxt "wndDeepgit.tbtPerspectiveCommit:"
 msgid "Investigate Log."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveHistory"
+msgctxt "wndDeepgit.tbtPerspectiveHistory:"
 msgid "Investigate Diff between file's revisions."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveOrigins"
+msgctxt "wndDeepgit.tbtPerspectiveOrigins:"
 msgid "Find out what else happened where the line originates from.\\n\\nIn order to inspect available Origins, they have to be evaluated first. First, select the file you want to investigate using File\\|Open and select a line in it. Then wait until the calculation of possible Origins has finished."
 msgstr ""
 
@@ -14205,35 +14181,35 @@ msgctxt "wndEditor.mni:"
 msgid "LF \\(Unix, macOS\\)"
 msgstr ""
 
-msgctxt "wndEditor.mniBlockSelection"
+msgctxt "wndEditor.mniBlockSelection:"
 msgid "Block Selection"
 msgstr ""
 
-msgctxt "wndEditor.mniEdit-undo"
+msgctxt "wndEditor.mniEdit-undo:"
 msgid "Undo"
 msgstr ""
 
-msgctxt "wndEditor.mniEofEnforceLineEnding"
+msgctxt "wndEditor.mniEofEnforceLineEnding:"
 msgid "Enforce Line Ending on End of File"
 msgstr ""
 
-msgctxt "wndEditor.mniReplaceTabsWithSpaces"
+msgctxt "wndEditor.mniReplaceTabsWithSpaces:"
 msgid "Replace Tabs With Spaces"
 msgstr ""
 
-msgctxt "wndEditor.mniSaveAuto"
+msgctxt "wndEditor.mniSaveAuto:"
 msgid "Auto-Save"
 msgstr ""
 
-msgctxt "wndEditor.mniView-remember-as-default"
+msgctxt "wndEditor.mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr ""
 
-msgctxt "wndEditor.mniView-settings"
+msgctxt "wndEditor.mniView-settings:"
 msgid "Settings"
 msgstr ""
 
-msgctxt "wndEditor.tbtFile-save"
+msgctxt "wndEditor.tbtFile-save:"
 msgid "Save file modifications."
 msgstr ""
 
@@ -14281,59 +14257,59 @@ msgctxt "wndGit.indexEditor.mni:"
 msgid "Unstage Selection"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-ignore-whitespaces"
+msgctxt "wndGit.indexEditor.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-all"
+msgctxt "wndGit.indexEditor.mniView-layout-all:"
 msgid "All"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-index"
+msgctxt "wndGit.indexEditor.mniView-layout-head-index:"
 msgid "HEAD and Index"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-index-wt"
+msgctxt "wndGit.indexEditor.mniView-layout-head-index-wt:"
 msgid "All"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-wt-above-index"
+msgctxt "wndGit.indexEditor.mniView-layout-head-wt-above-index:"
 msgid "HEAD and Working Tree Above Index"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-index-wt"
+msgctxt "wndGit.indexEditor.mniView-layout-index-wt:"
 msgid "Index and Working Tree"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-left-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-left-merge:"
 msgid "HEAD and Index"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-left-right-above-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-left-right-above-merge:"
 msgid "HEAD and Working Tree Above Index"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-right-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-right-merge:"
 msgid "Index and Working Tree"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.tbtEdit-take-left"
+msgctxt "wndGit.indexEditor.tbtEdit-take-left:"
 msgid "Take the left block to the merge result. Depending on the left block, this will insert, replace or delete at the merge result."
 msgstr ""
 
-msgctxt "wndGit.indexEditor.tbtEdit-take-right"
+msgctxt "wndGit.indexEditor.tbtEdit-take-right:"
 msgid "Take the right block to the merge result. Depending on the right block, this will insert, replace or delete at the merge result."
 msgstr ""
 
-msgctxt "wndGit.indexEditor.tbtFile-save"
+msgctxt "wndGit.indexEditor.tbtFile-save:"
 msgid "Save file modifications."
 msgstr ""
 
-msgctxt "wndGit.indexEditor.tbtGoto-next-diff"
+msgctxt "wndGit.indexEditor.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr ""
 
-msgctxt "wndGit.indexEditor.tbtGoto-previous-diff"
+msgctxt "wndGit.indexEditor.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr ""
 
@@ -14397,11 +14373,11 @@ msgctxt "wndLog.mni:"
 msgid "github \\(active\\)"
 msgstr ""
 
-msgctxt "wndLog.mniFixCaseChange"
+msgctxt "wndLog.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr ""
 
-msgctxt "wndLog.mniGitNoteAdd"
+msgctxt "wndLog.mniGitNoteAdd:"
 msgid "Add Note"
 msgstr ""
 
@@ -14437,7 +14413,7 @@ msgctxt "wndLog.tbt:"
 msgid "Refresh information from GitHub."
 msgstr ""
 
-msgctxt "wndLog.tbtAi.commitMessageCompose"
+msgctxt "wndLog.tbtAi.commitMessageCompose:"
 msgid "smartgit.jy: Cancelled"
 msgstr ""
 
@@ -14469,8 +14445,12 @@ msgctxt "wndProject.mni:"
 msgid "Show Rewritten Behind Commits"
 msgstr ""
 
-msgctxt "wndProject.mniFixCaseChange"
+msgctxt "wndProject.mniFixCaseChange:"
 msgid "Fix Case-Change"
+msgstr ""
+
+msgctxt "wndProject.mniOpen:"
+msgid "Open"
 msgstr ""
 
 msgctxt "wndStd.btn:"
@@ -14684,44 +14664,44 @@ msgctxt "wndStd.mni:"
 msgid "Stop"
 msgstr ""
 
-msgctxt "wndStd.mniBisectTryCommit"
+msgctxt "wndStd.mniBisectTryCommit:"
 msgid "Try Commit"
 msgstr ""
 
-msgctxt "wndStd.mniFixCaseChange"
+msgctxt "wndStd.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr ""
 
-msgctxt "wndStd.mniGitNoteAdd"
+msgctxt "wndStd.mniGitNoteAdd:"
 msgid "Add Note"
 msgstr ""
 
-msgctxt "wndStd.mniIntegrateMain"
+msgctxt "wndStd.mniIntegrateMain:"
 msgid "Integrate Main"
 msgstr ""
 
-msgctxt "wndStd.mniStdCiResultOpenInBrowser"
+msgctxt "wndStd.mniStdCiResultOpenInBrowser:"
 msgid "Open CI Result"
 msgstr ""
 
-msgctxt "wndStd.mniStdOpenSubmodule"
+msgctxt "wndStd.mniStdOpenSubmodule:"
 msgid "Open a Submodule"
 msgstr ""
 
-msgctxt "wndStd.mniStdOpenSubmoduleFromFile"
+msgctxt "wndStd.mniStdOpenSubmoduleFromFile:"
 msgid "Open this Submodule"
 msgstr ""
 
 #| msgid "Open in GitHub"
-msgctxt "wndStd.mniStdProviderOpenInBrowser"
+msgctxt "wndStd.mniStdProviderOpenInBrowser:"
 msgid "Open in $1"
 msgstr ""
 
-msgctxt "wndStd.mniStdSetModeHistory"
+msgctxt "wndStd.mniStdSetModeHistory:"
 msgid "Show History"
 msgstr ""
 
-msgctxt "wndStd.mniStdSetModeWt"
+msgctxt "wndStd.mniStdSetModeWt:"
 msgid "Show Local Changes"
 msgstr ""
 
@@ -14737,7 +14717,7 @@ msgctxt "wndStd.tbt:"
 msgid "History"
 msgstr ""
 
-msgctxt "wndStd.tbtFlowFeatureStart"
+msgctxt "wndStd.tbtFlowFeatureStart:"
 msgid "Start a new feature branch."
 msgstr ""
 
@@ -14746,20 +14726,20 @@ msgid "Ready"
 msgstr ""
 
 #| msgid "Full Screen"
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
 msgid "Enter Full Screen"
 msgstr ""
 
 #| msgid "Maximize"
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
 msgid "Zoom"
 msgstr ""
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore:"
 msgid "Restore"
 msgstr ""
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-minimize"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-minimize:"
 msgid "Minimize"
 msgstr ""
 
@@ -14779,83 +14759,83 @@ msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|
 msgid "Window"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left:"
 msgid "Take Left Block"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left-right"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left-right:"
 msgid "Take Left, then Right Block"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right:"
 msgid "Take Right Block"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right-left"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right-left:"
 msgid "Take Right, then Left Block"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-undo"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-undo:"
 msgid "Undo"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-export-html"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-export-html:"
 msgid "Export as HTML-File"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-open-base"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-open-base:"
 msgid "Open Base File Changes"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-conflict"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-conflict:"
 msgid "Next Conflict"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-diff"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-diff:"
 msgid "Next Change"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-conflict"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-conflict:"
 msgid "Previous Conflict"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-diff"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniShow-line-numbers"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniShow-line-numbers:"
 msgid "Show Line Numbers"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-all"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-all:"
 msgid "Ignore All Whitespaces for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-leading-trailing"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-leading-trailing:"
 msgid "Ignore Leading/Trailing Whitespaces for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-none"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-none:"
 msgid "Ignore No Whitespace for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-refresh"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-refresh:"
 msgid "Reload"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-remember-as-default"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-settings"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-settings:"
 msgid "Settings"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-show-current-line-control"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-show-current-line-control:"
 msgid "Show Long Current Lines"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-synchronize-scrolling"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-synchronize-scrolling:"
 msgid "Synchronize Scrolling"
 msgstr ""
 
@@ -14883,59 +14863,59 @@ msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mni:"
 msgid "Copy Selection"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniCustomize"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniCustomize:"
 msgid "Customize"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-copy"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-copy:"
 msgid "Copy"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-cut"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-cut:"
 msgid "Cut"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-ignore-case-changes"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-ignore-case-changes:"
 msgid "Ignore Case Change for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-paste"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-paste:"
 msgid "Paste"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-redo"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-redo:"
 msgid "Redo"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-close"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-close:"
 msgid "Close"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-save"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-save:"
 msgid "Save"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniGoto-line"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniGoto-line:"
 msgid "Go to Line"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-find"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-find:"
 msgid "Find"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-next"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-next:"
 msgid "Find Next"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-previous"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-previous:"
 msgid "Find Previous"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-replace"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-replace:"
 msgid "Find and Replace"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSet-syntax"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSet-syntax:"
 msgid "Syntax Language"
 msgstr ""
 
@@ -14959,11 +14939,11 @@ msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).tbr:"
 msgid "Save"
 msgstr ""
 
-msgctxt "wnd(Log|Project|).tbtFlowFeatureFinish"
+msgctxt "wnd(Log|Project|).tbtFlowFeatureFinish:"
 msgid "Finish a Git-Flow feature."
 msgstr ""
 
-msgctxt "wnd(Log|Project|).tbtFlowFeatureStart"
+msgctxt "wnd(Log|Project|).tbtFlowFeatureStart:"
 msgid "Start a new Git-Flow feature."
 msgstr ""
 
@@ -15261,10 +15241,6 @@ msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).lbl:"
 msgid "Files"
-msgstr ""
-
-msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\""
-msgid "Show Rewritten Behind Commits"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mni:"
@@ -15916,6 +15892,10 @@ msgid "Show Only Selected Refs"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mni:"
+msgid "Show Rewritten Behind Commits"
+msgstr ""
+
+msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Show Unchanged Directories"
 msgstr ""
 
@@ -16027,309 +16007,304 @@ msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Varying Coloring"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniAbout"
+msgctxt "wnd(Log|Project|Std|).mniAbout:"
 msgid "About SmartGit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniAdd"
+msgctxt "wnd(Log|Project|Std|).mniAdd:"
 msgid "Add"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniAnnotate"
+msgctxt "wnd(Log|Project|Std|).mniAnnotate:"
 msgid "Blame"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniAssume-unchanged-toggle"
+msgctxt "wnd(Log|Project|Std|).mniAssume-unchanged-toggle:"
 msgid "Toggle 'Assume Unchanged'"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBisectBad"
+msgctxt "wnd(Log|Project|Std|).mniBisectBad:"
 msgid "Mark HEAD as Bad"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBisectExit"
+msgctxt "wnd(Log|Project|Std|).mniBisectExit:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBisectGood"
+msgctxt "wnd(Log|Project|Std|).mniBisectGood:"
 msgid "Mark HEAD as Good"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBisectStart"
+msgctxt "wnd(Log|Project|Std|).mniBisectStart:"
 msgid "Start"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAbort"
+msgctxt "wnd(Log|Project|Std|).mniBranchAbort:"
 msgid "Abort"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAdd"
+msgctxt "wnd(Log|Project|Std|).mniBranchAdd:"
 msgid "Add Branch"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAddTag"
+msgctxt "wnd(Log|Project|Std|).mniBranchAddTag:"
 msgid "Add Tag"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchClose"
+msgctxt "wnd(Log|Project|Std|).mniBranchClose:"
 msgid "Close"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchContinue"
+msgctxt "wnd(Log|Project|Std|).mniBranchContinue:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchDelete"
+msgctxt "wnd(Log|Project|Std|).mniBranchDelete:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchRename"
+msgctxt "wnd(Log|Project|Std|).mniBranchRename:"
 msgid "Rename"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchResetTracking"
+msgctxt "wnd(Log|Project|Std|).mniBranchResetTracking:"
 msgid "Stop Tracking"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSetTracking"
+msgctxt "wnd(Log|Project|Std|).mniBranchSetTracking:"
 msgid "Set Tracked Branch"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSplit"
+msgctxt "wnd(Log|Project|Std|).mniBranchSplit:"
 msgid "Modify or Split Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSplitFiles"
+msgctxt "wnd(Log|Project|Std|).mniBranchSplitFiles:"
 msgid "Split Off Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowRemoteOnly"
+msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowRemoteOnly:"
 msgid "Show remote branches in their Git-Flow sections"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowTracked"
+msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowTracked:"
 msgid "Show remote, tracked branches"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionize"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionize:"
 msgid "Group tags and branches by path-like name \\(foo/bar\\)"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeAfterLastSlash"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeAfterLastSlash:"
 msgid "After last slash"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeCompact"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeCompact:"
 msgid "Except for single refs"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionsBeforeRefs"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionsBeforeRefs:"
 msgid "Show groups first"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSelectObsolete"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSelectObsolete:"
 msgid "Select Obsolete Local Branches"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByName"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByName:"
 msgid "Sort Refs by Name"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByNameReversed"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByNameReversed:"
 msgid "Sort Refs by Name \\(Numbers Reversed\\)"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByTime"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByTime:"
 msgid "Sort Refs by Commit Time"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.compact"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.compact:"
 msgid "Compact"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.ignoreLineSeparators"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.ignoreLineSeparators:"
 msgid "Ignore Line-Ending Changes"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.sideBySide"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.sideBySide:"
 msgid "Side by Side"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.unified"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.unified:"
 msgid "Unified"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCheckForLatestBuild"
+msgctxt "wnd(Log|Project|Std|).mniCheckForLatestBuild:"
 msgid "Check for Latest Build"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCheckForNewVersion"
+msgctxt "wnd(Log|Project|Std|).mniCheckForNewVersion:"
 msgid "Check for New Version"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCheckout"
+msgctxt "wnd(Log|Project|Std|).mniCheckout:"
 msgid "Check Out"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCherryPick"
+msgctxt "wnd(Log|Project|Std|).mniCherryPick:"
 msgid "Cherry-Pick"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniClean"
+msgctxt "wnd(Log|Project|Std|).mniClean:"
 msgid "Clean Working Tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniClearOutput"
+msgctxt "wnd(Log|Project|Std|).mniClearOutput:"
 msgid "Clear Output"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCommit"
+msgctxt "wnd(Log|Project|Std|).mniCommit:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCompact-display"
+msgctxt "wnd(Log|Project|Std|).mniCompact-display:"
 msgid "Compact Change Display"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCompareWithWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniCompareWithWorkingTree:"
 msgid "Compare with Working Tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniConfigureTagGrouping"
+msgctxt "wnd(Log|Project|Std|).mniConfigureTagGrouping:"
 msgid "Tag-Grouping"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniConfigureToolbar"
+msgctxt "wnd(Log|Project|Std|).mniConfigureToolbar:"
 msgid "Configure Toolbar"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniConflictSolver"
+msgctxt "wnd(Log|Project|Std|).mniConflictSolver:"
 msgid "Conflict Solver"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniContactSupport"
+msgctxt "wnd(Log|Project|Std|).mniContactSupport:"
 msgid "Contact Support"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCopyCommitId"
+msgctxt "wnd(Log|Project|Std|).mniCopyCommitId:"
 msgid "Copy ID"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCopyCommitMessage"
+msgctxt "wnd(Log|Project|Std|).mniCopyCommitMessage:"
 msgid "Copy Message"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCopyName"
+msgctxt "wnd(Log|Project|Std|).mniCopyName:"
 msgid "Copy Name"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCopyPath"
+msgctxt "wnd(Log|Project|Std|).mniCopyPath:"
 msgid "Copy Path"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCopyRelativePath"
+msgctxt "wnd(Log|Project|Std|).mniCopyRelativePath:"
 msgid "Copy Relative Path"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCustomize"
+msgctxt "wnd(Log|Project|Std|).mniCustomize:"
 msgid "Customize"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugCreateHeapDump"
+msgctxt "wnd(Log|Project|Std|).mniDebugCreateHeapDump:"
 msgid "Create Heap Dump"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugCreateThreadDumps"
+msgctxt "wnd(Log|Project|Std|).mniDebugCreateThreadDumps:"
 msgid "Create Periodical Thread Dumps"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugEnableRefreshTraceLogging"
+msgctxt "wnd(Log|Project|Std|).mniDebugEnableRefreshTraceLogging:"
 msgid "Starting Tracing Refreshing"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorEvents"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorEvents:"
 msgid "Log File Monitor Events"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorState"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorState:"
 msgid "Log File Monitor State"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogOpenRepositories"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogOpenRepositories:"
 msgid "Log Open Repositories"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugRestart"
+msgctxt "wnd(Log|Project|Std|).mniDebugRestart:"
 msgid "Restart"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugRunGc"
+msgctxt "wnd(Log|Project|Std|).mniDebugRunGc:"
 msgid "Run GC"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDelete"
+msgctxt "wnd(Log|Project|Std|).mniDelete:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDiscard"
+msgctxt "wnd(Log|Project|Std|).mniDiscard:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniEdit-ignore-case-changes"
+msgctxt "wnd(Log|Project|Std|).mniEdit-ignore-case-changes:"
 msgid "Ignore Case Change for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniEditCommitAuthor"
+msgctxt "wnd(Log|Project|Std|).mniEditCommitAuthor:"
 msgid "Edit Author"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniEditCommitMessage"
+msgctxt "wnd(Log|Project|Std|).mniEditCommitMessage:"
 msgid "Edit Message"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniEditFile"
+msgctxt "wnd(Log|Project|Std|).mniEditFile:"
 msgid "Edit File"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniExit"
+msgctxt "wnd(Log|Project|Std|).mniExit:"
 msgid "Exit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFastForward"
+msgctxt "wnd(Log|Project|Std|).mniFastForward:"
 msgid "Fast-Forward Merge"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFetch"
+msgctxt "wnd(Log|Project|Std|).mniFetch:"
 msgid "Pull"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFile-close"
+msgctxt "wnd(Log|Project|Std|).mniFile-close:"
 msgid "Close"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFilterCommits"
+msgctxt "wnd(Log|Project|Std|).mniFilterCommits:"
 msgid "Filter Commits"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFilterFiles"
+msgctxt "wnd(Log|Project|Std|).mniFilterFiles:"
 msgid "Filter Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFindAction"
+msgctxt "wnd(Log|Project|Std|).mniFindAction:"
 msgid "Find Command"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFindObject"
+msgctxt "wnd(Log|Project|Std|).mniFindObject:"
 msgid "Find Object"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFixup"
+msgctxt "wnd(Log|Project|Std|).mniFixup:"
 msgid "Use Message for Commit"
-msgstr ""
-
-#| msgid "Configure"
-msgctxt "wnd(Log|Project|Std|).mniFlowConfigure"
-msgid "Configure Features"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
@@ -16340,190 +16315,182 @@ msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowContext"
+msgctxt "wnd(Log|Project|Std|).mniFlowContext:"
 msgid "Git-Flow"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowFeatureFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowFeatureFinish:"
 msgid "Finish Feature"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowFeatureStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowFeatureStart:"
 msgid "Start Feature"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowHotfixFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowHotfixFinish:"
 msgid "Finish Hotfix"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowHotfixStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowHotfixStart:"
 msgid "Start Hotfix"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowIntegrateDevelop"
+msgctxt "wnd(Log|Project|Std|).mniFlowIntegrateDevelop:"
 msgid "Integrate Develop"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowReleaseFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowReleaseFinish:"
 msgid "Finish Release"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowReleaseStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowReleaseStart:"
 msgid "Start Release"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowSupportStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowSupportStart:"
 msgid "Start Support Branch"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniForgetCommit"
+msgctxt "wnd(Log|Project|Std|).mniForgetCommit:"
 msgid "Forget Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-line"
+msgctxt "wnd(Log|Project|Std|).mniGoto-line:"
 msgid "Go to Line"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-next-diff"
+msgctxt "wnd(Log|Project|Std|).mniGoto-next-diff:"
 msgid "Next Change"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-previous-diff"
+msgctxt "wnd(Log|Project|Std|).mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniGotoChildrenCommit"
+msgctxt "wnd(Log|Project|Std|).mniGotoChildrenCommit:"
 msgid "Select Child Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniGotoParentsCommit"
+msgctxt "wnd(Log|Project|Std|).mniGotoParentsCommit:"
 msgid "Select Parent Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniIgnore"
+msgctxt "wnd(Log|Project|Std|).mniIgnore:"
 msgid "Ignore"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniIgnore-line-separators"
+msgctxt "wnd(Log|Project|Std|).mniIgnore-line-separators:"
 msgid "Ignore Line-Ending Changes"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniIgnoreReveal"
+msgctxt "wnd(Log|Project|Std|).mniIgnoreReveal:"
 msgid "Edit Ignore File"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniIncludeTrackedRemoteBranches"
+msgctxt "wnd(Log|Project|Std|).mniIncludeTrackedRemoteBranches:"
 msgid "Include Tracked Remote Branches"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniIndexEditor"
+msgctxt "wnd(Log|Project|Std|).mniIndexEditor:"
 msgid "Index Editor"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniInvestigate"
+msgctxt "wnd(Log|Project|Std|).mniInvestigate:"
 msgid "Investigate"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLfsInstall"
+msgctxt "wnd(Log|Project|Std|).mniLfsInstall:"
 msgid "Install"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLfsLock"
+msgctxt "wnd(Log|Project|Std|).mniLfsLock:"
 msgid "Lock"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLfsPrune"
+msgctxt "wnd(Log|Project|Std|).mniLfsPrune:"
 msgid "Prune"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLfsTrack"
+msgctxt "wnd(Log|Project|Std|).mniLfsTrack:"
 msgid "Track"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLfsUnlock"
+msgctxt "wnd(Log|Project|Std|).mniLfsUnlock:"
 msgid "Unlock"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLicenseAgreement"
+msgctxt "wnd(Log|Project|Std|).mniLicenseAgreement:"
 msgid "License Agreement"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLocalGc"
+msgctxt "wnd(Log|Project|Std|).mniLocalGc:"
 msgid "Run Garbage Collector"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLog"
+msgctxt "wnd(Log|Project|Std|).mniLog:"
 msgid "Log"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringBranch"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringBranch:"
 msgid "Branch Coloring"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringDefault"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringDefault:"
 msgid "Default Coloring"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringLegacy"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringLegacy:"
 msgid "Varying Coloring"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringMerge"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringMerge:"
 msgid "Mergeable Coloring"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogRepository"
+msgctxt "wnd(Log|Project|Std|).mniLogRepository:"
 msgid "Show Log Window"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogShowAllParents"
+msgctxt "wnd(Log|Project|Std|).mniLogShowAllParents:"
 msgid "Follow All Parents"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogShowOnlyFirstParents"
+msgctxt "wnd(Log|Project|Std|).mniLogShowOnlyFirstParents:"
 msgid "Follow Only First Parent"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogTopoFiltering"
+msgctxt "wnd(Log|Project|Std|).mniLogTopoFiltering:"
 msgid "Show Graph While Filtering"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexOnDemand"
+msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexOnDemand:"
 msgid "Show Working Tree  Index On Demand"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexPermanent"
+msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexPermanent:"
 msgid "Show Working Tree Permanently"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniMailingList"
+msgctxt "wnd(Log|Project|Std|).mniMailingList:"
 msgid "SmartGit Website"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniMerge"
+msgctxt "wnd(Log|Project|Std|).mniMerge:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniModifyCommit"
+msgctxt "wnd(Log|Project|Std|).mniModifyCommit:"
 msgid "Modify"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniNewStandardWindow"
+msgctxt "wnd(Log|Project|Std|).mniNewStandardWindow:"
 msgid "Show Standard Window"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniNewWindow"
+msgctxt "wnd(Log|Project|Std|).mniNewWindow:"
 msgid "New Window"
 msgstr ""
 
-msgctxt "wnd(Log|Std|).mniOpen"
-msgid "Open from Working Tree"
-msgstr ""
-
-msgctxt "wndProject.mniOpen"
-msgid "Open"
-msgstr ""
-
 msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open from Working Tree"
 msgstr ""
@@ -16532,100 +16499,96 @@ msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniOpenDocumentation"
+msgctxt "wnd(Log|Project|Std|).mniOpenDocumentation:"
 msgid "Online Documentation"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniOpenRootLog"
+msgctxt "wnd(Log|Project|Std|).mniOpenRootLog:"
 msgid "Open Root Log"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniOpenUserEcho"
+msgctxt "wnd(Log|Project|Std|).mniOpenUserEcho:"
 msgid "Feature Requests"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniOpenWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniOpenWorkingTree:"
 msgid "Open Working Tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreferences"
+msgctxt "wnd(Log|Project|Std|).mniPreferences:"
 msgid "Preferences"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCommentNext"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCommentNext:"
 msgid "Next Comment"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCommentPrevious"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCommentPrevious:"
 msgid "Previous Comment"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareAutomatic"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareAutomatic:"
 msgid "Automatic"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareHeadVsIndex"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareHeadVsIndex:"
 msgid "HEAD vs. Index"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareIndexVsWT"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareIndexVsWT:"
 msgid "Index vs. Working Tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewRefresh"
+msgctxt "wnd(Log|Project|Std|).mniPreviewRefresh:"
 msgid "Reload"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewShowCurrentLines"
+msgctxt "wnd(Log|Project|Std|).mniPreviewShowCurrentLines:"
 msgid "Show Long Current Lines"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewUndo"
+msgctxt "wnd(Log|Project|Std|).mniPreviewUndo:"
 msgid "Undo"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPush"
+msgctxt "wnd(Log|Project|Std|).mniPush:"
 msgid "Push"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPushCommits"
+msgctxt "wnd(Log|Project|Std|).mniPushCommits:"
 msgid "Push Up To"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPushTo"
+msgctxt "wnd(Log|Project|Std|).mniPushTo:"
 msgid "Push To"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPushToGerrit"
+msgctxt "wnd(Log|Project|Std|).mniPushToGerrit:"
 msgid "Push to Gerrit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseAbort"
+msgctxt "wnd(Log|Project|Std|).mniRebaseAbort:"
 msgid "Abort"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseContinue"
+msgctxt "wnd(Log|Project|Std|).mniRebaseContinue:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseHeadTo"
+msgctxt "wnd(Log|Project|Std|).mniRebaseHeadTo:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseInteractive"
+msgctxt "wnd(Log|Project|Std|).mniRebaseInteractive:"
 msgid "Rebase Interactive From"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseSkip"
+msgctxt "wnd(Log|Project|Std|).mniRebaseSkip:"
 msgid "Skip"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseStep"
+msgctxt "wnd(Log|Project|Std|).mniRebaseStep:"
 msgid "Step"
-msgstr ""
-
-msgctxt "wnd(Log|Project|Std|).mniRebaseToHead"
-msgid "Rebase to HEAD"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
@@ -16636,75 +16599,75 @@ msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRefresh"
+msgctxt "wnd(Log|Project|Std|).mniRefresh:"
 msgid "Refresh"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRegister"
+msgctxt "wnd(Log|Project|Std|).mniRegister:"
 msgid "Register"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteAdd"
+msgctxt "wnd(Log|Project|Std|).mniRemoteAdd:"
 msgid "Add"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteCopyUrl"
+msgctxt "wnd(Log|Project|Std|).mniRemoteCopyUrl:"
 msgid "Copy URL"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteDelete"
+msgctxt "wnd(Log|Project|Std|).mniRemoteDelete:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetch"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetch:"
 msgid "Fetch"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetchAll"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetchAll:"
 msgid "Fetch All"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetchMore"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetchMore:"
 msgid "Fetch More"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteProperties"
+msgctxt "wnd(Log|Project|Std|).mniRemoteProperties:"
 msgid "Properties"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteRename"
+msgctxt "wnd(Log|Project|Std|).mniRemoteRename:"
 msgid "Rename"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRemove"
+msgctxt "wnd(Log|Project|Std|).mniRemove:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRename"
+msgctxt "wnd(Log|Project|Std|).mniRename:"
 msgid "Move or Rename"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryAdd"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryAdd:"
 msgid "Add or Create"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryAddGroup"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryAddGroup:"
 msgid "Add Group"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryClone"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryClone:"
 msgid "Clone"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryClose"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryClose:"
 msgid "Close Repository"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfig"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfig:"
 msgid "Repository"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfigUser"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfigUser:"
 msgid "User"
 msgstr ""
 
@@ -16720,96 +16683,92 @@ msgctxt "wnd(Log|Project|Std|).mniRepositoryFavorite:"
 msgid "Unmark as Favorite"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryOpen"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryOpen:"
 msgid "Open Repository"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryOpenInNewWindow"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryOpenInNewWindow:"
 msgid "Open Repository in New Window"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryRemove"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryRemove:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryRename"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryRename:"
 msgid "Rename"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySearch"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySearch:"
 msgid "Search for Repositories"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySelectObsolete"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySelectObsolete:"
 msgid "Select Obsolete Repositories"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySettings"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySettings:"
 msgid "Settings"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniReset"
+msgctxt "wnd(Log|Project|Std|).mniReset:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniResetAdvanced"
+msgctxt "wnd(Log|Project|Std|).mniResetAdvanced:"
 msgid "Reset Advanced"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniResolve"
+msgctxt "wnd(Log|Project|Std|).mniResolve:"
 msgid "Resolve"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniResolveOurs"
+msgctxt "wnd(Log|Project|Std|).mniResolveOurs:"
 msgid "Take Ours"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniResolveRecreateConflict"
+msgctxt "wnd(Log|Project|Std|).mniResolveRecreateConflict:"
 msgid "Recreate Conflict"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniResolveTheirs"
+msgctxt "wnd(Log|Project|Std|).mniResolveTheirs:"
 msgid "Take Theirs"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommit"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommit:"
 msgid "Reveal Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommitExtend"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommitExtend:"
 msgid "Compare with Selected Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommitWithHead"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommitWithHead:"
 msgid "Compare with HEAD"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRevealPrevCommit"
+msgctxt "wnd(Log|Project|Std|).mniRevealPrevCommit:"
 msgid "Reveal Previous Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRevealWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniRevealWorkingTree:"
 msgid "Reveal Working Tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRevert"
+msgctxt "wnd(Log|Project|Std|).mniRevert:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniReviewCommentCreate"
+msgctxt "wnd(Log|Project|Std|).mniReviewCommentCreate:"
 msgid "Add Comment"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniReviewConfigure"
+msgctxt "wnd(Log|Project|Std|).mniReviewConfigure:"
 msgid "Configure"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase"
+msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase:"
 msgid "Dump Database"
-msgstr ""
-
-msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate"
-msgid "Create Pull Request"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
@@ -16820,335 +16779,335 @@ msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Pull Request"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniReviewShowClosedPullRequests"
+msgctxt "wnd(Log|Project|Std|).mniReviewShowClosedPullRequests:"
 msgid "Show Closed Pull Requests"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniReviewSync"
+msgctxt "wnd(Log|Project|Std|).mniReviewSync:"
 msgid "Sync"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRewriteTextFile"
+msgctxt "wnd(Log|Project|Std|).mniRewriteTextFile:"
 msgid "Fix Line-Endings"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRollbackTo"
+msgctxt "wnd(Log|Project|Std|).mniRollbackTo:"
 msgid "Rollback To"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSaveAs"
+msgctxt "wnd(Log|Project|Std|).mniSaveAs:"
 msgid "Save As"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-find"
+msgctxt "wnd(Log|Project|Std|).mniSearch-find:"
 msgid "Find"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-next"
+msgctxt "wnd(Log|Project|Std|).mniSearch-next:"
 msgid "Find Next"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-previous"
+msgctxt "wnd(Log|Project|Std|).mniSearch-previous:"
 msgid "Find Previous"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSelectCommittableFiles"
+msgctxt "wnd(Log|Project|Std|).mniSelectCommittableFiles:"
 msgid "Select Committable Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSelectDirectory"
+msgctxt "wnd(Log|Project|Std|).mniSelectDirectory:"
 msgid "Select Directory"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSelectRoot"
+msgctxt "wnd(Log|Project|Std|).mniSelectRoot:"
 msgid "Select Repository Root"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSet-syntax"
+msgctxt "wnd(Log|Project|Std|).mniSet-syntax:"
 msgid "Syntax Language"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSetDepth"
+msgctxt "wnd(Log|Project|Std|).mniSetDepth:"
 msgid "Set Depth"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniShow-line-numbers"
+msgctxt "wnd(Log|Project|Std|).mniShow-line-numbers:"
 msgid "Show Line Numbers"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniShowChanges"
+msgctxt "wnd(Log|Project|Std|).mniShowChanges:"
 msgid "Show Changes"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSkipWorkTree"
+msgctxt "wnd(Log|Project|Std|).mniSkipWorkTree:"
 msgid "Toggle 'Skip Worktree'"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsAsIs"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsAsIs:"
 msgid "Sort By Time"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsFirstParentsBeforeMergeParents"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsFirstParentsBeforeMergeParents:"
 msgid "Sort First Parents before Merge Parents"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsMergeParentsBeforeFirstParents"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsMergeParentsBeforeFirstParents:"
 msgid "Sort Merge Parents before First Parents"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSplitCommit"
+msgctxt "wnd(Log|Project|Std|).mniSplitCommit:"
 msgid "Split"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSquashCommits"
+msgctxt "wnd(Log|Project|Std|).mniSquashCommits:"
 msgid "Squash"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniStage"
+msgctxt "wnd(Log|Project|Std|).mniStage:"
 msgid "Stage"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniStashApply"
+msgctxt "wnd(Log|Project|Std|).mniStashApply:"
 msgid "Apply Stash"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniStashDrop"
+msgctxt "wnd(Log|Project|Std|).mniStashDrop:"
 msgid "Drop Stash"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniStashRename"
+msgctxt "wnd(Log|Project|Std|).mniStashRename:"
 msgid "Rename Stash"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniStashSave"
+msgctxt "wnd(Log|Project|Std|).mniStashSave:"
 msgid "Stash All"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniStashSaveSelection"
+msgctxt "wnd(Log|Project|Std|).mniStashSaveSelection:"
 msgid "Stash Selection"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeactivate"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeactivate:"
 msgid "Deactivate"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeinit"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeinit:"
 msgid "Deinit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleInit"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleInit:"
 msgid "Initialize"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleRegister"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleRegister:"
 msgid "Add"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleReset"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleReset:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleSync"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleSync:"
 msgid "Synchronize"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleUnregister"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleUnregister:"
 msgid "Unregister"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeAdd"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeAdd:"
 msgid "Add"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeMerge"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeMerge:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreePush"
+msgctxt "wnd(Log|Project|Std|).mniSubtreePush:"
 msgid "Push"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeReset"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeReset:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeSplit"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeSplit:"
 msgid "Split"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSync"
+msgctxt "wnd(Log|Project|Std|).mniSync:"
 msgid "Synchronize"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniUndoLastCommit"
+msgctxt "wnd(Log|Project|Std|).mniUndoLastCommit:"
 msgid "Undo Last Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniUnstage"
+msgctxt "wnd(Log|Project|Std|).mniUnstage:"
 msgid "Unstage"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-all"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-all:"
 msgid "Ignore All Whitespaces for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-leading-trailing"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-leading-trailing:"
 msgid "Ignore Leading/Trailing Whitespaces for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-none"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-none:"
 msgid "Ignore No Whitespace for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-remember-as-default"
+msgctxt "wnd(Log|Project|Std|).mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-settings"
+msgctxt "wnd(Log|Project|Std|).mniView-settings:"
 msgid "Settings"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-show-current-line-control"
+msgctxt "wnd(Log|Project|Std|).mniView-show-current-line-control:"
 msgid "Show Long Current Lines"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewFromSubmodules"
+msgctxt "wnd(Log|Project|Std|).mniViewFromSubmodules:"
 msgid "Show Files From Submodules"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewIgnored"
+msgctxt "wnd(Log|Project|Std|).mniViewIgnored:"
 msgid "Show Ignored Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewRecursive"
+msgctxt "wnd(Log|Project|Std|).mniViewRecursive:"
 msgid "Files from Subdirectories"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewRenameSource"
+msgctxt "wnd(Log|Project|Std|).mniViewRenameSource:"
 msgid "Show Rename Source Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewSeparateWtAndIndex"
+msgctxt "wnd(Log|Project|Std|).mniViewSeparateWtAndIndex:"
 msgid "Separate Working Tree and Index"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewSetAnchorCommit"
+msgctxt "wnd(Log|Project|Std|).mniViewSetAnchorCommit:"
 msgid "Set Anchor Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewSkipped"
+msgctxt "wnd(Log|Project|Std|).mniViewSkipped:"
 msgid "Show Skipped Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewStaged"
+msgctxt "wnd(Log|Project|Std|).mniViewStaged:"
 msgid "Show Staged Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleIndex"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleIndex:"
 msgid "Only Index"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleMixed"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleMixed:"
 msgid "Mixed"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleWorkingTree:"
 msgid "Only Working Tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewToolBar"
+msgctxt "wnd(Log|Project|Std|).mniViewToolBar:"
 msgid "Show Toolbar"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnchanged"
+msgctxt "wnd(Log|Project|Std|).mniViewUnchanged:"
 msgid "Show Unchanged Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnchangedAssumed"
+msgctxt "wnd(Log|Project|Std|).mniViewUnchangedAssumed:"
 msgid "Show Assume-Unchanged Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnversioned"
+msgctxt "wnd(Log|Project|Std|).mniViewUnversioned:"
 msgid "Show Unversioned Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowBranches"
+msgctxt "wnd(Log|Project|Std|).mniWindowBranches:"
 msgid "Branches"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowChanges"
+msgctxt "wnd(Log|Project|Std|).mniWindowChanges:"
 msgid "Changes"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowClose"
+msgctxt "wnd(Log|Project|Std|).mniWindowClose:"
 msgid "Close"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowComments"
+msgctxt "wnd(Log|Project|Std|).mniWindowComments:"
 msgid "Comments"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowCommit"
+msgctxt "wnd(Log|Project|Std|).mniWindowCommit:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowDebugLog"
+msgctxt "wnd(Log|Project|Std|).mniWindowDebugLog:"
 msgid "Debug Log"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowDirectories"
+msgctxt "wnd(Log|Project|Std|).mniWindowDirectories:"
 msgid "Repositories"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowFiles"
+msgctxt "wnd(Log|Project|Std|).mniWindowFiles:"
 msgid "Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowGraph"
+msgctxt "wnd(Log|Project|Std|).mniWindowGraph:"
 msgid "Graph"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowHideView"
+msgctxt "wnd(Log|Project|Std|).mniWindowHideView:"
 msgid "Hide View"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowJournal"
+msgctxt "wnd(Log|Project|Std|).mniWindowJournal:"
 msgid "Journal"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutReset"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutReset:"
 msgid "Reset Perspective"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetMain"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetMain:"
 msgid "Main Perspective"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetReview"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetReview:"
 msgid "Review Perspective"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowOutput"
+msgctxt "wnd(Log|Project|Std|).mniWindowOutput:"
 msgid "Output"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniWindowWorkingTree:"
 msgid "Show Working Tree Window"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreeAdd"
+msgctxt "wnd(Log|Project|Std|).mniWorktreeAdd:"
 msgid "Add Worktree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreePrune"
+msgctxt "wnd(Log|Project|Std|).mniWorktreePrune:"
 msgid "Prune Obsolete Worktrees"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreeRemove"
+msgctxt "wnd(Log|Project|Std|).mniWorktreeRemove:"
 msgid "Remove Worktree"
 msgstr ""
 
@@ -17344,7 +17303,7 @@ msgctxt "wnd(Log|Project|Std|).tab:"
 msgid "Repositories"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbr\"  History  \""
+msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
 msgid "History"
 msgstr ""
 
@@ -17608,120 +17567,116 @@ msgctxt "wnd(Log|Project|Std|).tbt:"
 msgid "Show directories tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtAnnotate"
+msgctxt "wnd(Log|Project|Std|).tbtAnnotate:"
 msgid "Show a blame \\(annotated\\) view of the selected file."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtBranchAdd"
+msgctxt "wnd(Log|Project|Std|).tbtBranchAdd:"
 msgid "Add a new branch for the current commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtBranchAddTag"
+msgctxt "wnd(Log|Project|Std|).tbtBranchAddTag:"
 msgid "Add a new tag for the current commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtCheckout"
+msgctxt "wnd(Log|Project|Std|).tbtCheckout:"
 msgid "Check out an existing commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtCherryPick"
+msgctxt "wnd(Log|Project|Std|).tbtCherryPick:"
 msgid "Cherry-pick commits from other branches."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtClearOutput"
+msgctxt "wnd(Log|Project|Std|).tbtClearOutput:"
 msgid "Clear output pane."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtCommit"
+msgctxt "wnd(Log|Project|Std|).tbtCommit:"
 msgid "Commit local changes."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtConflictSolver"
+msgctxt "wnd(Log|Project|Std|).tbtConflictSolver:"
 msgid "Open the Conflict Solver \\(or configured external merge tool\\) to resolve conflicts."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtDelete"
+msgctxt "wnd(Log|Project|Std|).tbtDelete:"
 msgid "Delete the selected local files or directory."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtDiscard"
+msgctxt "wnd(Log|Project|Std|).tbtDiscard:"
 msgid "Discard local changes."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtFetch"
+msgctxt "wnd(Log|Project|Std|).tbtFetch:"
 msgid "Fetch commits from a remote repository and \\(optionally\\) integrate them with possible local commits."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowContext"
+msgctxt "wnd(Log|Project|Std|).tbtFlowContext:"
 msgid "Finish a Git-Flow feature."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixFinish"
+msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixFinish:"
 msgid "Finish a Git-Flow hotfix."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixStart"
+msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixStart:"
 msgid "Start a new Git-Flow hotfix."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowIntegrateDevelop"
+msgctxt "wnd(Log|Project|Std|).tbtFlowIntegrateDevelop:"
 msgid "Integrate new base commits into a Git-Flow feature."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtGoto-next-diff"
+msgctxt "wnd(Log|Project|Std|).tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtGoto-previous-diff"
+msgctxt "wnd(Log|Project|Std|).tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtIgnore"
+msgctxt "wnd(Log|Project|Std|).tbtIgnore:"
 msgid "Mark unversioned local files/directories to be ignored."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtIndexEditor"
+msgctxt "wnd(Log|Project|Std|).tbtIndexEditor:"
 msgid "Edit the Index state of the selected file, e.g. to decide which lines should be staged."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtInvestigate"
+msgctxt "wnd(Log|Project|Std|).tbtInvestigate:"
 msgid "Investigate history line-wise with DeepGit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtLog"
+msgctxt "wnd(Log|Project|Std|).tbtLog:"
 msgid "Show the history for selected file or directory."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtLogRepository"
+msgctxt "wnd(Log|Project|Std|).tbtLogRepository:"
 msgid "Show the history for the whole repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtMerge"
+msgctxt "wnd(Log|Project|Std|).tbtMerge:"
 msgid "Merge changes from other branches."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtPreviewRefresh"
+msgctxt "wnd(Log|Project|Std|).tbtPreviewRefresh:"
 msgid "Reload the previewed file contents."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtPush"
+msgctxt "wnd(Log|Project|Std|).tbtPush:"
 msgid "Push local commits to the remote origin repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtPushTo"
+msgctxt "wnd(Log|Project|Std|).tbtPushTo:"
 msgid "Push local commits to a remote repository, allowing to choose the target repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRebaseHeadTo"
+msgctxt "wnd(Log|Project|Std|).tbtRebaseHeadTo:"
 msgid "Apply commits from your current branch to the selected commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRefresh"
+msgctxt "wnd(Log|Project|Std|).tbtRefresh:"
 msgid "Refresh the log view."
-msgstr ""
-
-msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch"
-msgid "Fetch commits from current remote repository."
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
@@ -17732,123 +17687,123 @@ msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from current remote repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRemove"
+msgctxt "wnd(Log|Project|Std|).tbtRemove:"
 msgid "Remove selected files or directories from repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositoryAdd"
+msgctxt "wnd(Log|Project|Std|).tbtRepositoryAdd:"
 msgid "Add or create a new repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositoryClone"
+msgctxt "wnd(Log|Project|Std|).tbtRepositoryClone:"
 msgid "Clone a new repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositorySearch"
+msgctxt "wnd(Log|Project|Std|).tbtRepositorySearch:"
 msgid "Search for existing repositories."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtReset"
+msgctxt "wnd(Log|Project|Std|).tbtReset:"
 msgid "Reset current HEAD to another commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtResetAdvanced"
+msgctxt "wnd(Log|Project|Std|).tbtResetAdvanced:"
 msgid "Reset current HEAD to another commit and keep the difference in Index or Working Tree."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealHomeCommit"
+msgctxt "wnd(Log|Project|Std|).tbtRevealHomeCommit:"
 msgid "Reveal HEAD/working tree in graph."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealPrevCommit"
+msgctxt "wnd(Log|Project|Std|).tbtRevealPrevCommit:"
 msgid "Reveal selected commits before invoking Reveal Working Tree."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealWorkingTree"
+msgctxt "wnd(Log|Project|Std|).tbtRevealWorkingTree:"
 msgid "Reveal working tree node in graph."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRevert"
+msgctxt "wnd(Log|Project|Std|).tbtRevert:"
 msgid "Undo the changes of an existing commit by \"reverse\" merging it."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtShowChanges"
+msgctxt "wnd(Log|Project|Std|).tbtShowChanges:"
 msgid "Open the file compare for the selected file."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStage"
+msgctxt "wnd(Log|Project|Std|).tbtStage:"
 msgid "Store working tree files in the index to prepare the next commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStashApply"
+msgctxt "wnd(Log|Project|Std|).tbtStashApply:"
 msgid "Reapply local changes from a stash."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStashDrop"
+msgctxt "wnd(Log|Project|Std|).tbtStashDrop:"
 msgid "Drop one or more stashes from the repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStashSave"
+msgctxt "wnd(Log|Project|Std|).tbtStashSave:"
 msgid "Stash current local changes."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStdSetModeHistory"
+msgctxt "wnd(Log|Project|Std|).tbtStdSetModeHistory:"
 msgid "Show the history view."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStdSetModeWt"
+msgctxt "wnd(Log|Project|Std|).tbtStdSetModeWt:"
 msgid "Show the local files of the repository \\(Working Tree\\)."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtSync"
+msgctxt "wnd(Log|Project|Std|).tbtSync:"
 msgid "Push local commits of the current branch and pull remote changes."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtUnstage"
+msgctxt "wnd(Log|Project|Std|).tbtUnstage:"
 msgid "Remove staged changes from index."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtView-ignore-whitespaces"
+msgctxt "wnd(Log|Project|Std|).tbtView-ignore-whitespaces:"
 msgid "Ignore irrelevant whitespace"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewFromSubmodules"
+msgctxt "wnd(Log|Project|Std|).tbtViewFromSubmodules:"
 msgid "If selected, files from submodules will be shown."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewIgnored"
+msgctxt "wnd(Log|Project|Std|).tbtViewIgnored:"
 msgid "If selected, ignored files will be shown."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewRenameSource"
+msgctxt "wnd(Log|Project|Std|).tbtViewRenameSource:"
 msgid "If selected, removed/missing source files of detected renames will be shown."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewSkipped"
+msgctxt "wnd(Log|Project|Std|).tbtViewSkipped:"
 msgid "If selected, skipped files will be shown."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewStaged"
+msgctxt "wnd(Log|Project|Std|).tbtViewStaged:"
 msgid "If selected, files with staged \\(Index\\) changes and without working tree changes will be shown."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnchanged"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnchanged:"
 msgid "If selected, unchanged files will be shown."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnchangedAssumed"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnchangedAssumed:"
 msgid "If selected, files having the 'assume-unchanged' flag will be shown."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnversioned"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnversioned:"
 msgid "If selected, not yet version controlled files will be shown."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetMain"
+msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetMain:"
 msgid "Switch to the Main perspective."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetReview"
+msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetReview:"
 msgid "Switch to the Review perspective."
 msgstr ""
 
@@ -17858,4 +17813,8 @@ msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).tle:"
 msgid "$1 \\[$2\\] - Log for $3"
+msgstr ""
+
+msgctxt "wnd(Log|Std|).mniOpen:"
+msgid "Open from Working Tree"
 msgstr ""

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -125,7 +125,7 @@ msgctxt "dlgCommitGitHubConfirmEmail.fur:"
 msgid "If this repository is open-source, you might want to hide your email address, as \\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\], and use instead <username>@users.noreply.github.com."
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.hdl%1:"
+msgctxt "dlgCommitGitHubConfirmEmail.hdl:"
 msgid "Commit with default email address $1?"
 msgstr ""
 
@@ -358,11 +358,11 @@ msgctxt "dlgProgress.tle:"
 msgid "Verifying executables"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.fur%1:"
+msgctxt "dlgQBugFileSendingFailed.fur:"
 msgid "Maybe you need to configure a proxy or our server is temporarily down.\\nDetails: $1"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.hdl%1:"
+msgctxt "dlgQBugFileSendingFailed.hdl:"
 msgid "Could not send the crash logs to $1"
 msgstr ""
 
@@ -434,7 +434,7 @@ msgctxt "dlgQDockManagerClosedView.fur:"
 msgid "To reopen it again, use the corresponding menu item from the Window menu."
 msgstr ""
 
-msgctxt "dlgQDockManagerClosedView.hdl%1:"
+msgctxt "dlgQDockManagerClosedView.hdl:"
 msgid "You've closed the view '$1'."
 msgstr ""
 
@@ -450,7 +450,7 @@ msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur:"
 msgid "To save to a different file, click 'Cancel'."
 msgstr ""
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl%1:"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl:"
 msgid "The file $1 already exists. Do you want to overwrite it?"
 msgstr ""
 
@@ -482,11 +482,11 @@ msgctxt "dlgQFrameManagerExit.tle:"
 msgid "Exit"
 msgstr ""
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.fur%2:"
+msgctxt "dlgQIntegerInputProviderInvalidValue.fur:"
 msgid "Port must be in the range from $1 to $2."
 msgstr ""
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.hdl%1:"
+msgctxt "dlgQIntegerInputProviderInvalidValue.hdl:"
 msgid "The text in field '$1' is not valid."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgctxt "dlgQProxyConnectionFailed.fur:"
 msgid "Details: syntevo.com"
 msgstr ""
 
-msgctxt "dlgQProxyConnectionFailed.hdl%1:"
+msgctxt "dlgQProxyConnectionFailed.hdl:"
 msgid "Could not connect to $1."
 msgstr ""
 
@@ -582,7 +582,7 @@ msgctxt "dlgQUpdateCheckForNewVersion.tle:"
 msgid "Check for New Version"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.fur%1:"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.fur:"
 msgid "Details: Failed to connect to '$1'."
 msgstr ""
 
@@ -610,7 +610,7 @@ msgctxt "dlgQUpdateCheckLatestBuild.tle:"
 msgid "Check for Latest Build"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur%1:"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur:"
 msgid "Details: $1"
 msgstr ""
 
@@ -706,7 +706,7 @@ msgctxt "dlgScAboutUpdateInstallation.fur:"
 msgid "This will take a few moments and has to restart SmartGit."
 msgstr ""
 
-msgctxt "dlgScAboutUpdateInstallation.hdl%1:"
+msgctxt "dlgScAboutUpdateInstallation.hdl:"
 msgid "Do you want to upgrade the installation directory to version $1?"
 msgstr ""
 
@@ -762,11 +762,11 @@ msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl:"
 msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%1:"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%2:"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
 msgid "\\[$1\\] - $2"
 msgstr ""
 
@@ -958,7 +958,7 @@ msgctxt "dlgScDevOpsCredentials.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgScDevOpsCredentials.hdl%1:"
+msgctxt "dlgScDevOpsCredentials.hdl:"
 msgid "Login to '$1'"
 msgstr ""
 
@@ -990,7 +990,7 @@ msgctxt "dlgScDevOpsSslClientCertificate.edt:"
 msgid "Passphrase"
 msgstr ""
 
-msgctxt "dlgScDevOpsSslClientCertificate.hdl%1:"
+msgctxt "dlgScDevOpsSslClientCertificate.hdl:"
 msgid "Select the client certificate for $1"
 msgstr ""
 
@@ -1090,7 +1090,7 @@ msgctxt "dlgScDialogAssertionHandlerOutOfMemory.btn:"
 msgid "Force Exit"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur%1:"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur:"
 msgid "It is strongly recommended to restart SmartGit.\\n\\nTo increase the maximum memory limit edit $1, increase the value of the -Xmx option, for example to -Xmx1024m \\(or add it if not yet existing\\) and restart SmartGit."
 msgstr ""
 
@@ -1110,7 +1110,7 @@ msgctxt "dlgScEvaluationReminderContinue.btn:"
 msgid "Register"
 msgstr ""
 
-msgctxt "dlgScEvaluationReminderContinue.fur%2:"
+msgctxt "dlgScEvaluationReminderContinue.fur:"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends today."
 msgstr ""
 
-msgctxt "dlgScEvaluationReminderContinue.hdl%1:"
+msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr ""
 
@@ -1158,11 +1158,11 @@ msgctxt "dlgScEvaluationReminderExpiredGrace.tle:"
 msgid "Evaluation"
 msgstr ""
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl%2:"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl:"
 msgid "Cannot run program \"$1\": $2"
 msgstr ""
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle%1:"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
@@ -1356,7 +1356,7 @@ msgctxt "dlgScFilePatternsEdit.edt:"
 msgid "File Pattern"
 msgstr ""
 
-msgctxt "dlgScFilePatternsEdit.hdl%1:"
+msgctxt "dlgScFilePatternsEdit.hdl:"
 msgid "Language: $1"
 msgstr ""
 
@@ -1488,7 +1488,7 @@ msgctxt "dlgScJiraResolveIssue.edt:"
 msgid "Summary"
 msgstr ""
 
-msgctxt "dlgScJiraResolveIssue.hdl%1:"
+msgctxt "dlgScJiraResolveIssue.hdl:"
 msgid "Resolve issue $1"
 msgstr ""
 
@@ -1624,7 +1624,7 @@ msgctxt "dlgScPropertiesReset.fur:"
 msgid "The new values will be active after restarting SmartGit."
 msgstr ""
 
-msgctxt "dlgScPropertiesReset.hdl%1:"
+msgctxt "dlgScPropertiesReset.hdl:"
 msgid "Do you want to reset $1 system properties to their defaults?"
 msgstr ""
 
@@ -1640,7 +1640,7 @@ msgctxt "dlgScPropertyEdit.hdl:"
 msgid "Edit low-level property value"
 msgstr ""
 
-msgctxt "dlgScPropertyEdit.inf%1:"
+msgctxt "dlgScPropertyEdit.inf:"
 msgid "Set the value for property '$1'"
 msgstr ""
 
@@ -2070,7 +2070,7 @@ msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle:"
 msgid "SmartGit Installation Update"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur%1:"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur:"
 msgid "Please get rid of '$1' manually and retry the upgrade."
 msgstr ""
 
@@ -2086,7 +2086,7 @@ msgctxt "dlgScUpdateInstallationUpgrade.btn:"
 msgid "Upgrade Now"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpgrade.fur%1:"
+msgctxt "dlgScUpdateInstallationUpgrade.fur:"
 msgid "The new version $1 has been downloaded which needs to be installed."
 msgstr ""
 
@@ -2538,7 +2538,7 @@ msgctxt "dlgSgAiSetupLlmConfigurationInvalid.hdl:"
 msgid "Configuration is invalid."
 msgstr ""
 
-msgctxt "dlgSgApplicationAlreadyRunning.fur%1:"
+msgctxt "dlgSgApplicationAlreadyRunning.fur:"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
 msgstr ""
 
@@ -2582,7 +2582,7 @@ msgctxt "dlgSgAuthenticationShowPassword.edt:"
 msgid "Password"
 msgstr ""
 
-msgctxt "dlgSgAuthenticationShowPassword.tle%1:"
+msgctxt "dlgSgAuthenticationShowPassword.tle:"
 msgid "Password for $1"
 msgstr ""
 
@@ -2626,7 +2626,7 @@ msgctxt "dlgSgBisectResult.btn:"
 msgid "Leave Bisect"
 msgstr ""
 
-msgctxt "dlgSgBisectResult.fur%1:"
+msgctxt "dlgSgBisectResult.fur:"
 msgid "$1"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl%1:"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
@@ -2802,7 +2802,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl%1:"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
 
@@ -2842,7 +2842,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl%1:"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk%1:"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl%1:"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the branch '$1'?"
 msgstr ""
 
@@ -2902,7 +2902,7 @@ msgctxt "dlgSgBranchTrackingResetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingResetConfirm.hdl%2:"
+msgctxt "dlgSgBranchTrackingResetConfirm.hdl:"
 msgid "Should branch '$1' stop tracking '$2'?"
 msgstr ""
 
@@ -2918,7 +2918,7 @@ msgctxt "dlgSgBranchTrackingSetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingSetConfirm.hdl%2:"
+msgctxt "dlgSgBranchTrackingSetConfirm.hdl:"
 msgid "Do you want to configure '$1' to track '$2'?"
 msgstr ""
 
@@ -3010,7 +3010,7 @@ msgctxt "dlgSgCheckoutFastForwardMerge.fur:"
 msgid "Fast-forward-merging automatically moves the branch forward to the tracked remote branch."
 msgstr ""
 
-msgctxt "dlgSgCheckoutFastForwardMerge.hdl%1:"
+msgctxt "dlgSgCheckoutFastForwardMerge.hdl:"
 msgid "Do you want to fast-forward-merge remote changes after checking out '$1'?"
 msgstr ""
 
@@ -3026,11 +3026,11 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.fur%1:"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.fur:"
 msgid "This will make '$1' your current branch."
 msgstr ""
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl%1:"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl:"
 msgid "Do you want to checkout the branch '$1'?"
 msgstr ""
 
@@ -3150,7 +3150,7 @@ msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr ""
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl%1:"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
@@ -4019,7 +4019,7 @@ msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl:"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle%3:"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle:"
 msgid "\\[$1\\] - \\[$2\\] - $3"
 msgstr ""
 
@@ -4155,7 +4155,7 @@ msgctxt "dlgSgDeleteDirTrash.fur:"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.hdl%1:"
+msgctxt "dlgSgDeleteDirTrash.hdl:"
 msgid "Do you want to delete '$1' recursively?"
 msgstr ""
 
@@ -4163,11 +4163,11 @@ msgctxt "dlgSgDeleteDirTrash.tle:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgDeleteFileTrash.hdl%1:"
+msgctxt "dlgSgDeleteFileTrash.hdl:"
 msgid "Do you want to delete '$1'?"
 msgstr ""
 
-msgctxt "dlgSgDeleteFilesTrash.hdl%1:"
+msgctxt "dlgSgDeleteFilesTrash.hdl:"
 msgid "Do you want to delete the $1 selected files?"
 msgstr ""
 
@@ -4263,11 +4263,11 @@ msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToHead.hdl%1:"
+msgctxt "dlgSgDiscardRevertToHead.hdl:"
 msgid "Do you want to reset $1 files back to their HEAD state?"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToIndex.hdl%1:"
+msgctxt "dlgSgDiscardRevertToIndex.hdl:"
 msgid "Do you want to reset $1 files back to their Index state?"
 msgstr ""
 
@@ -4339,7 +4339,7 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.btn:"
 msgid "Force Opening"
 msgstr ""
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl%1:"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl:"
 msgid "Could not open Conflict Solver for '$1', because it seems to be no text file."
 msgstr ""
 
@@ -4347,7 +4347,7 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle:"
 msgid "Conflict Solver"
 msgstr ""
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.hdl%1:"
+msgctxt "dlgSgFileCompareInvokerFailedIO.hdl:"
 msgid "'$1' could not be invoked."
 msgstr ""
 
@@ -4387,11 +4387,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.btn:"
 msgid "Fast-Forward"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur%3:"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur:"
 msgid "The local branch '$1' is behind its tracked branch '$2'. You may fast-forward now or do it manually later, e.g. by checking out the branch '$3'."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl%2:"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl:"
 msgid "Should branch '$1' be fast-forwarded to '$2'?"
 msgstr ""
 
@@ -4403,11 +4403,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.btn:"
 msgid "Replace"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur%2:"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur:"
 msgid "The local branch '$1' seems to contain more recent but rewritten commits of remote branch '$2'.\\n\\nIf you are not sure whether the local branch is actually more recent than the remote branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl%2:"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl:"
 msgid "Should branch '$1' replace remote branch '$2'?"
 msgstr ""
 
@@ -4419,11 +4419,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur%2:"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur:"
 msgid "The remote branch '$1' seems to contain more recent but rewritten commits of local branch '$2'.\\n\\nIf you are not sure whether the remote branch is actually more recent than the local branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl%2:"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl:"
 msgid "Should branch '$1' be reset to remote branch '$2'?"
 msgstr ""
 
@@ -4607,7 +4607,7 @@ msgctxt "dlgSgFlowFeatureStart.hdl:"
 msgid "Start a new feature"
 msgstr ""
 
-msgctxt "dlgSgFlowFeatureStart.inf%1:"
+msgctxt "dlgSgFlowFeatureStart.inf:"
 msgid "Enter the name of the new feature branch. This operation will fork a new branch from the '$1' branch."
 msgstr ""
 
@@ -4711,7 +4711,7 @@ msgctxt "dlgSgFlowHotfixStart.hdl:"
 msgid "Start a new hotfix"
 msgstr ""
 
-msgctxt "dlgSgFlowHotfixStart.inf%1:"
+msgctxt "dlgSgFlowHotfixStart.inf:"
 msgid "Enter the name of the new hotfix branch. This operation will fork a new branch from the '$1' branch."
 msgstr ""
 
@@ -4731,7 +4731,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.chk:"
 msgid "Fetch latest '$1' commits from remote repository"
 msgstr ""
 
-msgctxt "dlgSgFlowIntegrateDevelop.hdl%1:"
+msgctxt "dlgSgFlowIntegrateDevelop.hdl:"
 msgid "Integrate commits from '$1'"
 msgstr ""
 
@@ -4843,7 +4843,7 @@ msgctxt "dlgSgFlowReleaseStart.hdl:"
 msgid "Start a new release"
 msgstr ""
 
-msgctxt "dlgSgFlowReleaseStart.inf%1:"
+msgctxt "dlgSgFlowReleaseStart.inf:"
 msgid "Enter the name of the new release branch. This operation will fork a new branch from the '$1' branch."
 msgstr ""
 
@@ -4879,7 +4879,7 @@ msgctxt "dlgSgFlowSupportStart.hdl:"
 msgid "Start a new support"
 msgstr ""
 
-msgctxt "dlgSgFlowSupportStart.inf%1:"
+msgctxt "dlgSgFlowSupportStart.inf:"
 msgid "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 msgstr ""
 
@@ -5394,7 +5394,7 @@ msgctxt "dlgSgHistoryModifySplitConfirm.fur:"
 msgid "'Modify' will stop after the commit.\\n\\n'Split' will put the changes into the Index. You may discard some changes that should go into the second commit.\\n\\nAfter you've done the changes, process the remaining commits by continuing the rebase."
 msgstr ""
 
-msgctxt "dlgSgHistoryModifySplitConfirm.hdl%1:"
+msgctxt "dlgSgHistoryModifySplitConfirm.hdl:"
 msgid "Do you want to modify or split commit $1?"
 msgstr ""
 
@@ -5410,7 +5410,7 @@ msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl%1:"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl:"
 msgid "Do you want to replace the remote branch by commit $1?"
 msgstr ""
 
@@ -5426,7 +5426,7 @@ msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur:"
 msgid "All commits up to the selected commit will be pushed to the remote repository."
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl%1:"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl:"
 msgid "Do you want to push changes up to commit $1?"
 msgstr ""
 
@@ -5833,11 +5833,11 @@ msgctxt "dlgSgHostingProviderEdit.err:"
 msgid "The provided SSL client certificate path is invalid."
 msgstr ""
 
-msgctxt "dlgSgHostingProviderEdit.hdl%1:"
+msgctxt "dlgSgHostingProviderEdit.hdl:"
 msgid "Configure $1 account"
 msgstr ""
 
-msgctxt "dlgSgHostingProviderEdit.inf%1:"
+msgctxt "dlgSgHostingProviderEdit.inf:"
 msgid "Please specify your credentials to connect to $1."
 msgstr ""
 
@@ -5949,11 +5949,11 @@ msgctxt "dlgSgHostingProvider(Add|Edit).lbl:"
 msgid "Optional SSL configuration"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur%3:"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur:"
 msgid "The OAuth-access token could not be requested. Most likely your $1 configuration has changed and SmartGit's stored OAuth credentials are invalid.\\n\\nTo resolve, recreate the $2 hosting provider in the Preferences.\\n\\nDetails:\\n\\n$3"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl%1:"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl:"
 msgid "$1 OAuth-authentication failed"
 msgstr ""
 
@@ -5977,7 +5977,7 @@ msgctxt "dlgSgHttpPasswordCredentials.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordCredentials.hdl%1:"
+msgctxt "dlgSgHttpPasswordCredentials.hdl:"
 msgid "Login to '$1'"
 msgstr ""
 
@@ -6029,7 +6029,7 @@ msgctxt "dlgSgIgnoreDirectoryConfirm.fur:"
 msgid "The directory name will be added to the ignore file. If the ignore file does not exist, it will be created."
 msgstr ""
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.hdl%1:"
+msgctxt "dlgSgIgnoreDirectoryConfirm.hdl:"
 msgid "Do you want to ignore directory '$1'?"
 msgstr ""
 
@@ -6157,11 +6157,11 @@ msgctxt "dlgSgJournalDoubleClick.btn:"
 msgid "Open Log"
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.fur%1:"
+msgctxt "dlgSgJournalDoubleClick.fur:"
 msgid "Select either to check out '$1' or to open the Log for the selected commit."
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.hdl%1:"
+msgctxt "dlgSgJournalDoubleClick.hdl:"
 msgid "Do you want to check out '$1'?"
 msgstr ""
 
@@ -6237,7 +6237,7 @@ msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.btn:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur%1:"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur:"
 msgid "You are about to apply lines from the Index to the working tree file '$1'. The modifications will be saved immediately."
 msgstr ""
 
@@ -6289,7 +6289,7 @@ msgctxt "dlgSgLogCheckoutFileAs.tle:"
 msgid "Save File As"
 msgstr ""
 
-msgctxt "dlgSgLogCommentDeleteConfirm.hdl%1:"
+msgctxt "dlgSgLogCommentDeleteConfirm.hdl:"
 msgid "Do you really want to delete comment '$1'?"
 msgstr ""
 
@@ -6305,7 +6305,7 @@ msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle:"
 msgid "Delete Comment"
 msgstr ""
 
-msgctxt "dlgSgLogCommentsDeleteConfirm.hdl%1:"
+msgctxt "dlgSgLogCommentsDeleteConfirm.hdl:"
 msgid "Do you really want to delete $1 comments?"
 msgstr ""
 
@@ -6449,7 +6449,7 @@ msgctxt "dlgSgLogRefActionsDeleteConfirm.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr ""
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl%1:"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl:"
 msgid "Do you really want to delete the local branch '$1'?"
 msgstr ""
 
@@ -6465,11 +6465,11 @@ msgctxt "dlgSgLogRefreshRepositoryInvalid.btn:"
 msgid "Remove Repository"
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.fur%1:"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.fur:"
 msgid "This could mean that the repository at\\n\\n$1was removed or renamed outside SmartGit."
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl%1:"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl:"
 msgid "The opened repository '$1' became invalid."
 msgstr ""
 
@@ -6605,7 +6605,7 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.fur:"
 msgid "The specified directory does not appear to be a valid Git repository."
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.hdl%1:"
+msgctxt "dlgSgOpenRepositoryInitializeGit.hdl:"
 msgid "Should '$1' be initialized as a new Git repository?"
 msgstr ""
 
@@ -6633,7 +6633,7 @@ msgctxt "dlgSgOpenRepositoryOuterOrInner.tle:"
 msgid "Add or Create Repository"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur%1:"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur:"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr ""
 
@@ -6937,11 +6937,11 @@ msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "repository '$1' not found."
 msgstr ""
 
-msgctxt "dlgSgPingRepositoryFailed.fur%1:"
+msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr ""
 
-msgctxt "dlgSgPingRepositoryFailed.hdl%1:"
+msgctxt "dlgSgPingRepositoryFailed.hdl:"
 msgid "Could not connect to the repository '$1'."
 msgstr ""
 
@@ -8364,7 +8364,7 @@ msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.hdl%1:"
+msgctxt "dlgSgProviderGenerateToken.hdl:"
 msgid "Generate a new API token for $1"
 msgstr ""
 
@@ -8424,7 +8424,7 @@ msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur:"
 msgid "The merge request itself will not be deleted on the server."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl%1:"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl:"
 msgid "Do you really want to drop the local commits of merge request $1?"
 msgstr ""
 
@@ -8440,7 +8440,7 @@ msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur:"
 msgid "The pull request itself will not be deleted on the server."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl%1:"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl:"
 msgid "Do you want to drop the local commits of pull request $1?"
 msgstr ""
 
@@ -8576,7 +8576,7 @@ msgctxt "dlgSgPullMergeInsteadOfRebase.btn:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.fur%1:"
+msgctxt "dlgSgPullMergeInsteadOfRebase.fur:"
 msgid "Amongst the changes to rebase there is merge-commit $1. Rebasing merge-commits can easily cause troubles."
 msgstr ""
 
@@ -8624,7 +8624,7 @@ msgctxt "dlgSgPullOrJustFetch.fur:"
 msgid "You can change the Pull behavior in the Repository Settings."
 msgstr ""
 
-msgctxt "dlgSgPullOrJustFetch.hdl%1:"
+msgctxt "dlgSgPullOrJustFetch.hdl:"
 msgid "Do you want to pull or just fetch $1 repositories?"
 msgstr ""
 
@@ -8652,11 +8652,11 @@ msgctxt "dlgSgPushConfirmSingleBranch.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleBranch.fur%1:"
+msgctxt "dlgSgPushConfirmSingleBranch.fur:"
 msgid "1 branch will be pushed to '$1'."
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleBranch.hdl%1:"
+msgctxt "dlgSgPushConfirmSingleBranch.hdl:"
 msgid "Do you want to push branch '$1'?"
 msgstr ""
 
@@ -8692,7 +8692,7 @@ msgctxt "dlgSgPushForced.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr ""
 
-msgctxt "dlgSgPushForced.hdl%1:"
+msgctxt "dlgSgPushForced.hdl:"
 msgid "Do you want to force-push \\(replace\\) the remote branch '$1'?"
 msgstr ""
 
@@ -8848,11 +8848,11 @@ msgctxt "dlgSgPushToRemote.edt:"
 msgid "Target Repository"
 msgstr ""
 
-msgctxt "dlgSgPushToRemote.hdl%1:"
+msgctxt "dlgSgPushToRemote.hdl:"
 msgid "Push '$1' branches to another remote"
 msgstr ""
 
-msgctxt "dlgSgPushToRemote.inf%1:"
+msgctxt "dlgSgPushToRemote.inf:"
 msgid "All branches of '$1' \\(as locally represented by the corresponding remote branches\\) will be pushed to the target repository."
 msgstr ""
 
@@ -8908,7 +8908,7 @@ msgctxt "dlgSgPushTrackingConfigureSingle.fur:"
 msgid "For your current branch tracking \\(its corresponding remote branch\\) has not been configured yet. Configuring tracking will keep your local branches in sync with the remote branches."
 msgstr ""
 
-msgctxt "dlgSgPushTrackingConfigureSingle.hdl%1:"
+msgctxt "dlgSgPushTrackingConfigureSingle.hdl:"
 msgid "Do you want to configure tracking for '$1' branch?"
 msgstr ""
 
@@ -8944,7 +8944,7 @@ msgctxt "dlgSgRebaseConfirmUnreachable.fur:"
 msgid "You only might be able to access this commit using the 'Recyclable Commits' option of the Branches view."
 msgstr ""
 
-msgctxt "dlgSgRebaseConfirmUnreachable.hdl%1:"
+msgctxt "dlgSgRebaseConfirmUnreachable.hdl:"
 msgid "The Commit $1 would become unreachable by refs."
 msgstr ""
 
@@ -8960,7 +8960,7 @@ msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur%1:"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur:"
 msgid "The splitting of commit $1 still is in progress and all changes of this commit have been applied."
 msgstr ""
 
@@ -9140,7 +9140,7 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.btn:"
 msgid "Put Changes into Index"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur%1:"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur:"
 msgid "The splitting of commit $1 still is in progress, but not all changes of this commit have been applied.\\n\\nIf this is intentional, you can continue. Otherwise, you should click 'Put Changes into Index' and review your changes."
 msgstr ""
 
@@ -9152,19 +9152,19 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur%1:"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) onto the selected commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl%1:"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl:"
 msgid "Do you want to rebase '$1' onto the selected commit?"
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur%2:"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) to '$2'."
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl%2:"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl:"
 msgid "Do you want to rebase '$1' to '$2'?"
 msgstr ""
 
@@ -9284,7 +9284,7 @@ msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur:"
 msgid "It might become hard or impossible to recover the commit again."
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl%1:"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl:"
 msgid "Do you want to remove the selected commit $1?"
 msgstr ""
 
@@ -9328,7 +9328,7 @@ msgctxt "dlgSgRebaseTagCommit.fur:"
 msgid "After the rebase, the remaining commit won't be reachable anymore."
 msgstr ""
 
-msgctxt "dlgSgRebaseTagCommit.hdl%1:"
+msgctxt "dlgSgRebaseTagCommit.hdl:"
 msgid "Should commit $1 be tagged?"
 msgstr ""
 
@@ -9420,7 +9420,7 @@ msgctxt "dlgSgRemoteDeleteConfirm.fur:"
 msgid "This will just delete the link to the remote repository."
 msgstr ""
 
-msgctxt "dlgSgRemoteDeleteConfirm.hdl%1:"
+msgctxt "dlgSgRemoteDeleteConfirm.hdl:"
 msgid "Do you want to delete the remote repository '$1'?"
 msgstr ""
 
@@ -9580,7 +9580,7 @@ msgctxt "dlgSgRemotesAdd.tle:"
 msgid "Add Remote Repository"
 msgstr ""
 
-msgctxt "dlgSgRemotesNoRemoteDetected.fur%1:"
+msgctxt "dlgSgRemotesNoRemoteDetected.fur:"
 msgid "To perform the operation the repository configuration for $1 must contain one uniquely determined remote."
 msgstr ""
 
@@ -9636,7 +9636,7 @@ msgctxt "dlgSgRenameBranch.hdl:"
 msgid "Rename branch"
 msgstr ""
 
-msgctxt "dlgSgRenameBranch.inf%1:"
+msgctxt "dlgSgRenameBranch.inf:"
 msgid "Enter the new name for the branch '$1'."
 msgstr ""
 
@@ -9841,7 +9841,7 @@ msgctxt "dlgSgRepositoryOpen.fur:"
 msgid "If it is relocated, remove it and add its new location."
 msgstr ""
 
-msgctxt "dlgSgRepositoryOpen.hdl%1:"
+msgctxt "dlgSgRepositoryOpen.hdl:"
 msgid "Do you want to remove the missing repository '$1'?"
 msgstr ""
 
@@ -9853,7 +9853,7 @@ msgctxt "dlgSgRepositoryRemoveFailed1.fur:"
 msgid "This could happen if the repository is open in another window or currently commands are executed."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveFailed1.hdl%1:"
+msgctxt "dlgSgRepositoryRemoveFailed1.hdl:"
 msgid "The repository '$1' could not be removed."
 msgstr ""
 
@@ -9865,7 +9865,7 @@ msgctxt "dlgSgRepositoryRemoveMultiGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl%1:"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl:"
 msgid "Do you want to remove $1 groups?"
 msgstr ""
 
@@ -9873,7 +9873,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl%1:"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl:"
 msgid "Do you want to remove $1 repositories?"
 msgstr ""
 
@@ -9881,7 +9881,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl%2:"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl:"
 msgid "Do you want to remove $1 repositories and $2 groups?"
 msgstr ""
 
@@ -9889,7 +9889,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl%2:"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl:"
 msgid "Do you want to remove $1 repositories and the group \"$2\"?"
 msgstr ""
 
@@ -9897,7 +9897,7 @@ msgctxt "dlgSgRepositoryRemoveSingleGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl%1:"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl:"
 msgid "Do you want to remove the group \"$1\"?"
 msgstr ""
 
@@ -9905,7 +9905,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl%1:"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl:"
 msgid "Do you want to remove the repository \"$1\"?"
 msgstr ""
 
@@ -9913,7 +9913,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl%2:"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl:"
 msgid "Do you want to remove the repository \"$1\" and $2 groups?"
 msgstr ""
 
@@ -9921,7 +9921,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl%2:"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl:"
 msgid "Do you want to remove the repository \"$1\" and the group \"$2\"?"
 msgstr ""
 
@@ -10094,7 +10094,7 @@ msgctxt "dlgSgResetAdv.chk:"
 msgid "Thoroughly fix line-endings according to .gitattributes"
 msgstr ""
 
-msgctxt "dlgSgResetAdv.hdl%1:"
+msgctxt "dlgSgResetAdv.hdl:"
 msgid "Reset to commit $1"
 msgstr ""
 
@@ -10154,7 +10154,7 @@ msgctxt "dlgSgResetConfirm.fur:"
 msgid "Current staged and local changes will be lost!"
 msgstr ""
 
-msgctxt "dlgSgResetConfirm.hdl%1:"
+msgctxt "dlgSgResetConfirm.hdl:"
 msgid "Do you want to reset the HEAD to commit $1?"
 msgstr ""
 
@@ -10650,7 +10650,7 @@ msgctxt "dlgSgRollbackToCommit.fur:"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr ""
 
-msgctxt "dlgSgRollbackToCommit.hdl%1:"
+msgctxt "dlgSgRollbackToCommit.hdl:"
 msgid "Do you want to rollback the Index to the state of commit $1?"
 msgstr ""
 
@@ -10950,7 +10950,7 @@ msgctxt "dlgSgSetupStdWnd.hdl:"
 msgid "Do you want to use the Standard Window?"
 msgstr ""
 
-msgctxt "dlgSgSetupStdWnd.tle%1:"
+msgctxt "dlgSgSetupStdWnd.tle:"
 msgid "Setup SmartGit $1"
 msgstr ""
 
@@ -10958,7 +10958,7 @@ msgctxt "dlgSgShowLocalChanges.btn:"
 msgid "Compare"
 msgstr ""
 
-msgctxt "dlgSgShowLocalChanges.hdl%1:"
+msgctxt "dlgSgShowLocalChanges.hdl:"
 msgid "File $1 modified in Index and working tree"
 msgstr ""
 
@@ -11058,7 +11058,7 @@ msgctxt "dlgSgSshCredentials.hdl:"
 msgid "SSH Credentials"
 msgstr ""
 
-msgctxt "dlgSgSshCredentials.inf%2:"
+msgctxt "dlgSgSshCredentials.inf:"
 msgid "Provide the credentials for authenticating to the SSH server '$1' as user '$2'."
 msgstr ""
 
@@ -11090,7 +11090,7 @@ msgctxt "dlgSgStageConflict.fur:"
 msgid "The file contains conflict markers which indicate that you have not resolved all conflicts."
 msgstr ""
 
-msgctxt "dlgSgStageConflict.hdl%1:"
+msgctxt "dlgSgStageConflict.hdl:"
 msgid "Should $1 really be staged?"
 msgstr ""
 
@@ -11532,7 +11532,7 @@ msgctxt "dlgSgSubmoduleDeinitConfirm.fur:"
 msgid "The submodule will be skipped from the working tree. To get rid from the \\(remote\\) repository, you have to use Unregister instead."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.hdl%1:"
+msgctxt "dlgSgSubmoduleDeinitConfirm.hdl:"
 msgid "Do you want to deinit submodule '$1'?"
 msgstr ""
 
@@ -11608,7 +11608,7 @@ msgctxt "dlgSgSubmoduleResetConfirm.fur:"
 msgid "The corresponding commit will be checked out, so the submodule content will match the content of the registered commit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetConfirm.hdl%1:"
+msgctxt "dlgSgSubmoduleResetConfirm.hdl:"
 msgid "Do you want to reset submodule '$1' to the commit registered in the repository?"
 msgstr ""
 
@@ -11806,7 +11806,7 @@ msgctxt "dlgSgSvnClientCertificate.hdl:"
 msgid "Client Certificate"
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.inf%1:"
+msgctxt "dlgSgSvnClientCertificate.inf:"
 msgid "Provide the client certificate for authentication to the SVN repository '$1'."
 msgstr ""
 
@@ -11914,7 +11914,7 @@ msgctxt "dlgSgTagAddOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different tag name."
 msgstr ""
 
-msgctxt "dlgSgTagAddOverwrite.hdl%1:"
+msgctxt "dlgSgTagAddOverwrite.hdl:"
 msgid "The tag '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
@@ -11930,7 +11930,7 @@ msgctxt "dlgSgTagDeleteConfirmSingle.chk:"
 msgid "Delete from all remotes"
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk%1:"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
 msgstr ""
 
@@ -11938,7 +11938,7 @@ msgctxt "dlgSgTagDeleteConfirmSingle.fur:"
 msgid "You will not be able to restore it."
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.hdl%1:"
+msgctxt "dlgSgTagDeleteConfirmSingle.hdl:"
 msgid "Do you want to delete the tag '$1'?"
 msgstr ""
 

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -1110,17 +1110,10 @@ msgctxt "dlgScEvaluationReminderContinue.btn:"
 msgid "Register"
 msgstr ""
 
-# TODO: Review
-# We need to verify whether the placeholder replacement is appropriate.
-# 
-# msgctxt "dlgScEvaluationReminderContinue.fur"
-# msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
-#, fuzzy
 msgctxt "dlgScEvaluationReminderContinue.fur%2:"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends today."
 msgstr ""
@@ -1133,44 +1126,34 @@ msgctxt "dlgScEvaluationReminderContinue.tle:"
 msgid "Evaluation"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
 msgid "&Continue \\($1\\)"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
 msgid "&Continue"
 msgstr ""
 
-#, fuzzy
-#| msgctxt "dlgScEvaluationReminderExpiredGrace.btn\"Continue \\(45\\)\""
-#| msgid "Continue \\(45\\)"
 msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
 msgid "Continue \\($1\\)"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
 msgid "Exit"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
 msgid "Register"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScEvaluationReminderExpiredGrace.fur:"
 msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScEvaluationReminderExpiredGrace.hdl:"
 msgid "Your evaluation has already expired."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScEvaluationReminderExpiredGrace.tle:"
 msgid "Evaluation"
 msgstr ""
@@ -1754,13 +1737,12 @@ msgctxt "dlgScSecretToken.edt:"
 msgid "API Key"
 msgstr ""
 
-#| msgid "Provide API key for 'custom'"
 msgctxt "dlgScSecretToken.hdl:"
 msgid "Provide API key for '$1'"
 msgstr ""
 
 msgctxt "dlgScSecretToken.inf:"
-msgid "An API key is required to access the AI at 'http://127.0.0.1:1234/'. It will be stored in SmartGit's password store."
+msgid "An API key is required to access the AI at '$1'. It will be stored in SmartGit's password store."
 msgstr ""
 
 msgctxt "dlgScSecretToken.lbl:"
@@ -2192,10 +2174,6 @@ msgctxt "dlgSgAbortRebasingConfirm.btn:"
 msgid "Abort Rebase"
 msgstr ""
 
-# TODO: Review
-# [decode] msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use ブランチ \| リベース \| リベース instead.\n\nAborting will clean any local modification \(by invoking 'git rebase --abort'\)!"
-#, fuzzy
-#| msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use \\u30d6\\u30e9\\u30f3\\u30c1 \\| \\u30ea\\u30d9\\u30fc\\u30b9 \\| \\u30ea\\u30d9\\u30fc\\u30b9 instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 msgctxt "dlgSgAbortRebasingConfirm.fur:"
 msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use $1 instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 msgstr ""
@@ -2290,7 +2268,6 @@ msgctxt "dlgSgAbout.edt:"
 msgid "User Count"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgAbout.edt:"
 msgid "Valid Until"
 msgstr ""
@@ -2340,12 +2317,10 @@ msgid "Deny"
 msgstr ""
 
 # $1: rootFile , $2: typeName , $3: details
-#| msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to OpenAI are allowed. If allowed, SmartGit may upload repository data required by the AI feature you invoke \\(for example: diffs, commit messages, and related metadata\\).\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
 msgctxt "dlgSgAiApiKeyRepoLlmConsent.fur:"
 msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to $2 are allowed. $3\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
 msgstr ""
 
-#| msgid "Do you allow SmartGit to upload repository data to OpenAI?"
 msgctxt "dlgSgAiApiKeyRepoLlmConsent.hdl:"
 msgid "Do you allow SmartGit to upload repository data to $1?"
 msgstr ""
@@ -2511,8 +2486,6 @@ msgctxt "dlgSgAiSetup.lbl:"
 msgid "Optional parameters"
 msgstr ""
 
-#| msgctxt "dlgSgAiSetup.lbl\"Please wait \\u2026\""
-#| msgid "Please wait \\u2026"
 msgctxt "dlgSgAiSetup.lbl:"
 msgid "Please wait \\u2026"
 msgstr ""
@@ -2541,7 +2514,6 @@ msgctxt "dlgSgAiSetup.rbt:"
 msgid "Enable AI integration"
 msgstr ""
 
-#| msgid "The configuration has been saved to '/Users/UserName/Git-projects/....', which is included by '/Users/UserName/Git-projects/....'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
 msgctxt "dlgSgAiSetupConfigurationSuccess.fur:"
 msgid "The configuration has been saved to '$1', which is included by '$2'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
 msgstr ""
@@ -2550,12 +2522,10 @@ msgctxt "dlgSgAiSetupConfigurationSuccess.hdl:"
 msgid "The AI integration has been configured successfully."
 msgstr ""
 
-#| msgid "Object 'message/content' not found."
 msgctxt "dlgSgAiSetupConnectivityFailed.fur:"
 msgid "Object '$1' not found."
 msgstr ""
 
-#| msgid "Connection to 'ollama' failed."
 msgctxt "dlgSgAiSetupConnectivityFailed.hdl:"
 msgid "Connection to '$1' failed."
 msgstr ""
@@ -2940,7 +2910,6 @@ msgctxt "dlgSgBranchTrackingResetConfirm.tle:"
 msgid "Stop Tracking"
 msgstr ""
 
-#| msgid "Configure"
 msgctxt "dlgSgBranchTrackingSetConfirm.btn:"
 msgid "Configure"
 msgstr ""
@@ -3078,7 +3047,7 @@ msgid "The target branch has a different submodules configuration \\(.gitmodules
 msgstr ""
 
 msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.hdl:"
-msgid "Do you want to check out branch 'main'?"
+msgid "Do you want to check out branch '$1'?"
 msgstr ""
 
 msgctxt "dlgSgCheckoutSwitchToWorktree.btn:"
@@ -3089,7 +3058,6 @@ msgctxt "dlgSgCheckoutSwitchToWorktree.fur:"
 msgid "A worktree repository already exists for the selected branch. Therefore, you can't check out this branch directly, but you can switch to this worktree."
 msgstr ""
 
-#| msgid "Do you want to switch to worktree 'C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations-25.1_windows'?"
 msgctxt "dlgSgCheckoutSwitchToWorktree.hdl:"
 msgid "Do you want to switch to worktree '$1'?"
 msgstr ""
@@ -3222,7 +3190,10 @@ msgctxt "dlgSgCherryPickConfirmation.chk:"
 msgid "Append source commit ID to commit message"
 msgstr ""
 
-#| msgid "This will cherry-pick the selected commit into the Working Tree."
+msgctxt "dlgSgCherryPickConfirmation.fur:"
+msgid "This will cherry-pick the selected commit into the Working Tree."
+msgstr ""
+
 msgctxt "dlgSgCherryPickConfirmation.fur:"
 msgid "This will cherry-pick the selected commits into the Working Tree."
 msgstr ""
@@ -4324,13 +4295,10 @@ msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "GIT_DIR for repository at '$1' does not exist."
 msgstr ""
 
-# TODO: Review
-# Multiple different messages (msgid) were detected.
-# msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-# msgid "Repository 'XXXXXX' is not valid."
-# msgid "No valid worktree state of the repository."
-# msgid "Server returned HTTP response code: 401 for URL: https://gitlab.com/api/v4/user:\\n\\nToken was revoked. You have to re-authorize from the user."
-#, fuzzy
+msgctxt "dlgSgErrorUtilsClientException.fur:"
+msgid "No valid worktree state of the repository."
+msgstr ""
+
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Repository '$1' is not valid."
 msgstr ""
@@ -5254,7 +5222,10 @@ msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle:"
 msgid "Commit"
 msgstr ""
 
-#| msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
+msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
+msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
+msgstr ""
+
 msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
 msgid "To modify commits of a different branch, you need to first check out this branch."
 msgstr ""
@@ -6822,15 +6793,10 @@ msgctxt "dlgSgOutput.lbl:"
 msgid "Command Push failed!"
 msgstr ""
 
-# Needs review (Place holder)
-# msgid "Command Rebase HEAD \\(pot-wip/v24.1-wsl\\) to 4d7f618e failed!"
-#| msgid "Command Rebase HEAD \\(BranchName\\) to fa50210c failed!"
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase HEAD \\($1\\) to $2 failed!"
 msgstr ""
 
-# Needs review (Place holder)
-# msgid "Command Rebase HEAD \\(pot-wip/v24.1-wsl\\) to 79193904 produced warnings."
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase HEAD \\($1\\) to $2 produced warnings."
 msgstr ""
@@ -6896,6 +6862,10 @@ msgid "Command Start Support Branch failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Tool $1 produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Unregister Submodule failed!"
 msgstr ""
 
@@ -6920,22 +6890,21 @@ msgid "The working tree has local changes."
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Tool $1 succeeded."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
 msgstr ""
 
-# Needs Review
-#, fuzzy
 msgctxt "dlgSgOutput.lbl:"
 msgid "unable to access '$1': Could not resolve host: $2"
 msgstr ""
 
-# TODO: review
-#, fuzzy
 msgctxt "dlgSgOutput.lbl:"
 msgid "unable to access '$1': server certificate verification failed. CAfile: $2 CRLfile: $3"
 msgstr ""
 
-#| msgid "unable to auto-detect email address \\(got 'XXXX@XXXXXX.\\(none\\)'\\)"
 msgctxt "dlgSgOutput.lbl:"
 msgid "unable to auto-detect email address \\(got '$1.\\(none\\)'\\)"
 msgstr ""
@@ -6964,7 +6933,6 @@ msgctxt "dlgSgOutput.tle:"
 msgid "Output"
 msgstr ""
 
-#| msgid "repository 'https://smartgit.userecho.com/communities/1/topics/395-clone-first-clone-just-the-head-and-then-fetch-the-other-commits-in-background/' not found."
 msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "repository '$1' not found."
 msgstr ""
@@ -9056,53 +9024,42 @@ msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle:"
 msgid "Rebase"
 msgstr ""
 
-#, fuzzy
-#| msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.btn\"Continue \\(Resume\\)\""
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.btn:"
 msgid "Continue \\(Resume\\)"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.chk:"
 msgid "Don't show again"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.fur:"
 msgid "Clicking 'Continue' will resume the rebase, e.g. to finish after having modified the commit\\(s\\)."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.hdl:"
 msgid "Do you want to continue the modify-commit-rebase?"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.tle:"
 msgid "Modify Commit"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.btn:"
 msgid "Step"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.chk:"
 msgid "Don't show again"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.fur:"
 msgid "Clicking 'Step' will continue the rebase and stop at the next commit. Use it to step through all pending commits, e.g. to verify whether they successfully build."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.hdl:"
 msgid "Do you want to step to the next commit?"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.tle:"
 msgid "Modify Commit"
 msgstr ""
@@ -10048,8 +10005,6 @@ msgctxt "dlgSgRepositorySettings.hdl:"
 msgid "Edit the repository settings"
 msgstr ""
 
-#, fuzzy
-#| msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
 msgctxt "dlgSgRepositorySettings.inf:"
 msgid "Here you can edit the Git settings for the repository. The default settings can be found in the Preferences."
 msgstr ""
@@ -10987,7 +10942,6 @@ msgctxt "dlgSgSetupStdWnd.btn:"
 msgid "Use Standard Window"
 msgstr ""
 
-#| msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 msgctxt "dlgSgSetupStdWnd.fur:"
 msgid "We recommend the Standard window for \\*new SmartGit users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 msgstr ""
@@ -11352,13 +11306,16 @@ msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Checkout"
 msgstr ""
 
-#| msgid "Reset"
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Edit Message"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Reset"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandDiscardConfirmation.btn:"
@@ -11377,7 +11334,6 @@ msgctxt "dlgSgStashOnDemandDiscardConfirmation.tle:"
 msgid "Reset"
 msgstr ""
 
-#| msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
 msgid "Once you have concluded the Reorder Commits, you should manually apply the latest stash to get your local changes back into the working tree."
 msgstr ""
@@ -12618,7 +12574,6 @@ msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
 msgstr ""
 
-#| msgid "SmartGit 25.1.054 Preview needs to be restarted now for the changes to take effect."
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
 msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
 msgstr ""
@@ -13140,7 +13095,15 @@ msgid "Open File"
 msgstr ""
 
 msgctxt "wnd.mni:"
+msgid "Open in Terminal"
+msgstr ""
+
+msgctxt "wnd.mni:"
 msgid "Open in VSCode"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Reveal in Finder"
 msgstr ""
 
 msgctxt "wnd.mni:"
@@ -13331,12 +13294,12 @@ msgctxt "wndAnnotate.tab:"
 msgid "History of current line"
 msgstr ""
 
-#| msgid "test_entry_model.py - Blame of tests/models/entry/test_entry_model.py"
+# $1: File Name $2 Relative path
 msgctxt "wndAnnotate.tle:"
 msgid "$1 - Blame of $2"
 msgstr ""
 
-#| msgid "sgpo.py - Blame of src/sgpo/sgpo.py@db0d01ee"
+# $1: File Name ,$2 Relative path ,$3:CommitID
 msgctxt "wndAnnotate.tle:"
 msgid "$1 - Blame of $2@$3"
 msgstr ""
@@ -14592,11 +14555,11 @@ msgid "Log"
 msgstr ""
 
 msgctxt "wndStd.mni:"
-msgid "On Manual Intervention"
+msgid "On $1: SmartGit: automatic stash on Pull."
 msgstr ""
 
 msgctxt "wndStd.mni:"
-msgid "On master: SmartGit: automatic stash on Pull."
+msgid "On Manual Intervention"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -14631,7 +14594,6 @@ msgctxt "wndStd.mni:"
 msgid "Save Stash"
 msgstr ""
 
-#, fuzzy
 msgctxt "wndStd.mni:"
 msgid "Select from GitHub"
 msgstr ""
@@ -14692,7 +14654,6 @@ msgctxt "wndStd.mniStdOpenSubmoduleFromFile:"
 msgid "Open this Submodule"
 msgstr ""
 
-#| msgid "Open in GitHub"
 msgctxt "wndStd.mniStdProviderOpenInBrowser:"
 msgid "Open in $1"
 msgstr ""
@@ -14725,12 +14686,18 @@ msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|
 msgid "Ready"
 msgstr ""
 
-#| msgid "Full Screen"
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
 msgid "Enter Full Screen"
 msgstr ""
 
-#| msgid "Maximize"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
+msgid "Full Screen"
+msgstr ""
+
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
+msgid "Maximize"
+msgstr ""
+
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
 msgid "Zoom"
 msgstr ""

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -37,6 +37,10 @@ msgctxt "*.btn:"
 msgid "OK"
 msgstr ""
 
+msgctxt "*.chk:"
+msgid "Don't show again"
+msgstr ""
+
 msgctxt "*.hnt:"
 msgid "Filter"
 msgstr ""
@@ -305,7 +309,6 @@ msgctxt "dlgProgress.lbl:"
 msgid "Please wait ..."
 msgstr ""
 
-# [decode] msgctxt "dlgProgress.lbl:"
 # [decode] msgid "Please wait …"
 msgctxt "dlgProgress.lbl:"
 msgid "Please wait \\u2026"
@@ -2291,6 +2294,30 @@ msgctxt "dlgSgAiAnnotatorDropAllNotes.tle:"
 msgid "Drop AI Notes"
 msgstr ""
 
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.btn:"
+msgid "Swap"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.edt:"
+msgid "New \\(To\\)"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.edt:"
+msgid "Old \\(From\\)"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.hdl:"
+msgid "Choose the diff direction"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.inf:"
+msgid "The two commits have diverged, so they can be compared in either direction. The diff represents the changes from Old to New."
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.tle:"
+msgid "Explain Diff"
+msgstr ""
+
 msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
 msgid "Allow"
 msgstr ""
@@ -2318,6 +2345,10 @@ msgstr ""
 
 msgctxt "dlgSgAiCommitAnnotatorError.tle:"
 msgid "Annotate Commits"
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorOutput.tle:"
+msgid "Explain Diff"
 msgstr ""
 
 msgctxt "dlgSgAiCommitMessageComposeActionSetup.fur:"
@@ -3417,7 +3448,7 @@ msgctxt "dlgSgClone.chk:"
 msgid "Map SVN trunk, tags and branches to Git"
 msgstr ""
 
-msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
+msgctxt "dlgSgClone.chk:"
 msgid "Skip large files \\(\"partial clone\"\\)"
 msgstr ""
 
@@ -3505,7 +3536,6 @@ msgctxt "dlgSgClone.hnt:"
 msgid "Searching ..."
 msgstr ""
 
-# [decode] msgctxt "dlgSgClone.hnt"Searching …""
 # [decode] msgid "Searching …"
 msgctxt "dlgSgClone.hnt:"
 msgid "Searching \\u2026"
@@ -3771,7 +3801,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Merge commit \\(multiple parents\\)"
 msgstr ""
 
-msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
+msgctxt "dlgSgCommit.rbt:"
 msgid "Simple commit \\(one parent, \"squash\"\\)"
 msgstr ""
 
@@ -4433,6 +4463,22 @@ msgstr ""
 
 msgctxt "dlgSgFileCompareNoChanges.tle:"
 msgid "File Compare"
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.btn:"
+msgid "Rerun"
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.fur:"
+msgid "For the initial commit\\(s\\) where the file was added, SmartGit will try to find a similar pre-existing file. If it finds one, it will continue the Log for that file as the source from which it might have been copied.\\n\\nTo enable this feature by default, set the Low-Level Property `log.file.followCopies` in the Preferences."
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.hdl:"
+msgid "Do you want to re-run the Log with copy-detection enabled?"
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.tle:"
+msgid "Follow Copies"
 msgstr ""
 
 msgctxt "dlgSgFindObject.edt:"
@@ -6603,12 +6649,20 @@ msgctxt "dlgSgMergeHowToMerge.fur:"
 msgid "If there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
 msgstr ""
 
+msgctxt "dlgSgMergeHowToMerge.fur:"
+msgid "You are about to perform an Octopus Merge from $1 source branches.\\n\\nIf there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
+msgstr ""
+
 msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from branch '$1'?"
 msgstr ""
 
 msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from tag '$1'?"
+msgstr ""
+
+msgctxt "dlgSgMergeHowToMerge.hdl:"
+msgid "How to merge the $1 selected branches?"
 msgstr ""
 
 msgctxt "dlgSgMergeHowToMerge.tle:"
@@ -6944,7 +6998,15 @@ msgid "Tool $1 succeeded."
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "You have not concluded your merge \\(MERGE_HEAD exists\\)."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "stash failed \\(return code $1\\)"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -7455,7 +7517,6 @@ msgctxt "dlgSgPreferences.cmb:"
 msgid "Custom..."
 msgstr ""
 
-# [decode] msgctxt "dlgSgPreferences.cmb"Custom…""
 # [decode] msgid "Custom…"
 msgctxt "dlgSgPreferences.cmb:"
 msgid "Custom\\u2026"
@@ -8433,7 +8494,6 @@ msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.inf:"
 msgid "Select which account you want to use for connecting to '$1'."
 msgstr ""
 
-# Verify that there’s no issue, since the `msgctxt` does not end with “:” and contains a proper noun.
 msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.tle:"
 msgid "Select GitHub account"
 msgstr ""
@@ -9362,6 +9422,14 @@ msgctxt "dlgSgRebaseInteractiveMessage.tle:"
 msgid "Edit Message"
 msgstr ""
 
+msgctxt "dlgSgRebaseInteractiveNoAutomaticSquashableCommitsFound.fur:"
+msgid "Auto-Squash searches for commits with identical messages and amend-commits them."
+msgstr ""
+
+msgctxt "dlgSgRebaseInteractiveNoAutomaticSquashableCommitsFound.hdl:"
+msgid "No automatic squashable commits found."
+msgstr ""
+
 msgctxt "dlgSgRebaseInteractiveRemoveCommit.btn:"
 msgid "Remove"
 msgstr ""
@@ -9390,6 +9458,14 @@ msgctxt "dlgSgRebaseNoop.tle:"
 msgid "Merge"
 msgstr ""
 
+msgctxt "dlgSgRebaseNoopParent.fur:"
+msgid "Rebasing a commit onto its parent is allowed by Git but will not create a new commit or any meaningful changes."
+msgstr ""
+
+msgctxt "dlgSgRebaseNoopParent.hdl:"
+msgid "There is nothing to rebase."
+msgstr ""
+
 msgctxt "dlgSgRebaseNoopSelf.fur:"
 msgid "Rebasing a commit onto itself is allowed by Git but will not create a new commit or any meaningful changes."
 msgstr ""
@@ -9400,6 +9476,18 @@ msgstr ""
 
 msgctxt "dlgSgRebaseNoopSelf.tle:"
 msgid "Rebase"
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.btn:"
+msgid "Rebase Single Commit"
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.fur:"
+msgid "You are about to rebase your branch onto its own history. This action is allowed by Git but will not create a new commit or any meaningful changes.\\n\\nTo rebase a single commit, you can do so now.\\n\\nTo rebase a range of commits, select them in the Graph and drag & drop to the target commit."
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.hdl:"
+msgid "Do you want to rebase only the HEAD commit?"
 msgstr ""
 
 msgctxt "dlgSgRebaseTagCommit.btn:"
@@ -9896,6 +9984,10 @@ msgstr ""
 
 msgctxt "dlgSgRepositoryClose.tle:"
 msgid "Close"
+msgstr ""
+
+msgctxt "dlgSgRepositoryClose.tle:"
+msgid "Exit"
 msgstr ""
 
 msgctxt "dlgSgRepositoryFrameCloseWithoutPush.btn:"
@@ -11367,6 +11459,10 @@ msgid "Do you want to save local changes to a stash and retry Reorder Commits?"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
+msgid "Do you want to save local changes to a stash and retry Squash Commits?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "Do you want to save untracked files to a stash and retry Edit Message?"
 msgstr ""
 
@@ -11399,7 +11495,15 @@ msgid "Pull"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Reorder Commits"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Reset"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Squash Commits"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandDiscardConfirmation.btn:"
@@ -11558,7 +11662,6 @@ msgctxt "dlgSgSubmoduleAdd.hnt:"
 msgid "Searching ..."
 msgstr ""
 
-# [decode] msgctxt "dlgSgSubmoduleAdd.hnt"Searching …""
 # [decode] msgid "Searching …"
 msgctxt "dlgSgSubmoduleAdd.hnt:"
 msgid "Searching \\u2026"
@@ -11642,6 +11745,14 @@ msgstr ""
 
 msgctxt "dlgSgSubmoduleInitAll.tle:"
 msgid "Initialize Submodule"
+msgstr ""
+
+msgctxt "dlgSgSubmoduleInitAllConfigured.fur:"
+msgid "You may now pull individual submodules or on the root directory to clone the configured repositories."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleInitAllConfigured.hdl:"
+msgid "Submodules have been configured."
 msgstr ""
 
 msgctxt "dlgSgSubmoduleInitGit.btn:"
@@ -11813,11 +11924,39 @@ msgid "Repository URL"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.err:"
+msgid "A local branch with this name already exists. Use a different name."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Consecutive dots are not allowed."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Consecutive slashes are not allowed."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
 msgid "Directory '$1' already exists."
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Enter the name of the local branch."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
 msgid "Please enter a valid relative path. The submodule will be created at this path inside the repository."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Please select a valid branch."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "The name must not contain control characters, space, ~, ^, :, ?, \\*, \\[, < or >."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "The name must not end with a slash or dot."
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.hdl:"
@@ -11828,7 +11967,6 @@ msgctxt "dlgSgSubtreeAdd.hdl:"
 msgid "Repository"
 msgstr ""
 
-# [decode] msgctxt "dlgSgSubtreeAdd.hnt"Searching …""
 # [decode] msgid "Searching …"
 msgctxt "dlgSgSubtreeAdd.hnt:"
 msgid "Searching \\u2026"
@@ -11868,6 +12006,90 @@ msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.tle:"
 msgid "Add Subtree"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.fur:"
+msgid "Subtree operations are now available in \\*Branches\\* and \\*Graph\\* view, for \\*$1\\* and refs belonging to the \\*$2\\* remote."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.fur:"
+msgid "Subtree operations are now available in \\*Branches\\* and \\*Graph\\* view, for refs belonging to the \\*$1\\* remote."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.hdl:"
+msgid "Subtree '$1' has been successfully added."
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.btn:"
+msgid "Merge"
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.fur:"
+msgid "Changes from '$1' will be merged into sub-directory '$2'."
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.hdl:"
+msgid "Do you want to merge subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.chk:"
+msgid "Annotate generated history with prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.chk:"
+msgid "Rejoin generated history \\(for more efficient future splits\\)"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.edt:"
+msgid "Prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.hdl:"
+msgid "Do you want to push back subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.inf:"
+msgid "HEAD changes from sub-directory '$1' will be rewritten onto '$2' and pushed back."
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.btn:"
+msgid "Reset"
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.fur:"
+msgid "This will reset the sub-directory '$1' in your main history to the same state as in the subtree history at '$2'.\\n\\nChanges in the sub-directory which are only present in your main history commits will be lost. Only use this operation after your changes have been merged into the subtree history!"
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.hdl:"
+msgid "Do you want to reset subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.chk:"
+msgid "Annotate generated history with prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.chk:"
+msgid "Rejoin generated history \\(for more efficient future splits\\)"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.edt:"
+msgid "Prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.edt:"
+msgid "Subtree-Branch to update"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.hdl:"
+msgid "Do you want to update subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.inf:"
+msgid "HEAD changes from sub-directory '$1' will be rewritten onto '$2'."
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.lbl:"
+msgid "The selected branch pointer will be set to the HEAD of the generated history."
 msgstr ""
 
 msgctxt "dlgSgSvnClientCertificate.btn:"
@@ -12358,6 +12580,42 @@ msgctxt "dlgShPushTrackingLocalSvnBranches.tle:"
 msgid "Push"
 msgstr ""
 
+msgctxt "dlgStdCheckoutCommit.btn:"
+msgid "Add Branch && Checkout"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.edt:"
+msgid "Branch"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.hdl:"
+msgid "Add branch at commit $1"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.inf:"
+msgid "Enter the name of the local branch to create. It will be checked out."
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.rbt:"
+msgid "Checkout local branch:"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.rbt:"
+msgid "Create local branch:"
+msgstr ""
+
+msgctxt "dlgStdDiscard.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdDiscard.fur:"
+msgid "You won't be able to restore them."
+msgstr ""
+
+msgctxt "dlgStdDiscard.hdl:"
+msgid "Do you want to discard local changes?"
+msgstr ""
+
 msgctxt "dlgStdDiscardConfirmUntrackedFiles.btn:"
 msgid "Discard"
 msgstr ""
@@ -12376,6 +12634,198 @@ msgstr ""
 
 msgctxt "dlgStdDiscardConfirmUntrackedFiles.tle:"
 msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.btn:"
+msgid "Confirm"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Feature Prefix"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Main Branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Main Branches"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.hdl:"
+msgid "Configure main and feature branches"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.hdl:"
+msgid "Configure main branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.inf:"
+msgid "Set the main branch for your repository and an optional prefix for feature branches."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.inf:"
+msgid "Set the main branch for your repository."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.lbl:"
+msgid "Example: develop, release-.\\*"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.lbl:"
+msgid "The 'main branch' represents the main development branch of your repository and serves as a foundation for releases. Usually it is named 'develop', 'master' or 'main'.\\n\\nBranches that are used to develop a single new feature, bugfix or other related changes \\(temporarily\\) isolated from the main branch are called 'feature branch' \\(or short 'feature'\\). They typically have a special name prefix, e.g. 'feature/'.\\n\\nNew features will be forked off from a main branch using 'Start'. For an existing feature, new changes from the main branch will be integrated using 'Integrate'. Once you have finished the feature, you can incorporate it into the main branch using 'Finish'.\\n\\nFor extended configuration options, invoke '\\u30d6\\u30e9\\u30f3\\u30c1 \\| Feature \\u306e\\u8a2d\\u5b9a'."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.ttp:"
+msgid "The <b>Feature Prefix</b> is optional. <tt>feature/</tt>is commonly used and compatible with Git-Flow."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.ttp:"
+msgid "You can configure one or more <b>Main Branches</b> by specifying their names separated by semicolon. To specify patterns instead of singular names, use regular expressions. For example: <tt>main,release-.\\*</tt>."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfigurationSimple.hdl:"
+msgid "'$1' has been configured as main branch and '$2' as feature-prefix."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.btn:"
+msgid "Select"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Create merge commit"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Delete feature branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Push results"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.edt:"
+msgid "Merge Message"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.hdl:"
+msgid "Finish feature '$1'"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.inf:"
+msgid "Choose how to finish the feature branch '$1'. This operation will integrate the feature branch into the '$2' branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.rbt:"
+msgid "Create Pull Request"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.rbt:"
+msgid "Finish to main branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinishFeatureEmpty.fur:"
+msgid "Your feature branch does not contain any new commits. Finishing now will simply remove the branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinishFeatureEmpty.hdl:"
+msgid "Feature branch is empty."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "Branch '$1' is ahead of '$2'.\\n\\nConsolidate the '$3'-branch, then invoke Integrate again."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "The feature branch has been rebased onto '$1'.\\n\\nYou may now verify and push the branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "The local feature branch has been rebased onto the remote branch '$1'.\\n\\nYou may now verify and push the branch, then invoke Integrate again."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Resolve diverged main branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Verify integrated main changes."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Verify integrated remote changes."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.lbl:"
+msgid "Steps"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.btn:"
+msgid "Start"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.edt:"
+msgid "Feature Name"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.hdl:"
+msgid "Start a new feature"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.inf:"
+msgid "Enter the name of the new feature branch. This operation will fork a new branch from '$1'."
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.lbl:"
+msgid "Resulting Branch: $1"
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.btn:"
+msgid "Switch Anyway"
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.fur:"
+msgid "Your working tree currently has local modifications, and you are not currently on the main branch. Initiating a new feature now will require switching commits, which can potentially fail due to the presence of local changes.\\n\\nThe recommended course of action is either to commit your local changes \\(if they pertain to the current branch\\) or stash them away in order to have a clean working tree before starting a new feature."
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.hdl:"
+msgid "Do you want to switch to a different branch despite having local changes?"
+msgstr ""
+
+msgctxt "dlgStdOutputCommandConflicts.fur:"
+msgid "These conflicts must be resolved before continuing. Select the conflicted files in the Local Files view and use the Conflict Solver to resolve them, then continue the operation."
+msgstr ""
+
+msgctxt "dlgStdOutputCommandConflicts.hdl:"
+msgid "SmartGit encountered conflicts during the Integrate main operation."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.fur:"
+msgid "Commit or stash local changes before cherry-picking."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.fur:"
+msgid "Commit or stash local changes before reverting."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.hdl:"
+msgid "The working tree contains local changes."
+msgstr ""
+
+msgctxt "dlgStdRemove.btn:"
+msgid "Delete Local Files"
+msgstr ""
+
+msgctxt "dlgStdRemove.btn:"
+msgid "Keep Local Files"
+msgstr ""
+
+msgctxt "dlgStdRemove.fur:"
+msgid "You can just remove the files from the repository \\(keeping the local files, e.g. to mark them later as ignored\\), or also delete the local files."
+msgstr ""
+
+msgctxt "dlgStdRemove.hdl:"
+msgid "How do you want to remove the files from the repository?"
 msgstr ""
 
 msgctxt "dlgTxtEditor.fileModified.btn:"
@@ -12518,6 +12968,18 @@ msgctxt "ntmCredentialHelper:"
 msgid "To disable this configuration, open the above config file, locate the <b>\\[credential\\]</b>-section and comment out the <b>helper\\=</b> line using <b>#</b>"
 msgstr ""
 
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Directory '$1' \\($2\\) has been excluded from file monitoring because it's listed in some .gitignore file."
+msgstr ""
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Sometimes ignored directories are containing tracked files in which case changes to these files might not show up automatically. If this is the case for you, you may disable this optimization by setting system property 'fileMonitor.excludeIgnoredDirectories\\=false'."
+msgstr ""
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Usually this does not cause any problems but improves Refreshing performance and reduces required inotify handles."
+msgstr ""
+
 msgctxt "ntmFollowUsOnTwitter:"
 msgid "<link1>Facebook</link1>: news"
 msgstr ""
@@ -12626,7 +13088,7 @@ msgctxt "ntmHostingProviderIntegrationNotYetConfigured:"
 msgid "SmartGit provides special support for $1. The integration can be configured in the Preferences."
 msgstr ""
 
-msgctxt "ntmLcTypeProblem\"If you experience problems with garbled file names/paths containing non-US-ASCII characters, consider to set the environment variables <tt>LC_ALL</tt>, or both <tt>LC_CTYPE</tt> and <tt>LANG</tt> to a country code which ends with \\\"<tt>.UTF-8</tt>\\\".\""
+msgctxt "ntmLcTypeProblem:"
 msgid "If you experience problems with garbled file names/paths containing non-US-ASCII characters, consider to set the environment variables <tt>LC_ALL</tt>, or both <tt>LC_CTYPE</tt> and <tt>LANG</tt> to a country code which ends with \"<tt>.UTF-8</tt>\"."
 msgstr ""
 
@@ -12650,6 +13112,10 @@ msgctxt "ntmRepositoryGitCleanup:"
 msgid "The repository '$1' contains a significant amount of loose or even unused 'objects'. Running a cleanup will reduce disk space and increase performance. SmartGit will try to do so, when it is idle."
 msgstr ""
 
+msgctxt "ntmRepositoryRefsReadingManyLoose:"
+msgid "The repository '$1' contains many 'loose' refs which makes refreshing inefficient. Repacking the refs will improve performance."
+msgstr ""
+
 msgctxt "ntmSupportExpired:"
 msgid "To extend your support, please purchase an update license and upgrade to the latest SmartGit version."
 msgstr ""
@@ -12658,8 +13124,18 @@ msgctxt "ntmSupportExpired:"
 msgid "You may continue to use SmartGit, just your support period expired."
 msgstr ""
 
+msgctxt "ntmUpdateCheckChannelSubscribePolls:"
+msgid "Occasionally, you'll be invited to quick polls here in the notification area. Your feedback helps shape SmartGit's future. You can turn this off anytime in the Preferences."
+msgstr ""
+
 msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
+msgstr ""
+
+# TODO: Check if the variable range is correct.
+#| msgid "SmartGit 25.1.093 needs to be restarted now for the changes to take effect."
+msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+msgid "$1 needs to be restarted now for the changes to take effect."
 msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
@@ -12702,6 +13178,10 @@ msgctxt "nttCredentialHelper:"
 msgid "Let SmartGit handle Authentication"
 msgstr ""
 
+msgctxt "nttFileMonitorDirectoriesExcluded:"
+msgid "Ignored directories are not monitored"
+msgstr ""
+
 msgctxt "nttFollowUsOnTwitter:"
 msgid "Follow SmartGit on Twitter!"
 msgstr ""
@@ -12724,6 +13204,10 @@ msgstr ""
 
 msgctxt "nttGeneral:"
 msgid "Remind me later"
+msgstr ""
+
+msgctxt "nttGeneral:"
+msgid "Skip this Poll"
 msgstr ""
 
 msgctxt "nttHighMemoryUsage:"
@@ -12778,12 +13262,40 @@ msgctxt "nttRepositoryGitCleanup:"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Do not warn me again for this repository"
+msgstr ""
+
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Many loose refs"
+msgstr ""
+
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Repack"
+msgstr ""
+
 msgctxt "nttSupportExpired:"
 msgid "Purchase Update"
 msgstr ""
 
 msgctxt "nttSupportExpired:"
 msgid "Your support period has expired on $1."
+msgstr ""
+
+msgctxt "nttUpdateCheck:"
+msgid "Quick Poll: $1"
+msgstr ""
+
+msgctxt "nttUpdateCheck:"
+msgid "Vote"
+msgstr ""
+
+msgctxt "nttUpdateCheckChannelSubscribePolls:"
+msgid "Turn on"
+msgstr ""
+
+msgctxt "nttUpdateCheckChannelSubscribePolls:"
+msgid "Want to influence SmartGit's development?"
 msgstr ""
 
 msgctxt "nttUpdateCheckFetchVersionStart:"
@@ -12824,6 +13336,10 @@ msgstr ""
 
 msgctxt "pop:"
 msgid "$1 succeeded."
+msgstr ""
+
+msgctxt "pop:"
+msgid "Already up-to-date"
 msgstr ""
 
 msgctxt "pop:"
@@ -12868,6 +13384,10 @@ msgstr ""
 
 msgctxt "pop:"
 msgid "The dropped directory is no Git repository."
+msgstr ""
+
+msgctxt "pop:"
+msgid "The working tree contains local changes."
 msgstr ""
 
 msgctxt "pop:"
@@ -12930,7 +13450,6 @@ msgctxt "ttpBranches:"
 msgid "<b>On: </b>$1"
 msgstr ""
 
-#| msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
 msgctxt "ttpBranches:"
 msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>$3</b>"
 msgstr ""
@@ -13697,7 +14216,6 @@ msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame \\(in progress...\\)"
 msgstr ""
 
-# [decode] msgctxt "wndDeepgit.lblBlameHeader"Blame \(in progress…\)""
 # [decode] msgid "Blame \(in progress…\)"
 msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame \\(in progress\\u2026\\)"
@@ -14111,7 +14629,6 @@ msgctxt "wndDeepgit.tab:"
 msgid "Navigation \\(initializing...\\)"
 msgstr ""
 
-# [decode] msgctxt "wndDeepgit.tab"Navigation \(initializing…\)""
 # [decode] msgid "Navigation \(initializing…\)"
 msgctxt "wndDeepgit.tab:"
 msgid "Navigation \\(initializing\\u2026\\)"
@@ -14418,6 +14935,10 @@ msgid "Explain Commit"
 msgstr ""
 
 msgctxt "wndLog.mni:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "wndLog.mni:"
 msgid "On Manual Intervention"
 msgstr ""
 
@@ -14457,25 +14978,21 @@ msgctxt "wndLog.mniGitNoteAdd:"
 msgid "Add Note"
 msgstr ""
 
-# [decode] msgctxt "wndLog.tab"Graph \(Initializing Subtree-Cache…\)""
 # [decode] msgid "Graph \(Initializing Subtree-Cache…\)"
 msgctxt "wndLog.tab:"
 msgid "Graph \\(Initializing Subtree-Cache\\u2026\\)"
 msgstr ""
 
-# [decode] msgctxt "wndLog.tab"Graph \(Loading…\)""
 # [decode] msgid "Graph \(Loading…\)"
 msgctxt "wndLog.tab:"
 msgid "Graph \\(Loading\\u2026\\)"
 msgstr ""
 
-# [decode] msgctxt "wndLog.tab"Graph \(Running log…\)""
 # [decode] msgid "Graph \(Running log…\)"
 msgctxt "wndLog.tab:"
 msgid "Graph \\(Running log\\u2026\\)"
 msgstr ""
 
-# [decode] msgctxt "wndLog.tab"Graph \(Scanning WT…\)""
 # [decode] msgid "Graph \(Scanning WT…\)"
 msgctxt "wndLog.tab:"
 msgid "Graph \\(Scanning WT\\u2026\\)"
@@ -14487,6 +15004,15 @@ msgstr ""
 
 msgctxt "wndLog.tbt:"
 msgid "Refresh information from GitHub."
+msgstr ""
+
+#| msgid "Rewording 1 commits\\u2026"
+msgctxt "wndLog.tbtAi.commitMessageCompose:"
+msgid "Rewording $1 commits\\u2026"
+msgstr ""
+
+msgctxt "wndLog.tbtFlowContext:"
+msgid "Start a new Git-Flow feature."
 msgstr ""
 
 msgctxt "wndProject.mni:"
@@ -14565,10 +15091,13 @@ msgctxt "wndStd.hnt:"
 msgid "Loading ..."
 msgstr ""
 
-# [decode] msgctxt "wndStd.hnt"Loading …""
 # [decode] msgid "Loading …"
 msgctxt "wndStd.hnt:"
 msgid "Loading \\u2026"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "No files below the selected directory"
 msgstr ""
 
 msgctxt "wndStd.hnt:"
@@ -14581,6 +15110,14 @@ msgstr ""
 
 msgctxt "wndStd.hnt:"
 msgid "No locally changed files"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "The repository's\\nreflog is empty."
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "This repository has\\nno stashes yet."
 msgstr ""
 
 msgctxt "wndStd.lbl:"
@@ -14632,6 +15169,14 @@ msgid "Changed files"
 msgstr ""
 
 msgctxt "wndStd.mni:"
+msgid "Close Others"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Close to the Right"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Continue in Background"
 msgstr ""
 
@@ -14640,7 +15185,15 @@ msgid "Continue with Description"
 msgstr ""
 
 msgctxt "wndStd.mni:"
+msgid "Copy Path"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Don't Show Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Drop All Notes"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -14677,6 +15230,10 @@ msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Only current branch \\(HEAD\\)"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Open in GitHub"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -14751,6 +15308,10 @@ msgctxt "wndStd.mniGitNoteAdd:"
 msgid "Add Note"
 msgstr ""
 
+msgctxt "wndStd.mniIndexEditor:"
+msgid "Edit in Index Editor"
+msgstr ""
+
 msgctxt "wndStd.mniIntegrateMain:"
 msgid "Integrate Main"
 msgstr ""
@@ -14767,8 +15328,16 @@ msgctxt "wndStd.mniStdOpenSubmoduleFromFile:"
 msgid "Open this Submodule"
 msgstr ""
 
+msgctxt "wndStd.mniStdProviderOpenFileInBrowser:"
+msgid "Open in GitHub"
+msgstr ""
+
 msgctxt "wndStd.mniStdProviderOpenInBrowser:"
 msgid "Open in $1"
+msgstr ""
+
+msgctxt "wndStd.mniStdProviderOpenRefInBrowser:"
+msgid "Open in GitHub"
 msgstr ""
 
 msgctxt "wndStd.mniStdSetModeHistory:"
@@ -14791,8 +15360,20 @@ msgctxt "wndStd.tbt:"
 msgid "History"
 msgstr ""
 
+msgctxt "wndStd.tbt:"
+msgid "Show filter input field."
+msgstr ""
+
+msgctxt "wndStd.tbtFlowFeatureFinish:"
+msgid "Finish the current feature branch."
+msgstr ""
+
 msgctxt "wndStd.tbtFlowFeatureStart:"
 msgid "Start a new feature branch."
+msgstr ""
+
+msgctxt "wndStd.tbtIntegrateMain:"
+msgid "Integrate latest changes from the main branch into the current feature branch."
 msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).lblStatusBarMessage:"
@@ -17383,10 +17964,6 @@ msgctxt "wnd(Log|Project|Std|).tab:"
 msgid "Repositories"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
-msgid "History"
-msgstr ""
-
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Add Branch"
 msgstr ""
@@ -17469,6 +18046,10 @@ msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Git-Flow"
+msgstr ""
+
+msgctxt "wnd(Log|Project|Std|).tbr:"
+msgid "History"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).tbr:"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -6761,6 +6761,11 @@ msgctxt "dlgSgOutput.chk:"
 msgid "Show automatically for failed command"
 msgstr ""
 
+# $1: Command name, $2: Return code
+msgctxt "dlgSgOutput.lbl:"
+msgid "$1 failed \\(return code $2\\)"
+msgstr ""
+
 msgctxt "dlgSgOutput.lbl:"
 msgid "Authentication using OAuth failed \\(see details below\\)"
 msgstr ""
@@ -7003,10 +7008,6 @@ msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
-msgstr ""
-
-msgctxt "dlgSgOutput.lbl:"
-msgid "stash failed \\(return code $1\\)"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -13132,14 +13133,9 @@ msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
 msgstr ""
 
-# TODO: Check if the variable range is correct.
-#| msgid "SmartGit 25.1.093 needs to be restarted now for the changes to take effect."
+# $1: Software name and version
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
 msgid "$1 needs to be restarted now for the changes to take effect."
-msgstr ""
-
-msgctxt "ntmUpdateCheckFetchVersionSuccess:"
-msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
 msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
@@ -13280,10 +13276,6 @@ msgstr ""
 
 msgctxt "nttSupportExpired:"
 msgid "Your support period has expired on $1."
-msgstr ""
-
-msgctxt "nttUpdateCheck:"
-msgid "Quick Poll: $1"
 msgstr ""
 
 msgctxt "nttUpdateCheck:"
@@ -15006,7 +14998,6 @@ msgctxt "wndLog.tbt:"
 msgid "Refresh information from GitHub."
 msgstr ""
 
-#| msgid "Rewording 1 commits\\u2026"
 msgctxt "wndLog.tbtAi.commitMessageCompose:"
 msgid "Rewording $1 commits\\u2026"
 msgstr ""

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -161,6 +161,21 @@ msgctxt "dlgCommitInvisibleIndex.tle"
 msgid "Commit"
 msgstr ""
 
+#, fuzzy
+msgctxt "dlgCommitNoEmailConfigured.fur"
+msgid "Before committing you will have to configure your name and email, e.g. in the SmartGit Preferences."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgCommitNoEmailConfigured.hdl"
+msgid "Please configure the email for commit."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgCommitNoEmailConfigured.tle"
+msgid "Commit"
+msgstr ""
+
 msgctxt "dlgCommitView.hiddenOptions.chk"
 msgid "Don't show again"
 msgstr ""
@@ -269,6 +284,19 @@ msgctxt "dlgDgSetPerspectiveCantSwitch.tle"
 msgid "Origins Perspective"
 msgstr ""
 
+msgctxt "dlgHostingProvider.canBeConfigured.btn:"
+msgid "Configure Hosting Provider"
+msgstr ""
+
+#| msgid "The easiest way to access the repository at https://gitlab.com/yubeshi/smartgit-translation.git is through a hosting provider."
+msgctxt "dlgHostingProvider.canBeConfigured.fur"
+msgid "The easiest way to access the repository at $1 is through a hosting provider."
+msgstr ""
+
+msgctxt "dlgHostingProvider.canBeConfigured.hdl"
+msgid "Do you want to configure a GitLab hosting provider?"
+msgstr ""
+
 msgctxt "dlgInfo.tle"
 msgid "Discard"
 msgstr ""
@@ -279,6 +307,14 @@ msgstr ""
 
 msgctxt "dlgProgress.lbl:"
 msgid "Please wait ..."
+msgstr ""
+
+# [decode] msgctxt "dlgProgress.lbl"Please wait …""
+# [decode] msgid "Please wait …"
+#| msgctxt "dlgProgress.lbl\"Please wait \\u2026\""
+#| msgid "Please wait \\u2026"
+msgctxt "dlgProgress.lbl:"
+msgid "Please wait \\u2026"
 msgstr ""
 
 msgctxt "dlgProgress.tle:"
@@ -1037,8 +1073,16 @@ msgctxt "dlgScDialogAssertionHandlerLinkageError.btn:"
 msgid "Force Exit"
 msgstr ""
 
+msgctxt "dlgScDialogAssertionHandlerLinkageError.btn:"
+msgid "Just Exit"
+msgstr ""
+
 msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
 msgid "SmartGit has detected inconsistencies within its installation files \\(JAR files\\), what has most likely been caused by a faulty installation.\\n\\nPlease uninstall SmartGit completely, make sure there are no more installation files left \\(especially JAR files\\), then reinstall.\\n\\nIf the problem persists, send following log file as an attachment to smartgit@syntevo.com."
+msgstr ""
+
+msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
+msgid "Your SmartGit-installation seems to be damaged."
 msgstr ""
 
 msgctxt "dlgScDialogAssertionHandlerLinkageError.tle"
@@ -1069,8 +1113,19 @@ msgctxt "dlgScEvaluationReminderContinue.btn:"
 msgid "Register"
 msgstr ""
 
+# TODO: Review
+# We need to verify whether the placeholder replacement is appropriate.
+#
+# msgctxt "dlgScEvaluationReminderContinue.fur"
+# msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
+#, fuzzy
 msgctxt "dlgScEvaluationReminderContinue.fur%2"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScEvaluationReminderContinue.hdl"
+msgid "Your SmartGit evaluation ends today."
 msgstr ""
 
 msgctxt "dlgScEvaluationReminderContinue.hdl%1"
@@ -1081,12 +1136,84 @@ msgctxt "dlgScEvaluationReminderContinue.tle"
 msgid "Evaluation"
 msgstr ""
 
+#, fuzzy
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "&Continue \\($1\\)"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "&Continue"
+msgstr ""
+
+#, fuzzy
+#| msgctxt "dlgScEvaluationReminderExpiredGrace.btn\"Continue \\(45\\)\""
+#| msgid "Continue \\(45\\)"
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Continue \\($1\\)"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Exit"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Register"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScEvaluationReminderExpiredGrace.fur"
+msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScEvaluationReminderExpiredGrace.hdl"
+msgid "Your evaluation has already expired."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScEvaluationReminderExpiredGrace.tle"
+msgid "Evaluation"
+msgstr ""
+
 msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl%2"
 msgid "Cannot run program \"$1\": $2"
 msgstr ""
 
 msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle%1"
 msgid "\\[$1\\] - Conflict Solver"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScExternalFileStarterCommandNoFile.fur"
+msgid "Be sure to add arguments to the appropriate input field."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScExternalFileStarterCommandNoFile.hdl"
+msgid "The specified command is no file."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScExternalFileStarterCommandNoFile.tle"
+msgid "Input Validation"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScExternalFileStarterEmptyCommand.fur"
+msgid "Select the command which should be invoked."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScExternalFileStarterEmptyCommand.hdl"
+msgid "The Command input field must not be empty!"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScExternalFileStarterEmptyCommand.tle"
+msgid "Input Validation"
 msgstr ""
 
 msgctxt "dlgScFileComparatorAdd.hdl"
@@ -1477,6 +1604,10 @@ msgctxt "dlgScMasterPasswordEnter.inf"
 msgid "A stored password or passphrase has been requested from the password store."
 msgstr ""
 
+msgctxt "dlgScMasterPasswordEnter.lbl:"
+msgid "Forgot it? Reset it in the preferences, 'Authentication' page."
+msgstr ""
+
 msgctxt "dlgScMasterPasswordEnter.tle"
 msgid "Passwords"
 msgstr ""
@@ -1569,6 +1700,11 @@ msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "Free Updates Until"
 msgstr ""
 
+#, fuzzy
+msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
+msgid "License ID"
+msgstr ""
+
 msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "Name"
 msgstr ""
@@ -1613,6 +1749,35 @@ msgctxt "dlgScRegisterRequestRejected.tle"
 msgid "SmartGit License"
 msgstr ""
 
+msgctxt "dlgScSecretToken.btn:"
+msgid "Connect"
+msgstr ""
+
+msgctxt "dlgScSecretToken.edt:"
+msgid "API Key"
+msgstr ""
+
+#| msgid "Provide API key for 'custom'"
+msgctxt "dlgScSecretToken.hdl"
+msgid "Provide API key for '$1'"
+msgstr ""
+
+msgctxt "dlgScSecretToken.inf"
+msgid "An API key is required to access the AI at 'http://127.0.0.1:1234/'. It will be stored in SmartGit's password store."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://console.anthropic.com/settings/keys Anthropic account\\]."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://console.mistral.ai/api-keys Mistral account\\]."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://platform.openai.com/settings/organization/api-keys OpenAI account\\]."
+msgstr ""
+
 msgctxt "dlgScSetupLicense.btn:"
 msgid "Configure Proxy"
 msgstr ""
@@ -1646,6 +1811,31 @@ msgid "Please provide your SmartGit license file you've received by email after 
 msgstr ""
 
 msgctxt "dlgScSetupLicense.tle"
+msgid "SmartGit License"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
+msgid "Exit Later"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
+msgid "Restart Now"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScSetupLicenseNeedsRestart.fur"
+msgid "You can do that now or manually later."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScSetupLicenseNeedsRestart.hdl"
+msgid "SmartGit has to be restarted for the license change to take effect."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgScSetupLicenseNeedsRestart.tle"
 msgid "SmartGit License"
 msgstr ""
 
@@ -2005,8 +2195,12 @@ msgctxt "dlgSgAbortRebasingConfirm.btn:"
 msgid "Abort Rebase"
 msgstr ""
 
+# TODO: Review
+# [decode] msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use ブランチ \| リベース \| リベース instead.\n\nAborting will clean any local modification \(by invoking 'git rebase --abort'\)!"
+#, fuzzy
+#| msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use \\u30d6\\u30e9\\u30f3\\u30c1 \\| \\u30ea\\u30d9\\u30fc\\u30b9 \\| \\u30ea\\u30d9\\u30fc\\u30b9 instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 msgctxt "dlgSgAbortRebasingConfirm.fur"
-msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
+msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use $1 instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 msgstr ""
 
 msgctxt "dlgSgAbortRebasingConfirm.hdl"
@@ -2041,6 +2235,11 @@ msgctxt "dlgSgAbortRevertingConfirm.tle:"
 msgid "Discard"
 msgstr ""
 
+#, fuzzy
+msgctxt "dlgSgAbout.btn:"
+msgid "Copy Evaluation-ID"
+msgstr ""
+
 msgctxt "dlgSgAbout.btn:"
 msgid "Register"
 msgstr ""
@@ -2055,6 +2254,11 @@ msgstr ""
 
 msgctxt "dlgSgAbout.edt:"
 msgid "Build Date"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgAbout.edt:"
+msgid "Demo Until"
 msgstr ""
 
 msgctxt "dlgSgAbout.edt:"
@@ -2093,6 +2297,11 @@ msgctxt "dlgSgAbout.edt:"
 msgid "User Count"
 msgstr ""
 
+#, fuzzy
+msgctxt "dlgSgAbout.edt:"
+msgid "Valid Until"
+msgstr ""
+
 msgctxt "dlgSgAbout.edt:"
 msgid "Version"
 msgstr ""
@@ -2111,6 +2320,257 @@ msgstr ""
 
 msgctxt "dlgSgAbout.tle"
 msgid "About SmartGit"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.btn:"
+msgid "Drop"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.fur"
+msgid "This will remove all AI-related Git notes from the repository."
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.hdl"
+msgid "Do you want to drop all AI-related Git notes?"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.tle"
+msgid "Drop AI Notes"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
+msgid "Allow"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
+msgid "Deny"
+msgstr ""
+
+#| msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n/Users/tomohiro/Git-projects/smartgit-translations-25.1-wip\\n\\nPlease confirm whether uploads to OpenAI are allowed. If allowed, SmartGit may upload repository data required by the AI feature you invoke \\(for example: diffs, commit messages, and related metadata\\).\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.fur"
+msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to OpenAI are allowed. If allowed, SmartGit may upload repository data required by the AI feature you invoke \\(for example: diffs, commit messages, and related metadata\\).\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.hdl"
+msgid "Do you allow SmartGit to upload repository data to OpenAI?"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.fur"
+msgid "Click the AI button again to generate your first commit message."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.hdl"
+msgid "GitHub models are now configured."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.tle"
+msgid "AI Commit Message Compose"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.fur"
+msgid "No modifications found."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.hdl"
+msgid "AI generation of the commit message failed."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.tle"
+msgid "AI Commit Message Compose"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.hdl"
+msgid "Configure AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.inf"
+msgid "SmartGit supports AI-generated commit messages, with more AI features coming. GitHub models can be used out-of-the-box."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Configure manually \\(view documentation\\)"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Disable AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Use GitHub models for this repository"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Use GitHub models globally"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.tle"
+msgid "AI Integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.btn:"
+msgid "Confirm"
+msgstr ""
+
+# [decode] msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data – either from the working tree or selected commits – to GitHub's servers.\n\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \(see the drop-down menu for configuration\)."
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.fur"
+msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data \\u2013 either from the working tree or selected commits \\u2013 to GitHub's servers.\\n\\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \\(see the drop-down menu for configuration\\)."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.hdl"
+msgid "Git diffs will be sent to GitHub for AI processing."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.tle"
+msgid "Confirm GitHub AI Usage"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.btn:"
+msgid "Go Back"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable automatic stash messages"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable commit explanation"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable commit rewording"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Only for current repository"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "API URL"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "Model"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "URL Query"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Commit Rewording"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Explain Commits"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Please wait"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Stash Messages"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Welcome"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can automatically generate stash messages."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can explain individual commits or commit ranges in the background. Results are stored in Git notes."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can reword commit messages in the background when using special markers."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit offers AI-powered features to enhance productivity, simplify workflows, and assist you with your repositories."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "Verifying connectivity\\u2026"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Leave the stash message blank to enable auto-generation.\\n- SmartGit will generate a message and safely update the stash in the background.\\n- You can always enable or disable AI stash rewording in the Save Stash dialog.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Select one or more commits to generate a natural language explanation.\\n- For multiple commits, explanations are generated in the background and saved in Git Notes.\\n- Select two different branches to generate an explanation of their differences.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Use '@ai' to reword the entire commit message.\\n- 'WIP' will describe Work in Progress with an AI generated commit message.\\n- You can always enable or disable AI commit rewording features from the hamburger menu.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Optional parameters"
+msgstr ""
+
+#| msgctxt "dlgSgAiSetup.lbl\"Please wait \\u2026\""
+#| msgid "Please wait \\u2026"
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Please wait \\u2026"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Select your AI provider. This is the service SmartGit will use to generate AI-powered content."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "SmartGit won't ask about AI features again."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Steps"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Your GitHub credentials from the Hosting Provider configuration will be used. There is nothing more to set up here."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.rbt:"
+msgid "Disable AI integration globally"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.rbt:"
+msgid "Enable AI integration"
+msgstr ""
+
+#| msgid "The configuration has been saved to '/Users/tomohiro/Git-projects/smartgit-translations/.git/smartgit-ai', which is included by '/Users/tomohiro/Git-projects/smartgit-translations/.git/config'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
+msgctxt "dlgSgAiSetupConfigurationSuccess.fur"
+msgid "The configuration has been saved to '$1', which is included by '$2'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.hdl"
+msgid "The AI integration has been configured successfully."
+msgstr ""
+
+#| msgid "Object 'message/content' not found."
+msgctxt "dlgSgAiSetupConnectivityFailed.fur"
+msgid "Object '$1' not found."
+msgstr ""
+
+#| msgid "Connection to 'ollama' failed."
+msgctxt "dlgSgAiSetupConnectivityFailed.hdl"
+msgid "Connection to '$1' failed."
+msgstr ""
+
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.fur"
+msgid "API URL missing."
+msgstr ""
+
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.hdl"
+msgid "Configuration is invalid."
 msgstr ""
 
 msgctxt "dlgSgApplicationAlreadyRunning.fur%1"
@@ -2485,8 +2945,9 @@ msgctxt "dlgSgBranchTrackingResetConfirm.tle"
 msgid "Stop Tracking"
 msgstr ""
 
+#| msgid "Configure"
 msgctxt "dlgSgBranchTrackingSetConfirm.btn:"
-msgid "Configure"
+msgid "Configure Features"
 msgstr ""
 
 msgctxt "dlgSgBranchTrackingSetConfirm.fur"
@@ -2499,6 +2960,22 @@ msgstr ""
 
 msgctxt "dlgSgBranchTrackingSetConfirm.tle"
 msgid "Set Tracked Branch"
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.btn:"
+msgid "Open"
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.chk"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.fur"
+msgid "You can see a detailed list of pull requests in the Log's Branches view and review changes in the Graph."
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.hdl"
+msgid "Do you want to review pull requests in the Log?"
 msgstr ""
 
 msgctxt "dlgSgBugReportSettings.btn:"
@@ -2597,6 +3074,34 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.tle"
 msgid "Check Out"
 msgstr ""
 
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.btn:"
+msgid "Checkout"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.fur"
+msgid "The target branch has a different submodules configuration \\(.gitmodules\\). If you were expecting this change, you can proceed as usual.\\n\\nOtherwise, be aware that significant changes to your submodule configuration can lead to complex working tree states. In some cases, it might be simpler to perform a fresh clone of the target branch."
+msgstr ""
+
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.hdl"
+msgid "Do you want to check out branch 'main'?"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.btn:"
+msgid "Switch"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.fur"
+msgid "A worktree repository already exists for the selected branch. Therefore, you can't check out this branch directly, but you can switch to this worktree."
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.hdl"
+msgid "Do you want to switch to worktree 'C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations-25.1_windows'?"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.tle"
+msgid "Check Out"
+msgstr ""
+
 msgctxt "dlgSgCheckoutTarget.btn:"
 msgid "Checkout"
 msgstr ""
@@ -2607,6 +3112,10 @@ msgstr ""
 
 msgctxt "dlgSgCheckoutTarget.chk:"
 msgid "Track remote branch"
+msgstr ""
+
+msgctxt "dlgSgCheckoutTarget.err:"
+msgid "The name must not end with a slash or dot."
 msgstr ""
 
 msgctxt "dlgSgCheckoutTarget.hdl:"
@@ -2717,8 +3226,9 @@ msgctxt "dlgSgCherryPickConfirmation.chk"
 msgid "Append source commit ID to commit message"
 msgstr ""
 
+#| msgid "This will cherry-pick the selected commit into the Working Tree."
 msgctxt "dlgSgCherryPickConfirmation.fur"
-msgid "This will cherry-pick the selected commit into the Working Tree."
+msgid "This will cherry-pick the selected commits into the Working Tree."
 msgstr ""
 
 msgctxt "dlgSgCherryPickConfirmation.hdl"
@@ -2837,8 +3347,25 @@ msgctxt "dlgSgCleanNoFilesFound.tle"
 msgid "Clean Working Tree"
 msgstr ""
 
+#| msgid "Configure"
+msgctxt "dlgSgClone.btn:"
+msgid "Configure Features"
+msgstr ""
+
 msgctxt "dlgSgClone.btn:"
 msgid "Configure"
+msgstr ""
+
+msgctxt "dlgSgClone.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgClone.btn:"
+msgid "Go Back"
+msgstr ""
+
+msgctxt "dlgSgClone.chk:"
+msgid "Configure newly cloned repository to use SmartGit as credential helper"
 msgstr ""
 
 msgctxt "dlgSgClone.chk:"
@@ -2953,6 +3480,12 @@ msgctxt "dlgSgClone.hnt:"
 msgid "Searching ..."
 msgstr ""
 
+# [decode] msgctxt "dlgSgClone.hnt"Searching …""
+# [decode] msgid "Searching …"
+msgctxt "dlgSgClone.hnt:"
+msgid "Searching \\u2026"
+msgstr ""
+
 msgctxt "dlgSgClone.inf:"
 msgid "Customize how and what to clone."
 msgstr ""
@@ -2987,6 +3520,21 @@ msgstr ""
 
 msgctxt "dlgSgClone.mni:"
 msgid "Add Hosting Provider"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgClone.mni:"
+msgid "Own Repositories"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgClone.mni:"
+msgid "Starred Repositories"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgClone.mni:"
+msgid "Top Repositories"
 msgstr ""
 
 msgctxt "dlgSgClone.rbt:"
@@ -3371,6 +3919,10 @@ msgstr ""
 
 msgctxt "dlgSgCommitSelectMessageFromLog.hdl"
 msgid "Select a commit"
+msgstr ""
+
+msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
+msgid "No graph roots selected."
 msgstr ""
 
 msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
@@ -3769,8 +4321,16 @@ msgctxt "dlgSgDiscardRevertTo(Head|Index).tle"
 msgid "Discard"
 msgstr ""
 
+# TODO: Review
+# Multiple different messages (msgid) were detected.
+# msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
+# msgid "Repository 'XXXXXX' is not valid."
+# msgid "No valid worktree state of the repository."
+# msgid "Server returned HTTP response code: 401 for URL: https://gitlab.com/api/v4/user:\\n\\nToken was revoked. You have to re-authorize from the user."
+#, fuzzy
+#| msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
 msgctxt "dlgSgErrorUtilsClientException.fur"
-msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
+msgid "Repository '$1' is not valid."
 msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
@@ -3837,8 +4397,14 @@ msgctxt "dlgSgFileCompareInvokerFailedIO.hdl%1"
 msgid "'$1' could not be invoked."
 msgstr ""
 
+#| msgid "Open"
 msgctxt "dlgSgFileCompareInvokerFailedIO.tle"
-msgid "Open"
+msgid "Open from Working Tree"
+msgstr ""
+
+#| msgid "Open"
+msgctxt "dlgSgFileCompareNoChanges.btn:"
+msgid "Open from Working Tree"
 msgstr ""
 
 msgctxt "dlgSgFileCompareNoChanges.btn:"
@@ -4421,6 +4987,53 @@ msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle"
 msgid "Run Garbage Collector"
 msgstr ""
 
+msgctxt "dlgSgGitConfigEditConfigNotFound.fur"
+msgid "The file C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations\\\\.git\\\\worktrees\\\\smartgit-translations-25.1_windows\\\\config could not be opened for editing."
+msgstr ""
+
+msgctxt "dlgSgGitConfigEditConfigNotFound.hdl"
+msgid "The file config was not found."
+msgstr ""
+
+msgctxt "dlgSgGitConfigEditConfigNotFound.tle"
+msgid "Edit Config"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
+msgid "Refresh"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
+msgid "Select"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgGitHubCommitMessageSelect.col:"
+msgid "Number"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgGitHubCommitMessageSelect.col:"
+msgid "Title"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgGitHubCommitMessageSelect.hdl"
+msgid "Select commit message by GitHub issue"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgGitHubCommitMessageSelect.inf"
+msgid "The selected issue summary will be used as commit message."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgGitHubCommitMessageSelect.tle"
+msgid "Select Issue"
+msgstr ""
+
 msgctxt "dlgSgGitHubGenerateToken.btn:"
 msgid "Authenticate"
 msgstr ""
@@ -4617,6 +5230,26 @@ msgctxt "dlgSgGitLabSettingsInvalidToken.tle"
 msgid "Input Validation"
 msgstr ""
 
+msgctxt "dlgSgGitNoteAdd.btn:"
+msgid "Add Note"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.edt:"
+msgid "Category"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.hdl"
+msgid "Add a note to a commit"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.inf"
+msgid "Provider the text which should be added to the selected commit."
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.tle"
+msgid "Add Note"
+msgstr ""
+
 msgctxt "dlgSgHeadMessageListenerReplaceMessage.btn:"
 msgid "Don't Replace"
 msgstr ""
@@ -4641,8 +5274,9 @@ msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle"
 msgid "Commit"
 msgstr ""
 
+#| msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
 msgctxt "dlgSgHistoryCommitCantBeModified.fur"
-msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
+msgid "To modify commits of a different branch, you need to first check out this branch."
 msgstr ""
 
 msgctxt "dlgSgHistoryCommitCantBeModified.hdl"
@@ -4691,6 +5325,26 @@ msgstr ""
 
 msgctxt "dlgSgHistoryEditAuthor.tle"
 msgid "Edit Author"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.btn:"
+msgid "From Commit"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.btn:"
+msgid "From Failed Command"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.fur"
+msgid "A previous Edit Message command invocation failed for this commit. Decide whether to use the commit message from the failed run or the commit's message."
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.hdl"
+msgid "Which commit message you like to use?"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.tle"
+msgid "Edit Message"
 msgstr ""
 
 msgctxt "dlgSgHistoryEditMessage.btn:"
@@ -4841,6 +5495,11 @@ msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl"
 msgid "Do you want to modify commits which are already pushed?"
 msgstr ""
 
+#, fuzzy
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.tle:"
+msgid "Edit Author"
+msgstr ""
+
 msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.tle:"
 msgid "Edit Message"
 msgstr ""
@@ -4887,6 +5546,10 @@ msgstr ""
 
 msgctxt "dlgSgHistorySplitConfirm.tle"
 msgid "Split Commit"
+msgstr ""
+
+msgctxt "dlgSgHistorySquash.btn:"
+msgid "Add co-authors"
 msgstr ""
 
 msgctxt "dlgSgHistorySquash.btn:"
@@ -5014,11 +5677,45 @@ msgid "The entered URL is invalid - it should look like https://server"
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Azure DevOps Server account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Azure DevOps account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Bitbucket Server account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Bitbucket account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitHub Enterprise account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Add GitHub account"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitLab \\(Self Hosted\\) account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitLab account"
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Configure a new hosting provider account"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgHostingProviderAdd.inf"
+msgid "Set or select the options according to your account."
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.inf:"
@@ -5039,6 +5736,10 @@ msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.lbl:"
 msgid "Provide a 'personal access token' which you can generate in your GitHub account settings."
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.lbl:"
+msgid "Required scopes are 'api' and 'write_repository'."
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.lbl:"
@@ -5435,6 +6136,10 @@ msgstr ""
 
 msgctxt "dlgSgIgnoreFile.edt:"
 msgid "Ignore File"
+msgstr ""
+
+msgctxt "dlgSgIgnoreFile.err:"
+msgid "Enter a pattern for the file\\(s\\) to be ignored. Use \\* to match multiple or ? for a single arbitrary character."
 msgstr ""
 
 msgctxt "dlgSgIgnoreFile.err:"
@@ -5961,6 +6666,27 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.tle"
 msgid "Add or Create Repository"
 msgstr ""
 
+msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
+msgid "Inner Repository"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
+msgid "Outer Repository"
+msgstr ""
+
+#| msgid "At the specified path nested repositories were found.\\nInner repository: D:\\\\GitRepository\\\\xxxx\\\\xxxx\\nOuter repository: D:\\\\GitRepository\\\\xxxx"
+msgctxt "dlgSgOpenRepositoryOuterOrInner.fur"
+msgid "At the specified path nested repositories were found.\\nInner repository: $1\\nOuter repository: $2"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.hdl"
+msgid "Do you want to open the outer or inner repository?"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.tle"
+msgid "Add or Create Repository"
+msgstr ""
+
 msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur%1"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr ""
@@ -5995,6 +6721,10 @@ msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Abort failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Add Branch failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -6054,6 +6784,18 @@ msgid "Command Discard failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Discard produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Edit Author produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Edit Message failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Fetch Pull Request produced warnings."
 msgstr ""
 
@@ -6063,6 +6805,10 @@ msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Fetch produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command LFS Install failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -6082,6 +6828,10 @@ msgid "Command Move produced warnings."
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Pull \\(Merge\\) failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Pull \\(Merge\\) produced warnings."
 msgstr ""
 
@@ -6097,6 +6847,23 @@ msgctxt "dlgSgOutput.lbl:"
 msgid "Command Push failed!"
 msgstr ""
 
+# Needs review (Place holder)
+# msgid "Command Rebase HEAD \\(pot-wip/v24.1-wsl\\) to 4d7f618e failed!"
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Rebase HEAD \\($1\\) to $2 failed!"
+msgstr ""
+
+# Needs review (Place holder)
+# msgid "Command Rebase HEAD \\(pot-wip/v24.1-wsl\\) to 79193904 produced warnings."
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Rebase HEAD \\($1\\) to $2 produced warnings."
+msgstr ""
+
+#| msgid "Command Rebase HEAD \\(feature/forceinclude\\) to fa50210c failed!"
+msgctxt "dlgSgOutput.lbl\"Command Rebase HEAD \\(feature/forceinclude\\) to fa50210c failed!\""
+msgid "Command Rebase HEAD \\(feature/forceinclude\\) to $1 failed!"
+msgstr ""
+
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase Interactive failed!"
 msgstr ""
@@ -6107,6 +6874,10 @@ msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Remove Worktree failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -6170,11 +6941,32 @@ msgid "Not all refs have been pushed."
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "The command output below contains more details on the problem."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "The working tree has local changes."
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
+msgstr ""
+
+# Needs Review
+#, fuzzy
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to access '$1': Could not resolve host: $2"
+msgstr ""
+
+# TODO: review
+#, fuzzy
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to access '$1': server certificate verification failed. CAfile: $2 CRLfile: $3"
+msgstr ""
+
+#| msgid "unable to auto-detect email address \\(got 'XXXX@XXXXXX.\\(none\\)'\\)"
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to auto-detect email address \\(got '$1.\\(none\\)'\\)"
 msgstr ""
 
 msgctxt "dlgSgOutput.mni:"
@@ -6199,6 +6991,11 @@ msgstr ""
 
 msgctxt "dlgSgOutput.tle:"
 msgid "Output"
+msgstr ""
+
+#| msgid "repository 'https://smartgit.userecho.com/communities/1/topics/395-clone-first-clone-just-the-head-and-then-fetch-the-other-commits-in-background/' not found."
+msgctxt "dlgSgPingRepositoryFailed.fur"
+msgid "repository '$1' not found."
 msgstr ""
 
 msgctxt "dlgSgPingRepositoryFailed.fur%1"
@@ -6258,6 +7055,10 @@ msgid "Import"
 msgstr ""
 
 msgctxt "dlgSgPreferences.btn:"
+msgid "Load All Stored Secrets"
+msgstr ""
+
+msgctxt "dlgSgPreferences.btn:"
 msgid "Move Down"
 msgstr ""
 
@@ -6287,6 +7088,10 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.btn:"
 msgid "Show Password"
+msgstr ""
+
+msgctxt "dlgSgPreferences.cdl:"
+msgid "AI Integration"
 msgstr ""
 
 msgctxt "dlgSgPreferences.cdl:"
@@ -6390,6 +7195,10 @@ msgid "Allow modifying pushed commits \\(e.g. forced-push\\)"
 msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Allow modifying pushed commits \\(e.g. forced-push\\):"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Allow to open multiple Log windows for the same repository/file"
 msgstr ""
 
@@ -6439,6 +7248,18 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
 msgid "Configure SmartGit as credential helper \\(for repository authentication\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Configure SmartGit as credential helper for Git command line"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Configure newly cloned repository to use SmartGit as credential helper on Git command line"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Delete branch"
 msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
@@ -6522,6 +7343,10 @@ msgid "Push all tags"
 msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Quick Polls \\(help shape SmartGit\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Refresh file system also while SmartGit is in background"
 msgstr ""
 
@@ -6578,6 +7403,10 @@ msgid "Sign all commits"
 msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "SmartGit-related announcements"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Swap 'ours' and 'theirs' on Rebase conflicts for easier understanding"
 msgstr ""
 
@@ -6627,6 +7456,12 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.cmb:"
 msgid "Custom..."
+msgstr ""
+
+# [decode] msgctxt "dlgSgPreferences.cmb"Custom…""
+# [decode] msgid "Custom…"
+msgctxt "dlgSgPreferences.cmb:"
+msgid "Custom\\u2026"
 msgstr ""
 
 msgctxt "dlgSgPreferences.cmb:"
@@ -6683,6 +7518,10 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.col:"
 msgid "Command"
+msgstr ""
+
+msgctxt "dlgSgPreferences.col:"
+msgid "Credential"
 msgstr ""
 
 msgctxt "dlgSgPreferences.col:"
@@ -6810,6 +7649,10 @@ msgid "Name"
 msgstr ""
 
 msgctxt "dlgSgPreferences.edt:"
+msgid "Notify about"
+msgstr ""
+
+msgctxt "dlgSgPreferences.edt:"
 msgid "On startup"
 msgstr ""
 
@@ -6929,7 +7772,11 @@ msgctxt "dlgSgPreferences.lbl:"
 msgid "Changing these low-level properties can be harmful to the stability or performance of SmartGit. You should only continue if you are sure of what you are doing. Changed properties with a trailing \\* need a restart to be applied."
 msgstr ""
 
-msgctxt "dlgSgPreferences.lbl\"Checkout \\(Switch branch\\)\""
+msgctxt "dlgSgPreferences.lbl:"
+msgid "Changing these low-level properties may harm the stability or performance of SmartGit.\\n\\[_ Changed properties\\] with a trailing \\\\\\* need a restart to be applied."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Checkout \\(Switch branch\\)"
 msgstr ""
 
@@ -6966,7 +7813,15 @@ msgid "External tool:"
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Finish Feature"
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Garbage Collector"
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "General"
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
@@ -6991,6 +7846,10 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "Local and Remote Changes"
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "Note: Some repositories may already have per-repository AI settings."
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
@@ -7034,6 +7893,10 @@ msgid "Stash"
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*not yet configured\\* \\(globally\\)."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "The last check was performed on $1."
 msgstr ""
 
@@ -7043,6 +7906,10 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "This file will be sent as is: $1"
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "To configure, click the AI button in the Commit Message view or the Commit dialog."
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
@@ -7146,6 +8013,10 @@ msgid "Copy Selection in Column"
 msgstr ""
 
 msgctxt "dlgSgPreferences.mni:"
+msgid "Credential"
+msgstr ""
+
+msgctxt "dlgSgPreferences.mni:"
 msgid "Default"
 msgstr ""
 
@@ -7177,7 +8048,7 @@ msgctxt "dlgSgPreferences.mni:"
 msgid "GitHub"
 msgstr ""
 
-msgctxt "dlgSgPreferences.mni\"GitLab \\(Self Hosted\\)\""
+msgctxt "dlgSgPreferences.mni:"
 msgid "GitLab \\(Self Hosted\\)"
 msgstr ""
 
@@ -7294,6 +8165,10 @@ msgid "Exact case \\('Foo' will match 'Foo', but not 'foo'\\)"
 msgstr ""
 
 msgctxt "dlgSgPreferences.rbt:"
+msgid "For all branches"
+msgstr ""
+
+msgctxt "dlgSgPreferences.rbt:"
 msgid "Ignore case \\('Foo' will match 'Foo' and 'foo'\\)"
 msgstr ""
 
@@ -7307,6 +8182,10 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.rbt:"
 msgid "Log graph \\(commit oriented\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.rbt:"
+msgid "Only for feature branches"
 msgstr ""
 
 msgctxt "dlgSgPreferences.rbt:"
@@ -7379,6 +8258,10 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.tab:"
 msgid "Colors"
+msgstr ""
+
+msgctxt "dlgSgPreferences.tab:"
+msgid "Credential Helper"
 msgstr ""
 
 msgctxt "dlgSgPreferences.tab:"
@@ -7481,6 +8364,10 @@ msgctxt "dlgSgProcessKiller.lbl:"
 msgid "If you think the process is hanging, click the 'Kill Process' button, otherwise 'Wait'."
 msgstr ""
 
+msgctxt "dlgSgProcessKiller.lbl:"
+msgid "SmartGit is waiting for the following process to finish."
+msgstr ""
+
 msgctxt "dlgSgProcessKiller.tle"
 msgid "Process Not Responding"
 msgstr ""
@@ -7503,6 +8390,38 @@ msgstr ""
 
 msgctxt "dlgSgProviderCommentEdit.tle"
 msgid "Edit Comment"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.btn:"
+msgid "Confirm"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.cmb:"
+msgid "github.com"
+msgstr ""
+
+#| msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.cmb\"github\\(yubeshi-AI\\)\""
+#| msgid "github\\($1\\)"
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.cmb:"
+msgid "github\\($1\\)"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.edt:"
+msgid "Provider"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.hdl"
+msgid "Select which GitHub account to use"
+msgstr ""
+
+#| msgid "Select which account you want to use for connecting to 'https://github.com/ktyubeshi/fast-bunkai.git'."
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.inf"
+msgid "Select which account you want to use for connecting to '$1'."
+msgstr ""
+
+# Verify that there’s no issue, since the `msgctxt` does not end with “:” and contains a proper noun.
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.tle"
+msgid "Select GitHub account"
 msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.btn:"
@@ -7681,8 +8600,9 @@ msgctxt "dlgSgPull.tle"
 msgid "Pull"
 msgstr ""
 
+#| msgid "Configure"
 msgctxt "dlgSgPullConfiguration.btn:"
-msgid "Configure"
+msgid "Configure Features"
 msgstr ""
 
 msgctxt "dlgSgPullConfiguration.chk:"
@@ -7821,6 +8741,16 @@ msgctxt "dlgSgPushConfirmSingleTag.chk"
 msgid "Don't show again"
 msgstr ""
 
+#| msgid "1 tag will be pushed to 'origin'."
+msgctxt "dlgSgPushConfirmSingleTag.fur"
+msgid "$1 tag will be pushed to '$2'."
+msgstr ""
+
+#| msgid "Do you want to push tag 'Release/0.0.14'?"
+msgctxt "dlgSgPushConfirmSingleTag.hdl"
+msgid "Do you want to push tag '$1'?"
+msgstr ""
+
 msgctxt "dlgSgPushConfirmSingleTag.tle"
 msgid "Push"
 msgstr ""
@@ -7833,8 +8763,12 @@ msgctxt "dlgSgPushForced.fur"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr ""
 
-msgctxt "dlgSgPushForced.hdl"
-msgid "Do you want to force-push \\(replace\\) the remote branch?"
+# TODO: Review
+# We need to verify whether the placeholder replacement is appropriate.
+#, fuzzy
+#| msgid "Do you want to force-push \\(replace\\) the remote branch 'pot-wip/24.1_windows'?"
+msgctxt "dlgSgPushForced.hdl%1"
+msgid "Do you want to force-push \\(replace\\) the remote branch '$1'?"
 msgstr ""
 
 msgctxt "dlgSgPushForced.tle"
@@ -8163,6 +9097,57 @@ msgstr ""
 
 msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle"
 msgid "Rebase"
+msgstr ""
+
+#, fuzzy
+#| msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.btn\"Continue \\(Resume\\)\""
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.btn:"
+msgid "Continue \\(Resume\\)"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.chk"
+msgid "Don't show again"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.fur"
+msgid "Clicking 'Continue' will resume the rebase, e.g. to finish after having modified the commit\\(s\\)."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.hdl"
+msgid "Do you want to continue the modify-commit-rebase?"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.tle"
+msgid "Modify Commit"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.btn:"
+msgid "Step"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.chk"
+msgid "Don't show again"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.fur"
+msgid "Clicking 'Step' will continue the rebase and stop at the next commit. Use it to step through all pending commits, e.g. to verify whether they successfully build."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.hdl"
+msgid "Do you want to step to the next commit?"
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.tle"
+msgid "Modify Commit"
 msgstr ""
 
 msgctxt "dlgSgRebaseContinueNothingToCommitSkip.btn:"
@@ -8729,6 +9714,10 @@ msgctxt "dlgSgRenameBranch.edt:"
 msgid "Name"
 msgstr ""
 
+msgctxt "dlgSgRenameBranch.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
+
 msgctxt "dlgSgRenameBranch.hdl"
 msgid "Rename branch"
 msgstr ""
@@ -8747,6 +9736,10 @@ msgstr ""
 
 msgctxt "dlgSgRenameFile.edt:"
 msgid "Path"
+msgstr ""
+
+msgctxt "dlgSgRenameFile.err:"
+msgid "No valid path specified."
 msgstr ""
 
 msgctxt "dlgSgRenameFile.hdl"
@@ -8889,6 +9882,11 @@ msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Close"
 msgstr ""
 
+#, fuzzy
+msgctxt "dlgSgRepositoryClose.btn:"
+msgid "Force Exit"
+msgstr ""
+
 msgctxt "dlgSgRepositoryClose.fur"
 msgid "Note that currently running Git processes might not be interrupted."
 msgstr ""
@@ -9018,6 +10016,10 @@ msgid "Always fetch new commits, tags and branches from submodule"
 msgstr ""
 
 msgctxt "dlgSgRepositorySettings.chk:"
+msgid "Configure SmartGit as credential helper for Git command line"
+msgstr ""
+
+msgctxt "dlgSgRepositorySettings.chk:"
 msgid "Initialize new submodules"
 msgstr ""
 
@@ -9089,12 +10091,18 @@ msgctxt "dlgSgRepositorySettings.hdl"
 msgid "Edit the repository settings"
 msgstr ""
 
+#, fuzzy
+#| msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
 msgctxt "dlgSgRepositorySettings.inf"
-msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
+msgid "Here you can edit the Git settings for the repository. The default settings can be found in the Preferences."
 msgstr ""
 
 msgctxt "dlgSgRepositorySettings.lbl:"
 msgid "\\* if repository commit references non-pushed submodule commit"
+msgstr ""
+
+msgctxt "dlgSgRepositorySettings.tab:"
+msgid "Credential Helper"
 msgstr ""
 
 msgctxt "dlgSgRepositorySettings.tab:"
@@ -9143,6 +10151,11 @@ msgstr ""
 
 msgctxt "dlgSgRepositorySettings.ttpGroupPatterns:"
 msgid "Patterns will show up in the GUI using auto-generated labels which are derived from their regular expression. You can assign a custom label <tt>label</tt> to a pattern by prefixing it by <tt>label:</tt>; a label may only contain letters, digits and '_'."
+msgstr ""
+
+#, fuzzy
+msgctxt "dlgSgRepositorySettings.wrn:"
+msgid "It is recommended to set an email address used for committing."
 msgstr ""
 
 msgctxt "dlgSgRepositorySettings.wrn:"
@@ -9806,11 +10819,23 @@ msgid "Send usage statistics"
 msgstr ""
 
 msgctxt "dlgSgSetup.chk:"
+msgid "Use SmartGit for authentication \\(ignoring your current credential.helper configuration\\)"
+msgstr ""
+
+msgctxt "dlgSgSetup.chk:"
 msgid "Use gravatar.com to show images for the users"
 msgstr ""
 
 msgctxt "dlgSgSetup.edt:"
 msgid "Email"
+msgstr ""
+
+msgctxt "dlgSgSetup.edt:"
+msgid "Full Name"
+msgstr ""
+
+msgctxt "dlgSgSetup.edt:"
+msgid "Git Email"
 msgstr ""
 
 msgctxt "dlgSgSetup.edt:"
@@ -9833,8 +10858,32 @@ msgctxt "dlgSgSetup.edt:"
 msgid "User Name"
 msgstr ""
 
+msgctxt "dlgSgSetup.hdl:"
+msgid "Git Executable"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "License"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "Privacy"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "Style"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "User Information"
+msgstr ""
+
 msgctxt "dlgSgSetup.inf:"
 msgid "If you are using SSH to connect to other Git repositories, select what SSH client to use. You can change it later in the Preferences."
+msgstr ""
+
+msgctxt "dlgSgSetup.inf:"
+msgid "Please review the following privacy options. You can change them later in the Preferences."
 msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
@@ -9851,6 +10900,10 @@ msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
 msgid "User name and email will be stored as part of your commits. Here you can configure the default values which are stored in .gitconfig."
+msgstr ""
+
+msgctxt "dlgSgSetup.inf:"
+msgid "User name and email will be stored as part of your commits. Here you can configure the default values which are stored in ~/.gitconfig."
 msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
@@ -9918,6 +10971,10 @@ msgid "may be harder to configure and use for new users, but is more flexible"
 msgstr ""
 
 msgctxt "dlgSgSetup.rbt:"
+msgid "Bundled Git"
+msgstr ""
+
+msgctxt "dlgSgSetup.rbt:"
 msgid "Commits \\(Log History\\)"
 msgstr ""
 
@@ -9931,6 +10988,10 @@ msgstr ""
 
 msgctxt "dlgSgSetup.rbt:"
 msgid "Non-commercial use only \\(most features, no support\\)"
+msgstr ""
+
+msgctxt "dlgSgSetup.rbt:"
+msgid "Other Git Executable:"
 msgstr ""
 
 msgctxt "dlgSgSetup.rbt:"
@@ -9957,6 +11018,10 @@ msgctxt "dlgSgSetup.rbt:"
 msgid "Working tree \\(file oriented\\)"
 msgstr ""
 
+msgctxt "dlgSgSetup.tle"
+msgid "Setup SmartGit 24.1.3"
+msgstr ""
+
 msgctxt "dlgSgSetup.tle:"
 msgid "Setup SmartGit $1"
 msgstr ""
@@ -9969,8 +11034,9 @@ msgctxt "dlgSgSetupStdWnd.btn:"
 msgid "Use Standard Window"
 msgstr ""
 
+#| msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 msgctxt "dlgSgSetupStdWnd.fur"
-msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
+msgid "We recommend the Standard window for \\*new SmartGit users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 msgstr ""
 
 msgctxt "dlgSgSetupStdWnd.hdl"
@@ -10254,6 +11320,10 @@ msgid "Automatically save stash"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.fur:"
+msgid "Add Branch may require a clean working tree to complete successfully. After the Add Branch succeeded, the stashed local changes will be automatically reapplied."
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.fur:"
 msgid "Check Out may require a clean working tree to complete successfully. After the Check Out succeeded, the stashed local changes will be automatically reapplied."
 msgstr ""
 
@@ -10279,6 +11349,10 @@ msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.fur:"
 msgid "Squash Commits may require a clean working tree to complete successfully. After the Squash Commits succeeded, the stashed local changes will be automatically reapplied."
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
+msgid "Do you want to save local changes to a stash and retry Add Branch?"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
@@ -10321,8 +11395,9 @@ msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "What to do with the working tree or Index changes?"
 msgstr ""
 
+#| msgid "Reset"
 msgctxt "dlgSgStashOnDemandConfirmation.tle"
-msgid "Reset"
+msgid "Edit Message"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
@@ -10333,8 +11408,25 @@ msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
 msgstr ""
 
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.fur"
+msgid "It might be hard or impossible to restore them!"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.hdl"
+msgid "Do you really want to discard the local changes?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.tle"
+msgid "Reset"
+msgstr ""
+
+#| msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur"
-msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
+msgid "Once you have concluded the Reorder Commits, you should manually apply the latest stash to get your local changes back into the working tree."
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl"
@@ -10442,7 +11534,23 @@ msgid "Directory '$1' already exists."
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.err:"
+msgid "Please specify the URL of the remote repository or the path of the local repository that should be cloned."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.err:"
 msgid "Please specify the URL of the remote repository to be cloned."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.err:"
+msgid "The specified directory is not the root of a repository."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hdl:"
+msgid "Path"
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hdl:"
+msgid "Repository"
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.hnt:"
@@ -10450,7 +11558,17 @@ msgid "No repository found."
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.hnt:"
+msgid "No repository matches the entered filter."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hnt:"
 msgid "Searching ..."
+msgstr ""
+
+# [decode] msgctxt "dlgSgSubmoduleAdd.hnt"Searching …""
+# [decode] msgid "Searching …"
+msgctxt "dlgSgSubmoduleAdd.hnt:"
+msgid "Searching \\u2026"
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.inf:"
@@ -10649,8 +11767,25 @@ msgctxt "dlgSgSubmoduleUnregisterConfirm.fur"
 msgid "All relevant files will be adjusted. Afterwards you will only need to perform a commit to finish the operation. To just skip the submodule from the working tree, use Deinit."
 msgstr ""
 
+#| msgid "Do you want to unregister submodule 'submodule/qmh-framework'?"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.hdl"
+msgid "Do you want to unregister submodule '$1'?"
+msgstr ""
+
 msgctxt "dlgSgSubmoduleUnregisterConfirm.tle"
 msgid "Unregister Submodule"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Configure"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Go Back"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.chk:"
@@ -10674,11 +11809,38 @@ msgid "Local Path"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.edt:"
+msgid "Relative Path"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.edt:"
 msgid "Remote"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.edt:"
 msgid "Repository URL"
+msgstr ""
+
+#| msgid "Directory '/Users/tomohiro/Git-projects/sgpo-tools-cli-WorkSpace/sgpo-tools-cli' already exists."
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Directory '$1' already exists."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Please enter a valid relative path. The submodule will be created at this path inside the repository."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.hdl:"
+msgid "Path"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.hdl:"
+msgid "Repository"
+msgstr ""
+
+# [decode] msgctxt "dlgSgSubtreeAdd.hnt"Searching …""
+# [decode] msgid "Searching …"
+msgctxt "dlgSgSubtreeAdd.hnt:"
+msgid "Searching \\u2026"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.inf:"
@@ -10689,8 +11851,16 @@ msgctxt "dlgSgSubtreeAdd.inf:"
 msgid "Specify the repository to clone as subtree."
 msgstr ""
 
+msgctxt "dlgSgSubtreeAdd.inf:"
+msgid "Specify the repository to clone as subtree.\\nTo configure multiple accounts of the same hosting provider, use the Preferences."
+msgstr ""
+
 msgctxt "dlgSgSubtreeAdd.lbl:"
 msgid "Local branches for subtrees will only be useful if you plan to use Subtree-Split and Subtree-Reset operations."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.lbl:"
+msgid "Steps"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.lbl:"
@@ -10903,6 +12073,10 @@ msgstr ""
 
 msgctxt "dlgSgToolEdit.err:"
 msgid "Please enter the name for this command."
+msgstr ""
+
+msgctxt "dlgSgToolEdit.err:"
+msgid "Select the command which should be invoked."
 msgstr ""
 
 msgctxt "dlgSgToolEdit.hdl"
@@ -11193,6 +12367,26 @@ msgctxt "dlgShPushTrackingLocalSvnBranches.tle"
 msgid "Push"
 msgstr ""
 
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.chk"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.fur"
+msgid "You are about to delete untracked files permanently. This action cannot be undone."
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.hdl"
+msgid "Do you want to delete untracked files?"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.tle"
+msgid "Discard"
+msgstr ""
+
 msgctxt "dlgTxtEditor.fileModified.btn:"
 msgid "Keep Content"
 msgstr ""
@@ -11205,8 +12399,9 @@ msgctxt "dlgTxtEditor.fileModified.fur"
 msgid "Unless you want to see the old file state, it is recommended to reload."
 msgstr ""
 
+#| msgid "The file config was changed. Reload it?"
 msgctxt "dlgTxtEditor.fileModified.hdl"
-msgid "The file config was changed. Reload it?"
+msgid "The file messages.pot was changed. Reload it?"
 msgstr ""
 
 msgctxt "dlgTxtEditor.fileModified.tle"
@@ -11314,6 +12509,10 @@ msgid "In case you are encountering strange errors or unexpected dialog popups, 
 msgstr ""
 
 msgctxt "ntmCredentialHelper:"
+msgid "In general this should be fine and is the recommended configuration when working with multiple Git clients. If unexpected credential popups or weird errors occur, try to let SmartGit handle the authentication itself."
+msgstr ""
+
+msgctxt "ntmCredentialHelper:"
 msgid "In general this should be fine and is the recommended configuration when working with multiple Git clients. In case you are encountering strange errors or unexpected dialog popups, try to disable this configuration and let SmartGit handle the authentication itself."
 msgstr ""
 
@@ -11374,7 +12573,19 @@ msgid "poll for opinions on how to implement new or change existing features"
 msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Bluesky</link1>: news"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Bluesky</link1>: news, polls, discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
 msgid "<link1>Facebook</link1>: news"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Mastodon</link1>: news"
 msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
@@ -11382,7 +12593,19 @@ msgid "<link1>Mastodon</link1>: news, polls, discussions"
 msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Reddit</link1>: discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>UserEcho</link1>: feature requests, voting"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
 msgid "<link1>UserEcho</link1>: improvement ideas, discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>X</link1>: news"
 msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
@@ -11446,6 +12669,10 @@ msgid "After the new version has been downloaded successfully, you will be notif
 msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+msgid "SmartGit 25.1.054 Preview needs to be restarted now for the changes to take effect."
+msgstr ""
+
+msgctxt "ntmUpdateCheckFetchVersionSuccess:"
 msgid "SmartGit needs to be restarted now for the changes to take effect."
 msgstr ""
 
@@ -11466,7 +12693,15 @@ msgid "vote at <link1>alternativeto.net</link1>"
 msgstr ""
 
 msgctxt "nttCredentialHelper:"
+msgid "External Credential Helper detected"
+msgstr ""
+
+msgctxt "nttCredentialHelper:"
 msgid "External Credentials Helper detected"
+msgstr ""
+
+msgctxt "nttCredentialHelper:"
+msgid "Let SmartGit handle Authentication"
 msgstr ""
 
 msgctxt "nttFollowUsOnTwitter:"
@@ -11551,6 +12786,15 @@ msgstr ""
 
 msgctxt "nttUpdateCheckFetchVersionStart:"
 msgid "Started downloading version $1 \\($2\\)."
+msgstr ""
+
+#| msgid "Started downloading version 24.1.3."
+msgctxt "nttUpdateCheckFetchVersionStart:"
+msgid "Started downloading version $1."
+msgstr ""
+
+msgctxt "nttUpdateCheckFetchVersionStart:"
+msgid "Started downloading version 25.1.055."
 msgstr ""
 
 msgctxt "nttUpdateCheckFetchVersionSuccess:"
@@ -11761,6 +13005,12 @@ msgctxt "ttpBranches:"
 msgid "<b>Tracking State:\\t</b>identical"
 msgstr ""
 
+#| msgctxt "ttpBranches\"<b>Worktree:\\t</b>C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations-24.1-merged\""
+#| msgid "<b>Worktree:\\t</b>C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations-24.1-merged"
+msgctxt "ttpBranches:"
+msgid "<b>Worktree:\\t</b>$1"
+msgstr ""
+
 msgctxt "ttpBranches:"
 msgid "<b>\\t</b><col1>Tracking is configured in .git/config but the tracked branch is not present \\(any more\\)."
 msgstr ""
@@ -11861,6 +13111,11 @@ msgctxt "ttpRepositories:"
 msgid "<b>Remotes:\\t</b>"
 msgstr ""
 
+#| msgid "<b>Tracked Branch:\\t</b>origin/work_space"
+msgctxt "ttpRepositories:"
+msgid "<b>Tracked Branch:\\t</b>$1"
+msgstr ""
+
 msgctxt "ttpRepositories:"
 msgid "<b>Tracked Branch:\\t</b>$1<col1>$2</col1>"
 msgstr ""
@@ -11923,6 +13178,67 @@ msgstr ""
 
 msgctxt "ttpRepositories:"
 msgid "The remote repository contains new commits."
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "About SmartGit"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Contact Support"
+msgstr ""
+
+# 注意
+msgctxt "wnd.mni:"
+msgid "Cursor"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Format"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Import Unknown"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "License Agreement"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open File"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open in VSCode"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "SmartGit Website"
+msgstr ""
+
+msgctxt "wnd.mniBisectTryCommit"
+msgid "Try Commit"
+msgstr ""
+
+msgctxt "wnd.mniFixCaseChange"
+msgid "Fix Case-Change"
+msgstr ""
+
+msgctxt "wnd.mniIntegrateMain"
+msgid "Integrate Main"
+msgstr ""
+
+msgctxt "wnd.mniShowInMyHistory"
+msgid "Show in My History"
+msgstr ""
+
+msgctxt "wnd.mniWindow-maximize"
+msgid "Zoom"
+msgstr ""
+
+msgctxt "wnd.mniWindowMaximizeRestore"
+msgid "Maximize View"
 msgstr ""
 
 msgctxt "wndAnnotate.cmb:"
@@ -12083,6 +13399,16 @@ msgstr ""
 
 msgctxt "wndAnnotate.tab:"
 msgid "History of current line"
+msgstr ""
+
+#| msgid "test_entry_model.py - Blame of tests/models/entry/test_entry_model.py"
+msgctxt "wndAnnotate.tle:"
+msgid "$1 - Blame of $2"
+msgstr ""
+
+#| msgid "sgpo.py - Blame of src/sgpo/sgpo.py@db0d01ee"
+msgctxt "wndAnnotate.tle:"
+msgid "$1 - Blame of $2@$3"
 msgstr ""
 
 msgctxt "wndAnnotate.tle:"
@@ -12373,6 +13699,12 @@ msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame \\(in progress...\\)"
 msgstr ""
 
+# [decode] msgctxt "wndDeepgit.lblBlameHeader"Blame \(in progress…\)""
+# [decode] msgid "Blame \(in progress…\)"
+msgctxt "wndDeepgit.lblBlameHeader:"
+msgid "Blame \\(in progress\\u2026\\)"
+msgstr ""
+
 msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame for"
 msgstr ""
@@ -12609,6 +13941,10 @@ msgctxt "wndDeepgit.mniDgFilterSetSelection"
 msgid "Set Selection as Filter"
 msgstr ""
 
+msgctxt "wndDeepgit.mniDgFollowInsignificantMerges"
+msgid "Follow Insignificant Merges \\(experimental\\)"
+msgstr ""
+
 msgctxt "wndDeepgit.mniDgFollowRenames"
 msgid "Follow Renames"
 msgstr ""
@@ -12770,7 +14106,17 @@ msgid "Files changed in commit $1"
 msgstr ""
 
 msgctxt "wndDeepgit.tab:"
+msgid "Files"
+msgstr ""
+
+msgctxt "wndDeepgit.tab:"
 msgid "Navigation \\(initializing...\\)"
+msgstr ""
+
+# [decode] msgctxt "wndDeepgit.tab"Navigation \(initializing…\)""
+# [decode] msgid "Navigation \(initializing…\)"
+msgctxt "wndDeepgit.tab:"
+msgid "Navigation \\(initializing\\u2026\\)"
 msgstr ""
 
 msgctxt "wndDeepgit.tab:"
@@ -12905,6 +14251,10 @@ msgctxt "wndEditor.mni:"
 msgid "LF \\(Unix, macOS\\)"
 msgstr ""
 
+msgctxt "wndEditor.mniBlockSelection"
+msgid "Block Selection"
+msgstr ""
+
 msgctxt "wndEditor.mniEdit-undo"
 msgid "Undo"
 msgstr ""
@@ -12955,6 +14305,10 @@ msgstr ""
 
 msgctxt "wndGit.indexEditor.mni:"
 msgid "Stage Line"
+msgstr ""
+
+msgctxt "wndGit.indexEditor.mni:"
+msgid "Stage Lines"
 msgstr ""
 
 msgctxt "wndGit.indexEditor.mni:"
@@ -13034,19 +14388,136 @@ msgid "$1 - Index Editor"
 msgstr ""
 
 msgctxt "wndLog.hnt:"
+msgid "No commit matches the filter."
+msgstr ""
+
+msgctxt "wndLog.hnt:"
 msgid "No graph roots selected."
+msgstr ""
+
+#| msgid "Add 2 Git repositories to Group 'LLM'"
+msgctxt "wndLog.mni:"
+msgid "Add $1 Git repositories to Group '$2'"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Continue in Background"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Continue with Description"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Copy Name <email>"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Drop All Notes"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Explain Commit"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "On Manual Intervention"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Reconfigure"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Reword '@ai' and 'WIP' commits"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Stop"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "github \\(active\\)"
 msgstr ""
 
 msgctxt "wndLog.mniFixCaseChange"
 msgid "Fix Case-Change"
 msgstr ""
 
+msgctxt "wndLog.mniGitNoteAdd"
+msgid "Add Note"
+msgstr ""
+
+# [decode] msgctxt "wndLog.tab"Graph \(Initializing Subtree-Cache…\)""
+# [decode] msgid "Graph \(Initializing Subtree-Cache…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Initializing Subtree-Cache\\u2026\\)"
+msgstr ""
+
+# [decode] msgctxt "wndLog.tab"Graph \(Loading…\)""
+# [decode] msgid "Graph \(Loading…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Loading\\u2026\\)"
+msgstr ""
+
+# [decode] msgctxt "wndLog.tab"Graph \(Running log…\)""
+# [decode] msgid "Graph \(Running log…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Running log\\u2026\\)"
+msgstr ""
+
+# [decode] msgctxt "wndLog.tab"Graph \(Scanning WT…\)""
+# [decode] msgid "Graph \(Scanning WT…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Scanning WT\\u2026\\)"
+msgstr ""
+
+msgctxt "wndLog.tbt:"
+msgid "Hidden toolbar items..."
+msgstr ""
+
 msgctxt "wndLog.tbt:"
 msgid "Refresh information from GitHub."
 msgstr ""
 
+msgctxt "wndLog.tbtAi.commitMessageCompose"
+msgid "smartgit.jy: Cancelled"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Base"
+msgstr ""
+
 msgctxt "wndProject.mni:"
 msgid "Log Selection"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "New_key"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "PR_Review"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Review_Tool"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Show Rewritten Behind Commits"
+msgstr ""
+
+msgctxt "wndProject.mniFixCaseChange"
+msgid "Fix Case-Change"
 msgstr ""
 
 msgctxt "wndStd.btn:"
@@ -13078,7 +14549,21 @@ msgid "Commit files: select 1 commit\\nDiff between Commits: select 2 commits"
 msgstr ""
 
 msgctxt "wndStd.hnt:"
+msgid "Filter by repository name or path"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
 msgid "Loading ..."
+msgstr ""
+
+# [decode] msgctxt "wndStd.hnt"Loading …""
+# [decode] msgid "Loading …"
+msgctxt "wndStd.hnt:"
+msgid "Loading \\u2026"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "No graph roots selected."
 msgstr ""
 
 msgctxt "wndStd.hnt:"
@@ -13122,6 +14607,10 @@ msgid "All files, incl. ignored"
 msgstr ""
 
 msgctxt "wndStd.mni:"
+msgid "All my branches"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Apply Stash"
 msgstr ""
 
@@ -13131,6 +14620,22 @@ msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Changed files"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Continue in Background"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Continue with Description"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Don't Show Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Explain Commit"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -13154,11 +14659,19 @@ msgid "Log"
 msgstr ""
 
 msgctxt "wndStd.mni:"
+msgid "On Manual Intervention"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "On master: SmartGit: automatic stash on Pull."
 msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Only current branch \\(HEAD\\)"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Open"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -13178,7 +14691,32 @@ msgid "Reset"
 msgstr ""
 
 msgctxt "wndStd.mni:"
+msgid "Reword '@ai' and 'WIP' commits"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Save Stash"
+msgstr ""
+
+#, fuzzy
+msgctxt "wndStd.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show 'My' Pull Requests \\(involving me\\)"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show 'My' and Unassigned Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show All Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show Tags"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -13189,6 +14727,10 @@ msgctxt "wndStd.mni:"
 msgid "Sort by Path"
 msgstr ""
 
+msgctxt "wndStd.mni:"
+msgid "Stop"
+msgstr ""
+
 msgctxt "wndStd.mniBisectTryCommit"
 msgid "Try Commit"
 msgstr ""
@@ -13197,8 +14739,16 @@ msgctxt "wndStd.mniFixCaseChange"
 msgid "Fix Case-Change"
 msgstr ""
 
+msgctxt "wndStd.mniGitNoteAdd"
+msgid "Add Note"
+msgstr ""
+
 msgctxt "wndStd.mniIntegrateMain"
 msgid "Integrate Main"
+msgstr ""
+
+msgctxt "wndStd.mniStdCiResultOpenInBrowser"
+msgid "Open CI Result"
 msgstr ""
 
 msgctxt "wndStd.mniStdOpenSubmodule"
@@ -13207,6 +14757,11 @@ msgstr ""
 
 msgctxt "wndStd.mniStdOpenSubmoduleFromFile"
 msgid "Open this Submodule"
+msgstr ""
+
+#| msgid "Open in GitHub"
+msgctxt "wndStd.mniStdProviderOpenInBrowser"
+msgid "Open in $1"
 msgstr ""
 
 msgctxt "wndStd.mniStdSetModeHistory"
@@ -13225,6 +14780,10 @@ msgctxt "wndStd.tbr:"
 msgid "Submodule"
 msgstr ""
 
+msgctxt "wndStd.tbt:"
+msgid "History"
+msgstr ""
+
 msgctxt "wndStd.tbtFlowFeatureStart"
 msgid "Start a new feature branch."
 msgstr ""
@@ -13233,12 +14792,14 @@ msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|
 msgid "Ready"
 msgstr ""
 
+#| msgid "Full Screen"
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen"
-msgid "Full Screen"
+msgid "Enter Full Screen"
 msgstr ""
 
+#| msgid "Maximize"
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize"
-msgid "Maximize"
+msgid "Zoom"
 msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore"
@@ -14813,8 +16374,9 @@ msgctxt "wnd(Log|Project|Std|).mniFixup"
 msgid "Use Message for Commit"
 msgstr ""
 
+#| msgid "Configure"
 msgctxt "wnd(Log|Project|Std|).mniFlowConfigure"
-msgid "Configure"
+msgid "Configure Features"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
@@ -15001,8 +16563,9 @@ msgctxt "wnd(Log|Project|Std|).mniNewWindow"
 msgid "New Window"
 msgstr ""
 
+#| msgid "Open from Working Tree"
 msgctxt "wnd(Log|Project|Std|).mniOpen"
-msgid "Open from Working Tree"
+msgid "Open"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mniOpen:"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -161,17 +161,14 @@ msgctxt "dlgCommitInvisibleIndex.tle:"
 msgid "Commit"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgCommitNoEmailConfigured.fur:"
 msgid "Before committing you will have to configure your name and email, e.g. in the SmartGit Preferences."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgCommitNoEmailConfigured.hdl:"
 msgid "Please configure the email for commit."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgCommitNoEmailConfigured.tle:"
 msgid "Commit"
 msgstr ""
@@ -763,11 +760,11 @@ msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr ""
 
 msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
-msgid "\\[$1\\] - Conflict Solver"
+msgid "\\[$1\\] - $2"
 msgstr ""
 
 msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
-msgid "\\[$1\\] - $2"
+msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
 msgctxt "dlgScConflictSolverUnresolvedConflicts.chk:"
@@ -1115,11 +1112,11 @@ msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purch
 msgstr ""
 
 msgctxt "dlgScEvaluationReminderContinue.hdl:"
-msgid "Your SmartGit evaluation ends today."
+msgid "Your SmartGit evaluation ends in $1 days."
 msgstr ""
 
 msgctxt "dlgScEvaluationReminderContinue.hdl:"
-msgid "Your SmartGit evaluation ends in $1 days."
+msgid "Your SmartGit evaluation ends today."
 msgstr ""
 
 msgctxt "dlgScEvaluationReminderContinue.tle:"
@@ -1166,32 +1163,26 @@ msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScExternalFileStarterCommandNoFile.fur:"
 msgid "Be sure to add arguments to the appropriate input field."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScExternalFileStarterCommandNoFile.hdl:"
 msgid "The specified command is no file."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScExternalFileStarterCommandNoFile.tle:"
 msgid "Input Validation"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScExternalFileStarterEmptyCommand.fur:"
 msgid "Select the command which should be invoked."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScExternalFileStarterEmptyCommand.hdl:"
 msgid "The Command input field must not be empty!"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScExternalFileStarterEmptyCommand.tle:"
 msgid "Input Validation"
 msgstr ""
@@ -1680,7 +1671,6 @@ msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "Free Updates Until"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "License ID"
 msgstr ""
@@ -1793,27 +1783,22 @@ msgctxt "dlgScSetupLicense.tle:"
 msgid "SmartGit License"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
 msgid "Exit Later"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
 msgid "Restart Now"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScSetupLicenseNeedsRestart.fur:"
 msgid "You can do that now or manually later."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScSetupLicenseNeedsRestart.hdl:"
 msgid "SmartGit has to be restarted for the license change to take effect."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgScSetupLicenseNeedsRestart.tle:"
 msgid "SmartGit License"
 msgstr ""
@@ -2206,7 +2191,6 @@ msgctxt "dlgSgAbortRevertingConfirm.tle:"
 msgid "Discard"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgAbout.btn:"
 msgid "Copy Evaluation-ID"
 msgstr ""
@@ -2227,7 +2211,6 @@ msgctxt "dlgSgAbout.edt:"
 msgid "Build Date"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgAbout.edt:"
 msgid "Demo Until"
 msgstr ""
@@ -2325,6 +2308,18 @@ msgctxt "dlgSgAiApiKeyRepoLlmConsent.hdl:"
 msgid "Do you allow SmartGit to upload repository data to $1?"
 msgstr ""
 
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.tle:"
+msgid "AI Upload Consent"
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorError.hdl:"
+msgid "Failed to annotate selected commits."
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorError.tle:"
+msgid "Annotate Commits"
+msgstr ""
+
 msgctxt "dlgSgAiCommitMessageComposeActionSetup.fur:"
 msgid "Click the AI button again to generate your first commit message."
 msgstr ""
@@ -2347,6 +2342,50 @@ msgstr ""
 
 msgctxt "dlgSgAiCommitMessageComposeError.tle:"
 msgid "AI Commit Message Compose"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageNoModifications.fur:"
+msgid "There are no uncommitted changes in your working tree, so an AI commit message cannot be generated."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageNoModifications.hdl:"
+msgid "No local changes detected."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.btn:"
+msgid "Reword"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.fur:"
+msgid "SmartGit has detected a commit message containing an AI-generation marker. If the commit has not yet been pushed, it can be automatically reworded in the background.\\n\\nYou can enable or disable this option from the AI popup menu."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.hdl:"
+msgid "Do you want to reword marked commits in the background?"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.tle:"
+msgid "Commit Message Rewording"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.fur:"
+msgid "Your settings exclude untracked files from commits, so they will not be used to generate the AI commit message.\\n\\nTo include untracked files in commits, update the setting in Preferences."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.hdl:"
+msgid "Untracked files are excluded."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.tle:"
+msgid "AI Commit Message"
 msgstr ""
 
 msgctxt "dlgSgAiIntegrationSetup.hdl:"
@@ -2467,6 +2506,10 @@ msgid "SmartGit offers AI-powered features to enhance productivity, simplify wor
 msgstr ""
 
 msgctxt "dlgSgAiSetup.inf:"
+msgid "Verifying connectivity..."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
 msgid "Verifying connectivity\\u2026"
 msgstr ""
 
@@ -2484,6 +2527,10 @@ msgstr ""
 
 msgctxt "dlgSgAiSetup.lbl:"
 msgid "Optional parameters"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Please wait ..."
 msgstr ""
 
 msgctxt "dlgSgAiSetup.lbl:"
@@ -2514,6 +2561,10 @@ msgctxt "dlgSgAiSetup.rbt:"
 msgid "Enable AI integration"
 msgstr ""
 
+msgctxt "dlgSgAiSetup.tle:"
+msgid "AI Setup"
+msgstr ""
+
 msgctxt "dlgSgAiSetupConfigurationSuccess.fur:"
 msgid "The configuration has been saved to '$1', which is included by '$2'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
 msgstr ""
@@ -2522,12 +2573,40 @@ msgctxt "dlgSgAiSetupConfigurationSuccess.hdl:"
 msgid "The AI integration has been configured successfully."
 msgstr ""
 
+msgctxt "dlgSgAiSetupConfigurationSuccess.tle:"
+msgid "AI Setup"
+msgstr ""
+
 msgctxt "dlgSgAiSetupConnectivityFailed.fur:"
 msgid "Object '$1' not found."
 msgstr ""
 
 msgctxt "dlgSgAiSetupConnectivityFailed.hdl:"
 msgid "Connection to '$1' failed."
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Back to Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Enable and Exit"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Exit without Enabling"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.fur:"
+msgid "You have selected some AI features. Do you want to enable them now, or exit the setup without enabling them?"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.hdl:"
+msgid "Enable already selected AI features?"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.tle:"
+msgid "AI Setup"
 msgstr ""
 
 msgctxt "dlgSgAiSetupLlmConfigurationInvalid.fur:"
@@ -2802,10 +2881,6 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
-msgid "Do you want to delete $1 local branches?"
-msgstr ""
-
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle:"
 msgid "Delete"
 msgstr ""
@@ -2842,10 +2917,6 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
-msgid "Do you want to delete the local branch '$1'?"
-msgstr ""
-
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle:"
 msgid "Delete"
 msgstr ""
@@ -2870,10 +2941,6 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
-msgid "Delete from remote repository '$1'"
-msgstr ""
-
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur:"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
 msgstr ""
@@ -2884,10 +2951,6 @@ msgstr ""
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
-msgstr ""
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
-msgid "Do you want to delete the branch '$1'?"
 msgstr ""
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle:"
@@ -3484,17 +3547,14 @@ msgctxt "dlgSgClone.mni:"
 msgid "Add Hosting Provider"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgClone.mni:"
 msgid "Own Repositories"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgClone.mni:"
 msgid "Starred Repositories"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgClone.mni:"
 msgid "Top Repositories"
 msgstr ""
@@ -4947,37 +5007,30 @@ msgctxt "dlgSgGitConfigEditConfigNotFound.tle:"
 msgid "Edit Config"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
 msgid "Refresh"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
 msgid "Select"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgGitHubCommitMessageSelect.col:"
 msgid "Number"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgGitHubCommitMessageSelect.col:"
 msgid "Title"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgGitHubCommitMessageSelect.hdl:"
 msgid "Select commit message by GitHub issue"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgGitHubCommitMessageSelect.inf:"
 msgid "The selected issue summary will be used as commit message."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgGitHubCommitMessageSelect.tle:"
 msgid "Select Issue"
 msgstr ""
@@ -5446,7 +5499,6 @@ msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl:"
 msgid "Do you want to modify commits which are already pushed?"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.tle:"
 msgid "Edit Author"
 msgstr ""
@@ -5651,7 +5703,6 @@ msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Add GitHub account"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Add GitLab \\(Self Hosted\\) account"
 msgstr ""
@@ -5664,7 +5715,6 @@ msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Configure a new hosting provider account"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgHostingProviderAdd.inf:"
 msgid "Set or select the options according to your account."
 msgstr ""
@@ -6934,11 +6984,11 @@ msgid "Output"
 msgstr ""
 
 msgctxt "dlgSgPingRepositoryFailed.fur:"
-msgid "repository '$1' not found."
+msgid "Please check the repository URL.\\n\\n$1"
 msgstr ""
 
 msgctxt "dlgSgPingRepositoryFailed.fur:"
-msgid "Please check the repository URL.\\n\\n$1"
+msgid "repository '$1' not found."
 msgstr ""
 
 msgctxt "dlgSgPingRepositoryFailed.hdl:"
@@ -7214,7 +7264,15 @@ msgid "Detect renames \\(for added and removed files, as command line Git does\\
 msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Disable AI integration \\(globally\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Distinguish between content and EOL-only changes \\(slightly more expensive\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Enable AI integration"
 msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
@@ -7784,6 +7842,10 @@ msgid "In order to use all SmartGit functionality, you need to have command line
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Learn how to tailor AI for your projects with the complete \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI SmartGit AI Integration documentation\\]."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Local and Remote Changes"
 msgstr ""
 
@@ -7832,6 +7894,18 @@ msgid "Stash"
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*configured globally\\*. Change it via AI button > \\*Reconfigure\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*disabled globally\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*manually configured\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "The AI integration is \\*not yet configured\\* \\(globally\\)."
 msgstr ""
 
@@ -7848,6 +7922,10 @@ msgid "This file will be sent as is: $1"
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "To change it, edit your Git config files directly."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "To configure, click the AI button in the Commit Message view or the Commit dialog."
 msgstr ""
 
@@ -7861,6 +7939,10 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "When comparing files, this list is searched from top to bottom to find a matching diff tool. If none is found, the built-in file compare is used for text files."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "When enabled, the AI button appears in the Commit Message view and the Commit dialog. Click it to complete the initial setup."
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
@@ -8366,6 +8448,10 @@ msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.hdl:"
 msgid "Generate a new API token for $1"
+msgstr ""
+
+msgctxt "dlgSgProviderGenerateToken.inf:"
+msgid "Authenticate at GitHub and grant access to SmartGit."
 msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.inf:"
@@ -9796,7 +9882,6 @@ msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Close"
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Exit"
 msgstr ""
@@ -10065,7 +10150,6 @@ msgctxt "dlgSgRepositorySettings.ttpGroupPatterns:"
 msgid "Patterns will show up in the GUI using auto-generated labels which are derived from their regular expression. You can assign a custom label <tt>label</tt> to a pattern by prefixing it by <tt>label:</tt>; a label may only contain letters, digits and '_'."
 msgstr ""
 
-#, fuzzy
 msgctxt "dlgSgRepositorySettings.wrn:"
 msgid "It is recommended to set an email address used for committing."
 msgstr ""
@@ -12542,6 +12626,10 @@ msgctxt "ntmHostingProviderIntegrationNotYetConfigured:"
 msgid "SmartGit provides special support for $1. The integration can be configured in the Preferences."
 msgstr ""
 
+msgctxt "ntmLcTypeProblem\"If you experience problems with garbled file names/paths containing non-US-ASCII characters, consider to set the environment variables <tt>LC_ALL</tt>, or both <tt>LC_CTYPE</tt> and <tt>LANG</tt> to a country code which ends with \\\"<tt>.UTF-8</tt>\\\".\""
+msgid "If you experience problems with garbled file names/paths containing non-US-ASCII characters, consider to set the environment variables <tt>LC_ALL</tt>, or both <tt>LC_CTYPE</tt> and <tt>LANG</tt> to a country code which ends with \"<tt>.UTF-8</tt>\"."
+msgstr ""
+
 msgctxt "ntmMarkRepositoriesAsFavorite:"
 msgid "Git repositories marked as 'favorites' will be refreshed and fetched automatically in the background."
 msgstr ""
@@ -12598,6 +12686,10 @@ msgctxt "ntmVoteForUs:"
 msgid "vote at <link1>alternativeto.net</link1>"
 msgstr ""
 
+msgctxt "ntmWslWorkaround:"
+msgid "To work around some problems with WSL, please check our documentation."
+msgstr ""
+
 msgctxt "nttCredentialHelper:"
 msgid "External Credential Helper detected"
 msgstr ""
@@ -12648,6 +12740,10 @@ msgstr ""
 
 msgctxt "nttHostingProviderIntegrationNotYetConfigured:"
 msgid "Configure Now"
+msgstr ""
+
+msgctxt "nttLcTypeProblem:"
+msgid "Experience problems with non-US-ASCII file names?"
 msgstr ""
 
 msgctxt "nttMarkRepositoriesAsFavorite:"
@@ -12716,6 +12812,14 @@ msgstr ""
 
 msgctxt "nttVoteForUs:"
 msgid "What do you like in SmartGit?"
+msgstr ""
+
+msgctxt "nttWslWorkaround:"
+msgid "It seems that you're running SmartGit in WSL."
+msgstr ""
+
+msgctxt "nttWslWorkaround:"
+msgid "Open Documentation"
 msgstr ""
 
 msgctxt "pop:"
@@ -12826,8 +12930,9 @@ msgctxt "ttpBranches:"
 msgid "<b>On: </b>$1"
 msgstr ""
 
+#| msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
 msgctxt "ttpBranches:"
-msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
+msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>$3</b>"
 msgstr ""
 
 msgctxt "ttpBranches:"
@@ -14333,7 +14438,15 @@ msgid "Stop"
 msgstr ""
 
 msgctxt "wndLog.mni:"
+msgid "generate \\(active\\)"
+msgstr ""
+
+msgctxt "wndLog.mni:"
 msgid "github \\(active\\)"
+msgstr ""
+
+msgctxt "wndLog.mniCopyCommitId:"
+msgid "Copy"
 msgstr ""
 
 msgctxt "wndLog.mniFixCaseChange:"
@@ -14376,10 +14489,6 @@ msgctxt "wndLog.tbt:"
 msgid "Refresh information from GitHub."
 msgstr ""
 
-msgctxt "wndLog.tbtAi.commitMessageCompose:"
-msgid "smartgit.jy: Cancelled"
-msgstr ""
-
 msgctxt "wndProject.mni:"
 msgid "Base"
 msgstr ""
@@ -14406,6 +14515,10 @@ msgstr ""
 
 msgctxt "wndProject.mni:"
 msgid "Show Rewritten Behind Commits"
+msgstr ""
+
+msgctxt "wndProject.mniCopyCommitId:"
+msgid "Copy"
 msgstr ""
 
 msgctxt "wndProject.mniFixCaseChange:"

--- a/po/messages.pot
+++ b/po/messages.pot
@@ -288,7 +288,6 @@ msgctxt "dlgHostingProvider.canBeConfigured.btn:"
 msgid "Configure Hosting Provider"
 msgstr ""
 
-#| msgid "The easiest way to access the repository at https://gitlab.com/yubeshi/smartgit-translation.git is through a hosting provider."
 msgctxt "dlgHostingProvider.canBeConfigured.fur"
 msgid "The easiest way to access the repository at $1 is through a hosting provider."
 msgstr ""
@@ -309,10 +308,8 @@ msgctxt "dlgProgress.lbl:"
 msgid "Please wait ..."
 msgstr ""
 
-# [decode] msgctxt "dlgProgress.lbl"Please wait …""
+# [decode] msgctxt "dlgProgress.lbl:"
 # [decode] msgid "Please wait …"
-#| msgctxt "dlgProgress.lbl\"Please wait \\u2026\""
-#| msgid "Please wait \\u2026"
 msgctxt "dlgProgress.lbl:"
 msgid "Please wait \\u2026"
 msgstr ""
@@ -1115,7 +1112,7 @@ msgstr ""
 
 # TODO: Review
 # We need to verify whether the placeholder replacement is appropriate.
-#
+# 
 # msgctxt "dlgScEvaluationReminderContinue.fur"
 # msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
 #, fuzzy
@@ -2346,13 +2343,15 @@ msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
 msgid "Deny"
 msgstr ""
 
-#| msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n/Users/tomohiro/Git-projects/smartgit-translations-25.1-wip\\n\\nPlease confirm whether uploads to OpenAI are allowed. If allowed, SmartGit may upload repository data required by the AI feature you invoke \\(for example: diffs, commit messages, and related metadata\\).\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
+# $1: rootFile , $2: typeName , $3: details
+#| msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to OpenAI are allowed. If allowed, SmartGit may upload repository data required by the AI feature you invoke \\(for example: diffs, commit messages, and related metadata\\).\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
 msgctxt "dlgSgAiApiKeyRepoLlmConsent.fur"
-msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to OpenAI are allowed. If allowed, SmartGit may upload repository data required by the AI feature you invoke \\(for example: diffs, commit messages, and related metadata\\).\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
+msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to $2 are allowed. $3\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
 msgstr ""
 
+#| msgid "Do you allow SmartGit to upload repository data to OpenAI?"
 msgctxt "dlgSgAiApiKeyRepoLlmConsent.hdl"
-msgid "Do you allow SmartGit to upload repository data to OpenAI?"
+msgid "Do you allow SmartGit to upload repository data to $1?"
 msgstr ""
 
 msgctxt "dlgSgAiCommitMessageComposeActionSetup.fur"
@@ -2546,7 +2545,7 @@ msgctxt "dlgSgAiSetup.rbt:"
 msgid "Enable AI integration"
 msgstr ""
 
-#| msgid "The configuration has been saved to '/Users/tomohiro/Git-projects/smartgit-translations/.git/smartgit-ai', which is included by '/Users/tomohiro/Git-projects/smartgit-translations/.git/config'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
+#| msgid "The configuration has been saved to '/Users/UserName/Git-projects/....', which is included by '/Users/UserName/Git-projects/....'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
 msgctxt "dlgSgAiSetupConfigurationSuccess.fur"
 msgid "The configuration has been saved to '$1', which is included by '$2'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
 msgstr ""
@@ -2947,7 +2946,7 @@ msgstr ""
 
 #| msgid "Configure"
 msgctxt "dlgSgBranchTrackingSetConfirm.btn:"
-msgid "Configure Features"
+msgid "Configure"
 msgstr ""
 
 msgctxt "dlgSgBranchTrackingSetConfirm.fur"
@@ -3094,8 +3093,9 @@ msgctxt "dlgSgCheckoutSwitchToWorktree.fur"
 msgid "A worktree repository already exists for the selected branch. Therefore, you can't check out this branch directly, but you can switch to this worktree."
 msgstr ""
 
+#| msgid "Do you want to switch to worktree 'C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations-25.1_windows'?"
 msgctxt "dlgSgCheckoutSwitchToWorktree.hdl"
-msgid "Do you want to switch to worktree 'C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations-25.1_windows'?"
+msgid "Do you want to switch to worktree '$1'?"
 msgstr ""
 
 msgctxt "dlgSgCheckoutSwitchToWorktree.tle"
@@ -3345,11 +3345,6 @@ msgstr ""
 
 msgctxt "dlgSgCleanNoFilesFound.tle"
 msgid "Clean Working Tree"
-msgstr ""
-
-#| msgid "Configure"
-msgctxt "dlgSgClone.btn:"
-msgid "Configure Features"
 msgstr ""
 
 msgctxt "dlgSgClone.btn:"
@@ -4397,14 +4392,12 @@ msgctxt "dlgSgFileCompareInvokerFailedIO.hdl%1"
 msgid "'$1' could not be invoked."
 msgstr ""
 
-#| msgid "Open"
 msgctxt "dlgSgFileCompareInvokerFailedIO.tle"
-msgid "Open from Working Tree"
+msgid "Open"
 msgstr ""
 
-#| msgid "Open"
 msgctxt "dlgSgFileCompareNoChanges.btn:"
-msgid "Open from Working Tree"
+msgid "Open"
 msgstr ""
 
 msgctxt "dlgSgFileCompareNoChanges.btn:"
@@ -4988,7 +4981,7 @@ msgid "Run Garbage Collector"
 msgstr ""
 
 msgctxt "dlgSgGitConfigEditConfigNotFound.fur"
-msgid "The file C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations\\\\.git\\\\worktrees\\\\smartgit-translations-25.1_windows\\\\config could not be opened for editing."
+msgid "The file $1config could not be opened for editing."
 msgstr ""
 
 msgctxt "dlgSgGitConfigEditConfigNotFound.hdl"
@@ -6674,7 +6667,6 @@ msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
 msgid "Outer Repository"
 msgstr ""
 
-#| msgid "At the specified path nested repositories were found.\\nInner repository: D:\\\\GitRepository\\\\xxxx\\\\xxxx\\nOuter repository: D:\\\\GitRepository\\\\xxxx"
 msgctxt "dlgSgOpenRepositoryOuterOrInner.fur"
 msgid "At the specified path nested repositories were found.\\nInner repository: $1\\nOuter repository: $2"
 msgstr ""
@@ -6859,9 +6851,9 @@ msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase HEAD \\($1\\) to $2 produced warnings."
 msgstr ""
 
-#| msgid "Command Rebase HEAD \\(feature/forceinclude\\) to fa50210c failed!"
-msgctxt "dlgSgOutput.lbl\"Command Rebase HEAD \\(feature/forceinclude\\) to fa50210c failed!\""
-msgid "Command Rebase HEAD \\(feature/forceinclude\\) to $1 failed!"
+#| msgid "Command Rebase HEAD \\(BranchName\\) to fa50210c failed!"
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Rebase HEAD \\($1\\) to $2 failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -8400,12 +8392,6 @@ msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.cmb:"
 msgid "github.com"
 msgstr ""
 
-#| msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.cmb\"github\\(yubeshi-AI\\)\""
-#| msgid "github\\($1\\)"
-msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.cmb:"
-msgid "github\\($1\\)"
-msgstr ""
-
 msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.edt:"
 msgid "Provider"
 msgstr ""
@@ -8414,7 +8400,6 @@ msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.hdl"
 msgid "Select which GitHub account to use"
 msgstr ""
 
-#| msgid "Select which account you want to use for connecting to 'https://github.com/ktyubeshi/fast-bunkai.git'."
 msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.inf"
 msgid "Select which account you want to use for connecting to '$1'."
 msgstr ""
@@ -8600,9 +8585,8 @@ msgctxt "dlgSgPull.tle"
 msgid "Pull"
 msgstr ""
 
-#| msgid "Configure"
 msgctxt "dlgSgPullConfiguration.btn:"
-msgid "Configure Features"
+msgid "Configure"
 msgstr ""
 
 msgctxt "dlgSgPullConfiguration.chk:"
@@ -8741,12 +8725,10 @@ msgctxt "dlgSgPushConfirmSingleTag.chk"
 msgid "Don't show again"
 msgstr ""
 
-#| msgid "1 tag will be pushed to 'origin'."
 msgctxt "dlgSgPushConfirmSingleTag.fur"
 msgid "$1 tag will be pushed to '$2'."
 msgstr ""
 
-#| msgid "Do you want to push tag 'Release/0.0.14'?"
 msgctxt "dlgSgPushConfirmSingleTag.hdl"
 msgid "Do you want to push tag '$1'?"
 msgstr ""
@@ -8763,10 +8745,6 @@ msgctxt "dlgSgPushForced.fur"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr ""
 
-# TODO: Review
-# We need to verify whether the placeholder replacement is appropriate.
-#, fuzzy
-#| msgid "Do you want to force-push \\(replace\\) the remote branch 'pot-wip/24.1_windows'?"
 msgctxt "dlgSgPushForced.hdl%1"
 msgid "Do you want to force-push \\(replace\\) the remote branch '$1'?"
 msgstr ""
@@ -11767,7 +11745,6 @@ msgctxt "dlgSgSubmoduleUnregisterConfirm.fur"
 msgid "All relevant files will be adjusted. Afterwards you will only need to perform a commit to finish the operation. To just skip the submodule from the working tree, use Deinit."
 msgstr ""
 
-#| msgid "Do you want to unregister submodule 'submodule/qmh-framework'?"
 msgctxt "dlgSgSubmoduleUnregisterConfirm.hdl"
 msgid "Do you want to unregister submodule '$1'?"
 msgstr ""
@@ -11820,7 +11797,6 @@ msgctxt "dlgSgSubtreeAdd.edt:"
 msgid "Repository URL"
 msgstr ""
 
-#| msgid "Directory '/Users/tomohiro/Git-projects/sgpo-tools-cli-WorkSpace/sgpo-tools-cli' already exists."
 msgctxt "dlgSgSubtreeAdd.err:"
 msgid "Directory '$1' already exists."
 msgstr ""
@@ -12399,9 +12375,8 @@ msgctxt "dlgTxtEditor.fileModified.fur"
 msgid "Unless you want to see the old file state, it is recommended to reload."
 msgstr ""
 
-#| msgid "The file config was changed. Reload it?"
 msgctxt "dlgTxtEditor.fileModified.hdl"
-msgid "The file messages.pot was changed. Reload it?"
+msgid "The file $1 was changed. Reload it?"
 msgstr ""
 
 msgctxt "dlgTxtEditor.fileModified.tle"
@@ -12788,13 +12763,8 @@ msgctxt "nttUpdateCheckFetchVersionStart:"
 msgid "Started downloading version $1 \\($2\\)."
 msgstr ""
 
-#| msgid "Started downloading version 24.1.3."
 msgctxt "nttUpdateCheckFetchVersionStart:"
 msgid "Started downloading version $1."
-msgstr ""
-
-msgctxt "nttUpdateCheckFetchVersionStart:"
-msgid "Started downloading version 25.1.055."
 msgstr ""
 
 msgctxt "nttUpdateCheckFetchVersionSuccess:"
@@ -13005,8 +12975,6 @@ msgctxt "ttpBranches:"
 msgid "<b>Tracking State:\\t</b>identical"
 msgstr ""
 
-#| msgctxt "ttpBranches\"<b>Worktree:\\t</b>C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations-24.1-merged\""
-#| msgid "<b>Worktree:\\t</b>C:\\\\XXXX\\\\XXXX\\\\XXXX\\\\smartgit-translations-24.1-merged"
 msgctxt "ttpBranches:"
 msgid "<b>Worktree:\\t</b>$1"
 msgstr ""
@@ -13111,7 +13079,6 @@ msgctxt "ttpRepositories:"
 msgid "<b>Remotes:\\t</b>"
 msgstr ""
 
-#| msgid "<b>Tracked Branch:\\t</b>origin/work_space"
 msgctxt "ttpRepositories:"
 msgid "<b>Tracked Branch:\\t</b>$1"
 msgstr ""
@@ -13186,19 +13153,6 @@ msgstr ""
 
 msgctxt "wnd.mni:"
 msgid "Contact Support"
-msgstr ""
-
-# 注意
-msgctxt "wnd.mni:"
-msgid "Cursor"
-msgstr ""
-
-msgctxt "wnd.mni:"
-msgid "Format"
-msgstr ""
-
-msgctxt "wnd.mni:"
-msgid "Import Unknown"
 msgstr ""
 
 msgctxt "wnd.mni:"
@@ -14395,7 +14349,6 @@ msgctxt "wndLog.hnt:"
 msgid "No graph roots selected."
 msgstr ""
 
-#| msgid "Add 2 Git repositories to Group 'LLM'"
 msgctxt "wndLog.mni:"
 msgid "Add $1 Git repositories to Group '$2'"
 msgstr ""
@@ -16563,8 +16516,11 @@ msgctxt "wnd(Log|Project|Std|).mniNewWindow"
 msgid "New Window"
 msgstr ""
 
-#| msgid "Open from Working Tree"
-msgctxt "wnd(Log|Project|Std|).mniOpen"
+msgctxt "wnd(Log|Std|).mniOpen"
+msgid "Open from Working Tree"
+msgstr ""
+
+msgctxt "wndProject.mniOpen"
 msgid "Open"
 msgstr ""
 

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -6929,7 +6929,7 @@ msgctxt "dlgSgPreferences.lbl:"
 msgid "Changing these low-level properties can be harmful to the stability or performance of SmartGit. You should only continue if you are sure of what you are doing. Changed properties with a trailing \\* need a restart to be applied."
 msgstr "Изменение низкоуровненых параметров может привести к нарушению стабильности или производительности Smartgit. Продолжайте, только если вы уверены в том, что делаете. Измененные свойства со знаком \\* в конце требуют перезапуска для применения."
 
-msgctxt "dlgSgPreferences.lbl\"Checkout \\(Switch branch\\)\""
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Checkout \\(Switch branch\\)"
 msgstr "Переключение \\(Смена ветки\\)"
 
@@ -7177,7 +7177,7 @@ msgctxt "dlgSgPreferences.mni:"
 msgid "GitHub"
 msgstr ""
 
-msgctxt "dlgSgPreferences.mni\"GitLab \\(Self Hosted\\)\""
+msgctxt "dlgSgPreferences.mni:"
 msgid "GitLab \\(Self Hosted\\)"
 msgstr ""
 

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -125,7 +125,7 @@ msgctxt "dlgCommitGitHubConfirmEmail.fur"
 msgid "If this repository is open-source, you might want to hide your email address, as \\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\], and use instead <username>@users.noreply.github.com."
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.hdl%1"
+msgctxt "dlgCommitGitHubConfirmEmail.hdl"
 msgid "Commit with default email address $1?"
 msgstr ""
 
@@ -325,11 +325,11 @@ msgctxt "dlgProgress.tle:"
 msgid "Verifying executables"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.fur%1"
+msgctxt "dlgQBugFileSendingFailed.fur"
 msgid "Maybe you need to configure a proxy or our server is temporarily down.\\nDetails: $1"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.hdl%1"
+msgctxt "dlgQBugFileSendingFailed.hdl"
 msgid "Could not send the crash logs to $1"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgctxt "dlgQDockManagerClosedView.fur"
 msgid "To reopen it again, use the corresponding menu item from the Window menu."
 msgstr "Для открытия панели снова, воспользуйтесь соответствующим пунктом в меню Окно."
 
-msgctxt "dlgQDockManagerClosedView.hdl%1"
+msgctxt "dlgQDockManagerClosedView.hdl"
 msgid "You've closed the view '$1'."
 msgstr "Вы закрыли панель '$1'."
 
@@ -417,7 +417,7 @@ msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur"
 msgid "To save to a different file, click 'Cancel'."
 msgstr ""
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl%1"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl"
 msgid "The file $1 already exists. Do you want to overwrite it?"
 msgstr ""
 
@@ -449,11 +449,11 @@ msgctxt "dlgQFrameManagerExit.tle"
 msgid "Exit"
 msgstr "Выйти"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.fur%2"
+msgctxt "dlgQIntegerInputProviderInvalidValue.fur"
 msgid "Port must be in the range from $1 to $2."
 msgstr ""
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.hdl%1"
+msgctxt "dlgQIntegerInputProviderInvalidValue.hdl"
 msgid "The text in field '$1' is not valid."
 msgstr ""
 
@@ -513,7 +513,7 @@ msgctxt "dlgQProxyConnectionFailed.fur"
 msgid "Details: syntevo.com"
 msgstr ""
 
-msgctxt "dlgQProxyConnectionFailed.hdl%1"
+msgctxt "dlgQProxyConnectionFailed.hdl"
 msgid "Could not connect to $1."
 msgstr ""
 
@@ -549,7 +549,7 @@ msgctxt "dlgQUpdateCheckForNewVersion.tle"
 msgid "Check for New Version"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.fur%1"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.fur"
 msgid "Details: Failed to connect to '$1'."
 msgstr ""
 
@@ -577,7 +577,7 @@ msgctxt "dlgQUpdateCheckLatestBuild.tle"
 msgid "Check for Latest Build"
 msgstr "Проверка наличия свежей сборки"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur%1"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur"
 msgid "Details: $1"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgctxt "dlgScAboutUpdateInstallation.fur"
 msgid "This will take a few moments and has to restart SmartGit."
 msgstr ""
 
-msgctxt "dlgScAboutUpdateInstallation.hdl%1"
+msgctxt "dlgScAboutUpdateInstallation.hdl"
 msgid "Do you want to upgrade the installation directory to version $1?"
 msgstr ""
 
@@ -729,11 +729,11 @@ msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl"
 msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%1"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%2"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 msgid "\\[$1\\] - $2"
 msgstr ""
 
@@ -925,7 +925,7 @@ msgctxt "dlgScDevOpsCredentials.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgScDevOpsCredentials.hdl%1"
+msgctxt "dlgScDevOpsCredentials.hdl"
 msgid "Login to '$1'"
 msgstr ""
 
@@ -957,7 +957,7 @@ msgctxt "dlgScDevOpsSslClientCertificate.edt:"
 msgid "Passphrase"
 msgstr ""
 
-msgctxt "dlgScDevOpsSslClientCertificate.hdl%1"
+msgctxt "dlgScDevOpsSslClientCertificate.hdl"
 msgid "Select the client certificate for $1"
 msgstr ""
 
@@ -1049,7 +1049,7 @@ msgctxt "dlgScDialogAssertionHandlerOutOfMemory.btn:"
 msgid "Force Exit"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur%1"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur"
 msgid "It is strongly recommended to restart SmartGit.\\n\\nTo increase the maximum memory limit edit $1, increase the value of the -Xmx option, for example to -Xmx1024m \\(or add it if not yet existing\\) and restart SmartGit."
 msgstr ""
 
@@ -1069,11 +1069,11 @@ msgctxt "dlgScEvaluationReminderContinue.btn:"
 msgid "Register"
 msgstr ""
 
-msgctxt "dlgScEvaluationReminderContinue.fur%2"
+msgctxt "dlgScEvaluationReminderContinue.fur"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
 msgstr ""
 
-msgctxt "dlgScEvaluationReminderContinue.hdl%1"
+msgctxt "dlgScEvaluationReminderContinue.hdl"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr ""
 
@@ -1081,11 +1081,11 @@ msgctxt "dlgScEvaluationReminderContinue.tle"
 msgid "Evaluation"
 msgstr ""
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl%2"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl"
 msgid "Cannot run program \"$1\": $2"
 msgstr ""
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle%1"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
@@ -1249,7 +1249,7 @@ msgctxt "dlgScFilePatternsEdit.edt:"
 msgid "File Pattern"
 msgstr "Шаблон имени файла"
 
-msgctxt "dlgScFilePatternsEdit.hdl%1"
+msgctxt "dlgScFilePatternsEdit.hdl"
 msgid "Language: $1"
 msgstr "Язык: $1"
 
@@ -1381,7 +1381,7 @@ msgctxt "dlgScJiraResolveIssue.edt:"
 msgid "Summary"
 msgstr ""
 
-msgctxt "dlgScJiraResolveIssue.hdl%1"
+msgctxt "dlgScJiraResolveIssue.hdl"
 msgid "Resolve issue $1"
 msgstr ""
 
@@ -1513,7 +1513,7 @@ msgctxt "dlgScPropertiesReset.fur"
 msgid "The new values will be active after restarting SmartGit."
 msgstr ""
 
-msgctxt "dlgScPropertiesReset.hdl%1"
+msgctxt "dlgScPropertiesReset.hdl"
 msgid "Do you want to reset $1 system properties to their defaults?"
 msgstr ""
 
@@ -1529,7 +1529,7 @@ msgctxt "dlgScPropertyEdit.hdl"
 msgid "Edit low-level property value"
 msgstr ""
 
-msgctxt "dlgScPropertyEdit.inf%1"
+msgctxt "dlgScPropertyEdit.inf"
 msgid "Set the value for property '$1'"
 msgstr ""
 
@@ -1901,7 +1901,7 @@ msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle"
 msgid "SmartGit Installation Update"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur%1"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur"
 msgid "Please get rid of '$1' manually and retry the upgrade."
 msgstr ""
 
@@ -1917,7 +1917,7 @@ msgctxt "dlgScUpdateInstallationUpgrade.btn:"
 msgid "Upgrade Now"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpgrade.fur%1"
+msgctxt "dlgScUpdateInstallationUpgrade.fur"
 msgid "The new version $1 has been downloaded which needs to be installed."
 msgstr ""
 
@@ -2113,7 +2113,7 @@ msgctxt "dlgSgAbout.tle"
 msgid "About SmartGit"
 msgstr "О SmartGit"
 
-msgctxt "dlgSgApplicationAlreadyRunning.fur%1"
+msgctxt "dlgSgApplicationAlreadyRunning.fur"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
 msgstr ""
 
@@ -2157,7 +2157,7 @@ msgctxt "dlgSgAuthenticationShowPassword.edt:"
 msgid "Password"
 msgstr ""
 
-msgctxt "dlgSgAuthenticationShowPassword.tle%1"
+msgctxt "dlgSgAuthenticationShowPassword.tle"
 msgid "Password for $1"
 msgstr ""
 
@@ -2201,7 +2201,7 @@ msgctxt "dlgSgBisectResult.btn:"
 msgid "Leave Bisect"
 msgstr ""
 
-msgctxt "dlgSgBisectResult.fur%1"
+msgctxt "dlgSgBisectResult.fur"
 msgid "$1"
 msgstr ""
 
@@ -2325,7 +2325,7 @@ msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl%1"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
@@ -2377,7 +2377,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr "Вы хотите удалить $1 локальные ветки?"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl%1"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
 
@@ -2417,7 +2417,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "Вы хотите удалить локальную ветку '$1'?"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl%1"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
 
@@ -2445,7 +2445,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk%1"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
 msgid "Delete from remote repository '$1'"
 msgstr "Удалить во внешнем репозитории '$1'"
 
@@ -2461,7 +2461,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl%1"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
 msgid "Do you want to delete the branch '$1'?"
 msgstr "Хотите удалить ветку '$1'?"
 
@@ -2477,7 +2477,7 @@ msgctxt "dlgSgBranchTrackingResetConfirm.fur"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "Необходимая конфигурация будет зафиксирована в файле .git/config."
 
-msgctxt "dlgSgBranchTrackingResetConfirm.hdl%2"
+msgctxt "dlgSgBranchTrackingResetConfirm.hdl"
 msgid "Should branch '$1' stop tracking '$2'?"
 msgstr "Прекратить отслеживание веткой '$1' ветки '$2'?"
 
@@ -2493,7 +2493,7 @@ msgctxt "dlgSgBranchTrackingSetConfirm.fur"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingSetConfirm.hdl%2"
+msgctxt "dlgSgBranchTrackingSetConfirm.hdl"
 msgid "Do you want to configure '$1' to track '$2'?"
 msgstr ""
 
@@ -2569,7 +2569,7 @@ msgctxt "dlgSgCheckoutFastForwardMerge.fur"
 msgid "Fast-forward-merging automatically moves the branch forward to the tracked remote branch."
 msgstr "Быстрое слияние автоматически перемещает ветку вперед к отслеживаемой внешней ветке."
 
-msgctxt "dlgSgCheckoutFastForwardMerge.hdl%1"
+msgctxt "dlgSgCheckoutFastForwardMerge.hdl"
 msgid "Do you want to fast-forward-merge remote changes after checking out '$1'?"
 msgstr "Хотите выполнить быстрое слияние внешних изменений после переключения на '$1'?"
 
@@ -2585,11 +2585,11 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.chk"
 msgid "Don't show again"
 msgstr "Не спрашивать снова"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.fur%1"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.fur"
 msgid "This will make '$1' your current branch."
 msgstr "Текущей веткой станет '$1'"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl%1"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl"
 msgid "Do you want to checkout the branch '$1'?"
 msgstr "Переключиться на ветку '$1'?"
 
@@ -2677,7 +2677,7 @@ msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr ""
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl%1"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
@@ -3505,7 +3505,7 @@ msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle%3"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
 msgid "\\[$1\\] - \\[$2\\] - $3"
 msgstr ""
 
@@ -3641,7 +3641,7 @@ msgctxt "dlgSgDeleteDirTrash.fur"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.hdl%1"
+msgctxt "dlgSgDeleteDirTrash.hdl"
 msgid "Do you want to delete '$1' recursively?"
 msgstr ""
 
@@ -3649,11 +3649,11 @@ msgctxt "dlgSgDeleteDirTrash.tle"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgDeleteFileTrash.hdl%1"
+msgctxt "dlgSgDeleteFileTrash.hdl"
 msgid "Do you want to delete '$1'?"
 msgstr "Удалить файл '$1'?"
 
-msgctxt "dlgSgDeleteFilesTrash.hdl%1"
+msgctxt "dlgSgDeleteFilesTrash.hdl"
 msgid "Do you want to delete the $1 selected files?"
 msgstr ""
 
@@ -3749,11 +3749,11 @@ msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToHead.hdl%1"
+msgctxt "dlgSgDiscardRevertToHead.hdl"
 msgid "Do you want to reset $1 files back to their HEAD state?"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToIndex.hdl%1"
+msgctxt "dlgSgDiscardRevertToIndex.hdl"
 msgid "Do you want to reset $1 files back to their Index state?"
 msgstr ""
 
@@ -3825,7 +3825,7 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.btn:"
 msgid "Force Opening"
 msgstr ""
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl%1"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl"
 msgid "Could not open Conflict Solver for '$1', because it seems to be no text file."
 msgstr ""
 
@@ -3833,7 +3833,7 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle"
 msgid "Conflict Solver"
 msgstr ""
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.hdl%1"
+msgctxt "dlgSgFileCompareInvokerFailedIO.hdl"
 msgid "'$1' could not be invoked."
 msgstr ""
 
@@ -3873,11 +3873,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.btn:"
 msgid "Fast-Forward"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur%3"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur"
 msgid "The local branch '$1' is behind its tracked branch '$2'. You may fast-forward now or do it manually later, e.g. by checking out the branch '$3'."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl"
 msgid "Should branch '$1' be fast-forwarded to '$2'?"
 msgstr ""
 
@@ -3889,11 +3889,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.btn:"
 msgid "Replace"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur"
 msgid "The local branch '$1' seems to contain more recent but rewritten commits of remote branch '$2'.\\n\\nIf you are not sure whether the local branch is actually more recent than the remote branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl"
 msgid "Should branch '$1' replace remote branch '$2'?"
 msgstr ""
 
@@ -3905,11 +3905,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur"
 msgid "The remote branch '$1' seems to contain more recent but rewritten commits of local branch '$2'.\\n\\nIf you are not sure whether the remote branch is actually more recent than the local branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl"
 msgid "Should branch '$1' be reset to remote branch '$2'?"
 msgstr ""
 
@@ -4093,7 +4093,7 @@ msgctxt "dlgSgFlowFeatureStart.hdl"
 msgid "Start a new feature"
 msgstr "Начало работы над новой задачей"
 
-msgctxt "dlgSgFlowFeatureStart.inf%1"
+msgctxt "dlgSgFlowFeatureStart.inf"
 msgid "Enter the name of the new feature branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Введите имя новой ветки задачи. В результате будет создана новая ветка из ветки '$1'"
 
@@ -4197,7 +4197,7 @@ msgctxt "dlgSgFlowHotfixStart.hdl"
 msgid "Start a new hotfix"
 msgstr "Создание нового хотфикса"
 
-msgctxt "dlgSgFlowHotfixStart.inf%1"
+msgctxt "dlgSgFlowHotfixStart.inf"
 msgid "Enter the name of the new hotfix branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Введите имя новой ветки хотфикса. В результате будет создана новая ветка из ветки '$1'"
 
@@ -4217,7 +4217,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.chk:"
 msgid "Fetch latest '$1' commits from remote repository"
 msgstr "Получить последние изменения ветки '$1' с внешнего репозитория"
 
-msgctxt "dlgSgFlowIntegrateDevelop.hdl%1"
+msgctxt "dlgSgFlowIntegrateDevelop.hdl"
 msgid "Integrate commits from '$1'"
 msgstr "Включение коммитов ветки '$1'"
 
@@ -4329,7 +4329,7 @@ msgctxt "dlgSgFlowReleaseStart.hdl"
 msgid "Start a new release"
 msgstr "Начать выпуск нового релиза"
 
-msgctxt "dlgSgFlowReleaseStart.inf%1"
+msgctxt "dlgSgFlowReleaseStart.inf"
 msgid "Enter the name of the new release branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Введите имя новой ветки релиза. В результате будет создано ответвление новой ветки от ветки '$1'"
 
@@ -4365,7 +4365,7 @@ msgctxt "dlgSgFlowSupportStart.hdl"
 msgid "Start a new support"
 msgstr "Создание новой сервисной ветки"
 
-msgctxt "dlgSgFlowSupportStart.inf%1"
+msgctxt "dlgSgFlowSupportStart.inf"
 msgid "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Введите имя новой сервисной ветки. В результате будет создана новая ветка из ветки '$1'"
 
@@ -4789,7 +4789,7 @@ msgctxt "dlgSgHistoryModifySplitConfirm.fur"
 msgid "'Modify' will stop after the commit.\\n\\n'Split' will put the changes into the Index. You may discard some changes that should go into the second commit.\\n\\nAfter you've done the changes, process the remaining commits by continuing the rebase."
 msgstr ""
 
-msgctxt "dlgSgHistoryModifySplitConfirm.hdl%1"
+msgctxt "dlgSgHistoryModifySplitConfirm.hdl"
 msgid "Do you want to modify or split commit $1?"
 msgstr ""
 
@@ -4805,7 +4805,7 @@ msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl%1"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl"
 msgid "Do you want to replace the remote branch by commit $1?"
 msgstr ""
 
@@ -4821,7 +4821,7 @@ msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur"
 msgid "All commits up to the selected commit will be pushed to the remote repository."
 msgstr "Все коммиты до выбранного будут отправлены во внешний репозиторий."
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl%1"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl"
 msgid "Do you want to push changes up to commit $1?"
 msgstr "Вы хотите отправить изменения коммита $1?"
 
@@ -5185,11 +5185,11 @@ msgctxt "dlgSgHostingProviderEdit.err:"
 msgid "The provided SSL client certificate path is invalid."
 msgstr ""
 
-msgctxt "dlgSgHostingProviderEdit.hdl%1"
+msgctxt "dlgSgHostingProviderEdit.hdl"
 msgid "Configure $1 account"
 msgstr ""
 
-msgctxt "dlgSgHostingProviderEdit.inf%1"
+msgctxt "dlgSgHostingProviderEdit.inf"
 msgid "Please specify your credentials to connect to $1."
 msgstr ""
 
@@ -5301,11 +5301,11 @@ msgctxt "dlgSgHostingProvider(Add|Edit).lbl:"
 msgid "Optional SSL configuration"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur%3"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur"
 msgid "The OAuth-access token could not be requested. Most likely your $1 configuration has changed and SmartGit's stored OAuth credentials are invalid.\\n\\nTo resolve, recreate the $2 hosting provider in the Preferences.\\n\\nDetails:\\n\\n$3"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl%1"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl"
 msgid "$1 OAuth-authentication failed"
 msgstr ""
 
@@ -5329,7 +5329,7 @@ msgctxt "dlgSgHttpPasswordCredentials.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordCredentials.hdl%1"
+msgctxt "dlgSgHttpPasswordCredentials.hdl"
 msgid "Login to '$1'"
 msgstr ""
 
@@ -5381,7 +5381,7 @@ msgctxt "dlgSgIgnoreDirectoryConfirm.fur"
 msgid "The directory name will be added to the ignore file. If the ignore file does not exist, it will be created."
 msgstr ""
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.hdl%1"
+msgctxt "dlgSgIgnoreDirectoryConfirm.hdl"
 msgid "Do you want to ignore directory '$1'?"
 msgstr ""
 
@@ -5505,11 +5505,11 @@ msgctxt "dlgSgJournalDoubleClick.btn:"
 msgid "Open Log"
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.fur%1"
+msgctxt "dlgSgJournalDoubleClick.fur"
 msgid "Select either to check out '$1' or to open the Log for the selected commit."
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.hdl%1"
+msgctxt "dlgSgJournalDoubleClick.hdl"
 msgid "Do you want to check out '$1'?"
 msgstr ""
 
@@ -5585,7 +5585,7 @@ msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.btn:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur%1"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur"
 msgid "You are about to apply lines from the Index to the working tree file '$1'. The modifications will be saved immediately."
 msgstr ""
 
@@ -5637,7 +5637,7 @@ msgctxt "dlgSgLogCheckoutFileAs.tle"
 msgid "Save File As"
 msgstr ""
 
-msgctxt "dlgSgLogCommentDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogCommentDeleteConfirm.hdl"
 msgid "Do you really want to delete comment '$1'?"
 msgstr ""
 
@@ -5653,7 +5653,7 @@ msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle"
 msgid "Delete Comment"
 msgstr ""
 
-msgctxt "dlgSgLogCommentsDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogCommentsDeleteConfirm.hdl"
 msgid "Do you really want to delete $1 comments?"
 msgstr ""
 
@@ -5797,7 +5797,7 @@ msgctxt "dlgSgLogRefActionsDeleteConfirm.fur"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr ""
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl"
 msgid "Do you really want to delete the local branch '$1'?"
 msgstr ""
 
@@ -5813,11 +5813,11 @@ msgctxt "dlgSgLogRefreshRepositoryInvalid.btn:"
 msgid "Remove Repository"
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.fur%1"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.fur"
 msgid "This could mean that the repository at\\n\\n$1was removed or renamed outside SmartGit."
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl%1"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl"
 msgid "The opened repository '$1' became invalid."
 msgstr ""
 
@@ -5953,7 +5953,7 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.fur"
 msgid "The specified directory does not appear to be a valid Git repository."
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.hdl%1"
+msgctxt "dlgSgOpenRepositoryInitializeGit.hdl"
 msgid "Should '$1' be initialized as a new Git repository?"
 msgstr ""
 
@@ -5961,7 +5961,7 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.tle"
 msgid "Add or Create Repository"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur%1"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr ""
 
@@ -6201,11 +6201,11 @@ msgctxt "dlgSgOutput.tle:"
 msgid "Output"
 msgstr ""
 
-msgctxt "dlgSgPingRepositoryFailed.fur%1"
+msgctxt "dlgSgPingRepositoryFailed.fur"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr ""
 
-msgctxt "dlgSgPingRepositoryFailed.hdl%1"
+msgctxt "dlgSgPingRepositoryFailed.hdl"
 msgid "Could not connect to the repository '$1'."
 msgstr "Не удалось подключиться к репозиторию '$1'."
 
@@ -7513,7 +7513,7 @@ msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.hdl%1"
+msgctxt "dlgSgProviderGenerateToken.hdl"
 msgid "Generate a new API token for $1"
 msgstr ""
 
@@ -7573,7 +7573,7 @@ msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur"
 msgid "The merge request itself will not be deleted on the server."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl%1"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl"
 msgid "Do you really want to drop the local commits of merge request $1?"
 msgstr ""
 
@@ -7589,7 +7589,7 @@ msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur"
 msgid "The pull request itself will not be deleted on the server."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl%1"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl"
 msgid "Do you want to drop the local commits of pull request $1?"
 msgstr ""
 
@@ -7725,7 +7725,7 @@ msgctxt "dlgSgPullMergeInsteadOfRebase.btn:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.fur%1"
+msgctxt "dlgSgPullMergeInsteadOfRebase.fur"
 msgid "Amongst the changes to rebase there is merge-commit $1. Rebasing merge-commits can easily cause troubles."
 msgstr ""
 
@@ -7773,7 +7773,7 @@ msgctxt "dlgSgPullOrJustFetch.fur"
 msgid "You can change the Pull behavior in the Repository Settings."
 msgstr ""
 
-msgctxt "dlgSgPullOrJustFetch.hdl%1"
+msgctxt "dlgSgPullOrJustFetch.hdl"
 msgid "Do you want to pull or just fetch $1 repositories?"
 msgstr ""
 
@@ -7801,11 +7801,11 @@ msgctxt "dlgSgPushConfirmSingleBranch.chk"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgPushConfirmSingleBranch.fur%1"
+msgctxt "dlgSgPushConfirmSingleBranch.fur"
 msgid "1 branch will be pushed to '$1'."
 msgstr "1 ветка будет отправлена в '$1'."
 
-msgctxt "dlgSgPushConfirmSingleBranch.hdl%1"
+msgctxt "dlgSgPushConfirmSingleBranch.hdl"
 msgid "Do you want to push branch '$1'?"
 msgstr "Вы хотите отправить ветку '$1'?"
 
@@ -7989,11 +7989,11 @@ msgctxt "dlgSgPushToRemote.edt:"
 msgid "Target Repository"
 msgstr "Репозиторий доставки"
 
-msgctxt "dlgSgPushToRemote.hdl%1"
+msgctxt "dlgSgPushToRemote.hdl"
 msgid "Push '$1' branches to another remote"
 msgstr "Отправка веток '$1' в другой внешний репозиторий"
 
-msgctxt "dlgSgPushToRemote.inf%1"
+msgctxt "dlgSgPushToRemote.inf"
 msgid "All branches of '$1' \\(as locally represented by the corresponding remote branches\\) will be pushed to the target repository."
 msgstr "Все ветки '$1' \\(локальные, связанные с внешними\\) будут отправлены в указанный репозиторий."
 
@@ -8049,7 +8049,7 @@ msgctxt "dlgSgPushTrackingConfigureSingle.fur"
 msgid "For your current branch tracking \\(its corresponding remote branch\\) has not been configured yet. Configuring tracking will keep your local branches in sync with the remote branches."
 msgstr ""
 
-msgctxt "dlgSgPushTrackingConfigureSingle.hdl%1"
+msgctxt "dlgSgPushTrackingConfigureSingle.hdl"
 msgid "Do you want to configure tracking for '$1' branch?"
 msgstr ""
 
@@ -8085,7 +8085,7 @@ msgctxt "dlgSgRebaseConfirmUnreachable.fur"
 msgid "You only might be able to access this commit using the 'Recyclable Commits' option of the Branches view."
 msgstr ""
 
-msgctxt "dlgSgRebaseConfirmUnreachable.hdl%1"
+msgctxt "dlgSgRebaseConfirmUnreachable.hdl"
 msgid "The Commit $1 would become unreachable by refs."
 msgstr ""
 
@@ -8101,7 +8101,7 @@ msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur%1"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur"
 msgid "The splitting of commit $1 still is in progress and all changes of this commit have been applied."
 msgstr ""
 
@@ -8241,7 +8241,7 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.btn:"
 msgid "Put Changes into Index"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur%1"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur"
 msgid "The splitting of commit $1 still is in progress, but not all changes of this commit have been applied.\\n\\nIf this is intentional, you can continue. Otherwise, you should click 'Put Changes into Index' and review your changes."
 msgstr ""
 
@@ -8253,19 +8253,19 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur%1"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) onto the selected commit."
 msgstr "Все коммиты рабочего каталога ветки '$1' \\(HEAD\\) будут применены поверх выбранного коммита."
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl%1"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl"
 msgid "Do you want to rebase '$1' onto the selected commit?"
 msgstr "Вы хотите переместить '$1' поверх выбранного коммита?"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur%2"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) to '$2'."
 msgstr "Все коммиты рабочего каталога ветки '$1' \\(HEAD\\) будут применены поверх '$2'."
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl%2"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl"
 msgid "Do you want to rebase '$1' to '$2'?"
 msgstr "Вы хотите переместить '$1' поверх '$2'?"
 
@@ -8385,7 +8385,7 @@ msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur"
 msgid "It might become hard or impossible to recover the commit again."
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl%1"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl"
 msgid "Do you want to remove the selected commit $1?"
 msgstr ""
 
@@ -8429,7 +8429,7 @@ msgctxt "dlgSgRebaseTagCommit.fur"
 msgid "After the rebase, the remaining commit won't be reachable anymore."
 msgstr ""
 
-msgctxt "dlgSgRebaseTagCommit.hdl%1"
+msgctxt "dlgSgRebaseTagCommit.hdl"
 msgid "Should commit $1 be tagged?"
 msgstr ""
 
@@ -8521,7 +8521,7 @@ msgctxt "dlgSgRemoteDeleteConfirm.fur"
 msgid "This will just delete the link to the remote repository."
 msgstr "Эта операция удалит ссылку на внешний репозиторий."
 
-msgctxt "dlgSgRemoteDeleteConfirm.hdl%1"
+msgctxt "dlgSgRemoteDeleteConfirm.hdl"
 msgid "Do you want to delete the remote repository '$1'?"
 msgstr "Вы хотите удалить внешний репозиторий '$1'?"
 
@@ -8681,7 +8681,7 @@ msgctxt "dlgSgRemotesAdd.tle"
 msgid "Add Remote Repository"
 msgstr "Добавление внешнего репозитория"
 
-msgctxt "dlgSgRemotesNoRemoteDetected.fur%1"
+msgctxt "dlgSgRemotesNoRemoteDetected.fur"
 msgid "To perform the operation the repository configuration for $1 must contain one uniquely determined remote."
 msgstr ""
 
@@ -8733,7 +8733,7 @@ msgctxt "dlgSgRenameBranch.hdl"
 msgid "Rename branch"
 msgstr "Переименование ветки"
 
-msgctxt "dlgSgRenameBranch.inf%1"
+msgctxt "dlgSgRenameBranch.inf"
 msgid "Enter the new name for the branch '$1'."
 msgstr "Введите новое имя для ветки '$1'."
 
@@ -8929,7 +8929,7 @@ msgctxt "dlgSgRepositoryOpen.fur"
 msgid "If it is relocated, remove it and add its new location."
 msgstr ""
 
-msgctxt "dlgSgRepositoryOpen.hdl%1"
+msgctxt "dlgSgRepositoryOpen.hdl"
 msgid "Do you want to remove the missing repository '$1'?"
 msgstr ""
 
@@ -8941,7 +8941,7 @@ msgctxt "dlgSgRepositoryRemoveFailed1.fur"
 msgid "This could happen if the repository is open in another window or currently commands are executed."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveFailed1.hdl%1"
+msgctxt "dlgSgRepositoryRemoveFailed1.hdl"
 msgid "The repository '$1' could not be removed."
 msgstr ""
 
@@ -8953,7 +8953,7 @@ msgctxt "dlgSgRepositoryRemoveMultiGroup.fur"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl%1"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl"
 msgid "Do you want to remove $1 groups?"
 msgstr ""
 
@@ -8961,7 +8961,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepo.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "Репозитории на диске останутся, но SmartGit забудет о них."
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl%1"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl"
 msgid "Do you want to remove $1 repositories?"
 msgstr "Вы хотите удалить $1 репозитория\\(ев\\)?"
 
@@ -8969,7 +8969,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "Репозитории на диске останутся, но SmartGit забудет о них. Репозитории удаляемых групп будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl"
 msgid "Do you want to remove $1 repositories and $2 groups?"
 msgstr "Вы хотите удалить $1 репозитория\\(ев\\) и $2 групп\\(ы\\)?"
 
@@ -8977,7 +8977,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "Репозитории останутся на диске, но SmartGit забудет о них. Репозитории удаляемой группы будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl"
 msgid "Do you want to remove $1 repositories and the group \"$2\"?"
 msgstr "Вы хотите удалить $1 репозитория\\(ев\\) и группу \"$2\"?"
 
@@ -8985,7 +8985,7 @@ msgctxt "dlgSgRepositoryRemoveSingleGroup.fur"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "Репозитории удаляемой группы будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl%1"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl"
 msgid "Do you want to remove the group \"$1\"?"
 msgstr "Вы хотите удалить группу \"$1\"?"
 
@@ -8993,7 +8993,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepo.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "Репозиторий на диске останется, но SmartGit забудет о нем."
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl%1"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl"
 msgid "Do you want to remove the repository \"$1\"?"
 msgstr "Вы хотите удалить репозиторий \"$1\"?"
 
@@ -9001,7 +9001,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "Репозиторий на диске останется, но SmartGit забудет о нем. Репозитории удаляемых групп будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl"
 msgid "Do you want to remove the repository \"$1\" and $2 groups?"
 msgstr "Вы хотите удалить репозиторий \"$1\" и $2 групп\\(ы\\)?"
 
@@ -9009,7 +9009,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "Репозиторий на диске останется, но SmartGit забудет о нем. Репозитории удаляемой группы будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl"
 msgid "Do you want to remove the repository \"$1\" and the group \"$2\"?"
 msgstr "Вы хотите удалить репозиторий \"$1\" и группу \"$2\"?"
 
@@ -9169,7 +9169,7 @@ msgctxt "dlgSgResetAdv.chk:"
 msgid "Thoroughly fix line-endings according to .gitattributes"
 msgstr "Исправить окончания строк в соответствии с .gitattributes"
 
-msgctxt "dlgSgResetAdv.hdl%1"
+msgctxt "dlgSgResetAdv.hdl"
 msgid "Reset to commit $1"
 msgstr "Сброс состояния к коммиту $1"
 
@@ -9229,7 +9229,7 @@ msgctxt "dlgSgResetConfirm.fur"
 msgid "Current staged and local changes will be lost!"
 msgstr "Все внесенные изменения будут утеряны!"
 
-msgctxt "dlgSgResetConfirm.hdl%1"
+msgctxt "dlgSgResetConfirm.hdl"
 msgid "Do you want to reset the HEAD to commit $1?"
 msgstr "Вы хотите сбросить состояние к коммиту $1?"
 
@@ -9289,7 +9289,7 @@ msgctxt "dlgSgResolveManuallyModifiedSingle.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.fur%1"
+msgctxt "dlgSgResolveManuallyModifiedSingle.fur"
 msgid "$1 seems to contain manual conflict resolutions. They will be lost when continuing."
 msgstr ""
 
@@ -9337,7 +9337,7 @@ msgctxt "dlgSgRevealCommitLocalOrTracked.chk"
 msgid "Always reveal local branch"
 msgstr "Всегда переходить к локальной ветке"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.fur%2"
+msgctxt "dlgSgRevealCommitLocalOrTracked.fur"
 msgid "Select whether to reveal '$1' or '$2'."
 msgstr "Выберите к какой перейти '$1' или '$2'."
 
@@ -9725,7 +9725,7 @@ msgctxt "dlgSgRollbackToCommit.fur"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr "Все различия между HEAD и выбранным коммитом будут сохранены в рабочем каталоге."
 
-msgctxt "dlgSgRollbackToCommit.hdl%1"
+msgctxt "dlgSgRollbackToCommit.hdl"
 msgid "Do you want to rollback the Index to the state of commit $1?"
 msgstr "Вы хотите откатить изменения инндекса к состоянию коммита $1?"
 
@@ -9977,7 +9977,7 @@ msgctxt "dlgSgSetupStdWnd.hdl"
 msgid "Do you want to use the Standard Window?"
 msgstr ""
 
-msgctxt "dlgSgSetupStdWnd.tle%1"
+msgctxt "dlgSgSetupStdWnd.tle"
 msgid "Setup SmartGit $1"
 msgstr ""
 
@@ -9985,7 +9985,7 @@ msgctxt "dlgSgShowLocalChanges.btn:"
 msgid "Compare"
 msgstr ""
 
-msgctxt "dlgSgShowLocalChanges.hdl%1"
+msgctxt "dlgSgShowLocalChanges.hdl"
 msgid "File $1 modified in Index and working tree"
 msgstr ""
 
@@ -10085,7 +10085,7 @@ msgctxt "dlgSgSshCredentials.hdl"
 msgid "SSH Credentials"
 msgstr ""
 
-msgctxt "dlgSgSshCredentials.inf%2"
+msgctxt "dlgSgSshCredentials.inf"
 msgid "Provide the credentials for authenticating to the SSH server '$1' as user '$2'."
 msgstr ""
 
@@ -10117,7 +10117,7 @@ msgctxt "dlgSgStageConflict.fur"
 msgid "The file contains conflict markers which indicate that you have not resolved all conflicts."
 msgstr "Файл содержит отметки, указывающие на то, что конфликты не были разрешены."
 
-msgctxt "dlgSgStageConflict.hdl%1"
+msgctxt "dlgSgStageConflict.hdl"
 msgid "Should $1 really be staged?"
 msgstr "Проиндексировать файл $1?"
 
@@ -10505,7 +10505,7 @@ msgctxt "dlgSgSubmoduleDeinitConfirm.fur"
 msgid "The submodule will be skipped from the working tree. To get rid from the \\(remote\\) repository, you have to use Unregister instead."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.hdl%1"
+msgctxt "dlgSgSubmoduleDeinitConfirm.hdl"
 msgid "Do you want to deinit submodule '$1'?"
 msgstr ""
 
@@ -10581,7 +10581,7 @@ msgctxt "dlgSgSubmoduleResetConfirm.fur"
 msgid "The corresponding commit will be checked out, so the submodule content will match the content of the registered commit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetConfirm.hdl%1"
+msgctxt "dlgSgSubmoduleResetConfirm.hdl"
 msgid "Do you want to reset submodule '$1' to the commit registered in the repository?"
 msgstr ""
 
@@ -10729,7 +10729,7 @@ msgctxt "dlgSgSvnClientCertificate.hdl"
 msgid "Client Certificate"
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.inf%1"
+msgctxt "dlgSgSvnClientCertificate.inf"
 msgid "Provide the client certificate for authentication to the SVN repository '$1'."
 msgstr ""
 
@@ -10837,7 +10837,7 @@ msgctxt "dlgSgTagAddOverwrite.fur"
 msgid "Click 'Cancel' to choose a different tag name."
 msgstr "Нажмите 'Отмена' для ввода другого имени."
 
-msgctxt "dlgSgTagAddOverwrite.hdl%1"
+msgctxt "dlgSgTagAddOverwrite.hdl"
 msgid "The tag '$1' already exists. Do you want to overwrite it?"
 msgstr "Метка '$1' уже существует. Переписать ее?"
 
@@ -10853,7 +10853,7 @@ msgctxt "dlgSgTagDeleteConfirmSingle.chk"
 msgid "Delete from all remotes"
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk%1"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk"
 msgid "Delete from remote '$1'"
 msgstr "Удалить во внешнем '$1'"
 
@@ -10861,7 +10861,7 @@ msgctxt "dlgSgTagDeleteConfirmSingle.fur"
 msgid "You will not be able to restore it."
 msgstr "Вы не сможете ее восстановить после удаления."
 
-msgctxt "dlgSgTagDeleteConfirmSingle.hdl%1"
+msgctxt "dlgSgTagDeleteConfirmSingle.hdl"
 msgid "Do you want to delete the tag '$1'?"
 msgstr "Вы хотите удалить метку '$1'?"
 

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -2011,10 +2011,6 @@ msgstr "Вы хотите прервать перемещение?"
 
 msgctxt "dlgSgAbortRebasingConfirm.tle:"
 msgid "Abort"
-msgstr ""
-
-msgctxt "dlgSgAbortRebasingConfirm.tle:"
-msgid "Abort"
 msgstr "Прерывание операции"
 
 msgctxt "dlgSgAbortRevertingConfirm.btn:"
@@ -2371,10 +2367,6 @@ msgstr "Вы можете потерять неотправленные изме
 
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
-msgstr ""
-
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
-msgid "Do you want to delete $1 local branches?"
 msgstr "Вы хотите удалить $1 локальные ветки?"
 
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle:"
@@ -2411,10 +2403,6 @@ msgstr "Локальная ветка отслеживает '$1'. Решите,
 
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
-msgstr ""
-
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
-msgid "Do you want to delete the local branch '$1'?"
 msgstr "Вы хотите удалить локальную ветку '$1'?"
 
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle:"
@@ -2434,16 +2422,12 @@ msgid "Delete"
 msgstr "Удалить"
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
-msgid "Delete from remote repository '$1'"
-msgstr "Удалить во внешнем репозитории '$1'"
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
 msgstr ""
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
-msgstr ""
+msgstr "Удалить во внешнем репозитории '$1'"
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur:"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
@@ -2452,10 +2436,6 @@ msgstr "Если не удалить ветку во внешнем репози
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the branch '$1'?"
 msgstr "Хотите удалить ветку '$1'?"
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
-msgid "Do you want to delete the branch '$1'?"
-msgstr ""
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
@@ -3762,10 +3742,6 @@ msgid "Discard"
 msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
-msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-msgstr ""
-
-msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Commit '$1' was not found in repository."
 msgstr ""
 
@@ -3779,6 +3755,10 @@ msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Repository '$1' is not valid."
+msgstr ""
+
+msgctxt "dlgSgErrorUtilsClientException.fur:"
+msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
 msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
@@ -10310,16 +10290,16 @@ msgid "What to do with the working tree or Index changes?"
 msgstr "Что делать с изменениями в рабочем каталоге или индексе?"
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
-msgid "Reset"
-msgstr "Сброс изменений"
-
-msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Checkout"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
 msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Reset"
+msgstr "Сброс изменений"
 
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
 msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
@@ -14802,16 +14782,12 @@ msgid "Use Message for Commit"
 msgstr "Использовать сообщение для коммита"
 
 msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
-msgid "Configure"
-msgstr "Настроить"
-
-msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure Features"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure"
-msgstr ""
+msgstr "Настроить"
 
 msgctxt "wnd(Log|Project|Std|).mniFlowContext:"
 msgid "Git-Flow"
@@ -14994,10 +14970,6 @@ msgid "Open from Working Tree"
 msgstr "Открыть в рабочем каталоге"
 
 msgctxt "wnd(Log|Project|Std|).mniOpen:"
-msgid "Open from Working Tree"
-msgstr "Открыть в рабочем каталоге"
-
-msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open"
 msgstr ""
 
@@ -15092,10 +15064,6 @@ msgstr "Пропустить"
 msgctxt "wnd(Log|Project|Std|).mniRebaseStep:"
 msgid "Step"
 msgstr "Далее"
-
-msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
-msgid "Rebase to HEAD"
-msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD \\($1\\)"
@@ -15276,10 +15244,6 @@ msgstr ""
 msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase:"
 msgid "Dump Database"
 msgstr ""
-
-msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
-msgid "Create Pull Request"
-msgstr "Создать PR"
 
 msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Merge Request"
@@ -16187,10 +16151,6 @@ msgstr "Применение коммитов текущей ветки пове
 
 msgctxt "wnd(Log|Project|Std|).tbtRefresh:"
 msgid "Refresh the log view."
-msgstr ""
-
-msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
-msgid "Fetch commits from current remote repository."
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -39,7 +39,7 @@ msgstr "OK"
 
 msgctxt "*.chk:"
 msgid "Don't show again"
-msgstr ""
+msgstr "Не показывать снова"
 
 msgctxt "*.hnt:"
 msgid "Filter"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -101,19 +101,19 @@ msgctxt "dlgCommit.replaceMessage.btn:"
 msgid "Replace"
 msgstr ""
 
-msgctxt "dlgCommit.replaceMessage.chk"
+msgctxt "dlgCommit.replaceMessage.chk:"
 msgid "Always replace"
 msgstr ""
 
-msgctxt "dlgCommit.replaceMessage.fur"
+msgctxt "dlgCommit.replaceMessage.fur:"
 msgid "After replacing you can find the previous message when clicking the history button."
 msgstr ""
 
-msgctxt "dlgCommit.replaceMessage.hdl"
+msgctxt "dlgCommit.replaceMessage.hdl:"
 msgid "Replace the existing message?"
 msgstr ""
 
-msgctxt "dlgCommit.replaceMessage.tle"
+msgctxt "dlgCommit.replaceMessage.tle:"
 msgid "Replace Message"
 msgstr ""
 
@@ -121,11 +121,11 @@ msgctxt "dlgCommitGitHubConfirmEmail.btn:"
 msgid "Confirm Email"
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.fur"
+msgctxt "dlgCommitGitHubConfirmEmail.fur:"
 msgid "If this repository is open-source, you might want to hide your email address, as \\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\], and use instead <username>@users.noreply.github.com."
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.hdl"
+msgctxt "dlgCommitGitHubConfirmEmail.hdl:"
 msgid "Commit with default email address $1?"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgctxt "dlgCommitGitHubConfirmEmail.rbt:"
 msgid "Use following email address:"
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.tle"
+msgctxt "dlgCommitGitHubConfirmEmail.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -149,31 +149,31 @@ msgctxt "dlgCommitInvisibleIndex.btn:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "dlgCommitInvisibleIndex.fur"
+msgctxt "dlgCommitInvisibleIndex.fur:"
 msgid "Some staged files are not visible at the moment."
 msgstr ""
 
-msgctxt "dlgCommitInvisibleIndex.hdl"
+msgctxt "dlgCommitInvisibleIndex.hdl:"
 msgid "Commit invisible staged files?"
 msgstr ""
 
-msgctxt "dlgCommitInvisibleIndex.tle"
+msgctxt "dlgCommitInvisibleIndex.tle:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.chk"
+msgctxt "dlgCommitView.hiddenOptions.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgCommitView.hiddenOptions.fur"
+msgctxt "dlgCommitView.hiddenOptions.fur:"
 msgid "To use the options, they need to remain visible."
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.hdl"
+msgctxt "dlgCommitView.hiddenOptions.hdl:"
 msgid "Hidden options will be treated as unselected."
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.tle"
+msgctxt "dlgCommitView.hiddenOptions.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -217,27 +217,27 @@ msgctxt "dlgDgAbout.tab:"
 msgid "Licensee"
 msgstr ""
 
-msgctxt "dlgDgAbout.tle"
+msgctxt "dlgDgAbout.tle:"
 msgid "About DeepGit"
 msgstr ""
 
-msgctxt "dlgDgClientException.hdl"
+msgctxt "dlgDgClientException.hdl:"
 msgid "Executing a command has failed."
 msgstr ""
 
-msgctxt "dlgDgClientException.tle"
+msgctxt "dlgDgClientException.tle:"
 msgid "Command Failed"
 msgstr ""
 
-msgctxt "dlgDgRefMapperGroupConfig.hdl"
+msgctxt "dlgDgRefMapperGroupConfig.hdl:"
 msgid "Configure patterns for grouping tags of this repository"
 msgstr ""
 
-msgctxt "dlgDgRefMapperGroupConfig.inf"
+msgctxt "dlgDgRefMapperGroupConfig.inf:"
 msgid "Tags, branches and other refs matched by this configuration will be displayed in the Navigation graph."
 msgstr ""
 
-msgctxt "dlgDgRefMapperGroupConfig.tle"
+msgctxt "dlgDgRefMapperGroupConfig.tle:"
 msgid "Configure Tag-Grouping"
 msgstr ""
 
@@ -245,31 +245,31 @@ msgctxt "dlgDgSetEncoding.edt:"
 msgid "Text File Encoding"
 msgstr ""
 
-msgctxt "dlgDgSetEncoding.hdl"
+msgctxt "dlgDgSetEncoding.hdl:"
 msgid "Configure Encoding"
 msgstr ""
 
-msgctxt "dlgDgSetEncoding.inf"
+msgctxt "dlgDgSetEncoding.inf:"
 msgid "Specify the encoding which should be used for processing and viewing files. Note, that UTF-8 encoding will be auto-detected, regardless of the configuration here."
 msgstr ""
 
-msgctxt "dlgDgSetEncoding.tle"
+msgctxt "dlgDgSetEncoding.tle:"
 msgid "Set Encoding"
 msgstr ""
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.fur"
+msgctxt "dlgDgSetPerspectiveCantSwitch.fur:"
 msgid "In order to inspect available Origins, they have to be evaluated first. Select a line in the Blame view. Then wait until the calculation of possible Origins has finished."
 msgstr ""
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.hdl"
+msgctxt "dlgDgSetPerspectiveCantSwitch.hdl:"
 msgid "Can't switch perspective."
 msgstr ""
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.tle"
+msgctxt "dlgDgSetPerspectiveCantSwitch.tle:"
 msgid "Origins Perspective"
 msgstr ""
 
-msgctxt "dlgInfo.tle"
+msgctxt "dlgInfo.tle:"
 msgid "Discard"
 msgstr ""
 
@@ -325,15 +325,15 @@ msgctxt "dlgProgress.tle:"
 msgid "Verifying executables"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.fur"
+msgctxt "dlgQBugFileSendingFailed.fur:"
 msgid "Maybe you need to configure a proxy or our server is temporarily down.\\nDetails: $1"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.hdl"
+msgctxt "dlgQBugFileSendingFailed.hdl:"
 msgid "Could not send the crash logs to $1"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.tle"
+msgctxt "dlgQBugFileSendingFailed.tle:"
 msgid "Native Crash Logs"
 msgstr ""
 
@@ -389,23 +389,23 @@ msgctxt "dlgQBugReportSend.lbl:"
 msgid "What did you do? We often solve a difficult bug after receiving just one good hint!"
 msgstr ""
 
-msgctxt "dlgQBugReportSend.tle"
+msgctxt "dlgQBugReportSend.tle:"
 msgid "Internal Error"
 msgstr ""
 
-msgctxt "dlgQDockManagerClosedView.chk"
+msgctxt "dlgQDockManagerClosedView.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgQDockManagerClosedView.fur"
+msgctxt "dlgQDockManagerClosedView.fur:"
 msgid "To reopen it again, use the corresponding menu item from the Window menu."
 msgstr "Для открытия панели снова, воспользуйтесь соответствующим пунктом в меню Окно."
 
-msgctxt "dlgQDockManagerClosedView.hdl"
+msgctxt "dlgQDockManagerClosedView.hdl:"
 msgid "You've closed the view '$1'."
 msgstr "Вы закрыли панель '$1'."
 
-msgctxt "dlgQDockManagerClosedView.tle"
+msgctxt "dlgQDockManagerClosedView.tle:"
 msgid "Closed View"
 msgstr "Закрытие панели"
 
@@ -413,15 +413,15 @@ msgctxt "dlgQFileSaveAcceptFilterOverwrite.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur:"
 msgid "To save to a different file, click 'Cancel'."
 msgstr ""
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl:"
 msgid "The file $1 already exists. Do you want to overwrite it?"
 msgstr ""
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.tle"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.tle:"
 msgid "Overwrite File"
 msgstr ""
 
@@ -441,23 +441,23 @@ msgctxt "dlgQFrameManagerExit.fur:"
 msgid "There are unsaved changes which would be lost when exiting now!"
 msgstr ""
 
-msgctxt "dlgQFrameManagerExit.hdl"
+msgctxt "dlgQFrameManagerExit.hdl:"
 msgid "Do you really want to exit SmartGit?"
 msgstr "Вы действительно хотите выйти из SmartGit?"
 
-msgctxt "dlgQFrameManagerExit.tle"
+msgctxt "dlgQFrameManagerExit.tle:"
 msgid "Exit"
 msgstr "Выйти"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.fur"
+msgctxt "dlgQIntegerInputProviderInvalidValue.fur:"
 msgid "Port must be in the range from $1 to $2."
 msgstr ""
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.hdl"
+msgctxt "dlgQIntegerInputProviderInvalidValue.hdl:"
 msgid "The text in field '$1' is not valid."
 msgstr ""
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.tle"
+msgctxt "dlgQIntegerInputProviderInvalidValue.tle:"
 msgid "Input Validation"
 msgstr ""
 
@@ -497,7 +497,7 @@ msgctxt "dlgQProxyConfigure.rbt:"
 msgid "Use following proxy"
 msgstr ""
 
-msgctxt "dlgQProxyConfigure.tle"
+msgctxt "dlgQProxyConfigure.tle:"
 msgid "Configure Proxy"
 msgstr ""
 
@@ -509,15 +509,15 @@ msgctxt "dlgQProxyConnectionFailed.btn:"
 msgid "Retry"
 msgstr ""
 
-msgctxt "dlgQProxyConnectionFailed.fur"
+msgctxt "dlgQProxyConnectionFailed.fur:"
 msgid "Details: syntevo.com"
 msgstr ""
 
-msgctxt "dlgQProxyConnectionFailed.hdl"
+msgctxt "dlgQProxyConnectionFailed.hdl:"
 msgid "Could not connect to $1."
 msgstr ""
 
-msgctxt "dlgQProxyConnectionFailed.tle"
+msgctxt "dlgQProxyConnectionFailed.tle:"
 msgid "Connection Failed"
 msgstr ""
 
@@ -537,27 +537,27 @@ msgctxt "dlgQUpdateCheckForNewVersion.btn:"
 msgid "Skip"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersion.hdl"
+msgctxt "dlgQUpdateCheckForNewVersion.hdl:"
 msgid "SmartGit needs to check for updates"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersion.inf"
+msgctxt "dlgQUpdateCheckForNewVersion.inf:"
 msgid "If necessary, please configure the proxy and retry."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersion.tle"
+msgctxt "dlgQUpdateCheckForNewVersion.tle:"
 msgid "Check for New Version"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.fur"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.fur:"
 msgid "Details: Failed to connect to '$1'."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.hdl"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.hdl:"
 msgid "Checking for new versions has failed."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.tle"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.tle:"
 msgid "Check for New Version"
 msgstr ""
 
@@ -565,27 +565,27 @@ msgctxt "dlgQUpdateCheckLatestBuild.btn:"
 msgid "Get Latest Build"
 msgstr "Получить"
 
-msgctxt "dlgQUpdateCheckLatestBuild.fur"
+msgctxt "dlgQUpdateCheckLatestBuild.fur:"
 msgid "Only use the latest build if requested by the support team."
 msgstr "Используйте последнюю сборку только по просьбе команды поддержки."
 
-msgctxt "dlgQUpdateCheckLatestBuild.hdl"
+msgctxt "dlgQUpdateCheckLatestBuild.hdl:"
 msgid "Do you want to download the latest build?"
 msgstr "Вы хотите скачать последнюю сборку?"
 
-msgctxt "dlgQUpdateCheckLatestBuild.tle"
+msgctxt "dlgQUpdateCheckLatestBuild.tle:"
 msgid "Check for Latest Build"
 msgstr "Проверка наличия свежей сборки"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur:"
 msgid "Details: $1"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.hdl"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.hdl:"
 msgid "Initializing upgrade failed."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.tle"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.tle:"
 msgid "Check for Latest Build"
 msgstr ""
 
@@ -593,39 +593,39 @@ msgctxt "dlgQUpdateCheckNewVersion.btn:"
 msgid "Download"
 msgstr "Скачать"
 
-msgctxt "dlgQUpdateCheckNewVersion.fur"
+msgctxt "dlgQUpdateCheckNewVersion.fur:"
 msgid "It's recommended to update to the new version."
 msgstr "Рекоммендуем выполнить обновление до новой версии."
 
-msgctxt "dlgQUpdateCheckNewVersion.hdl"
+msgctxt "dlgQUpdateCheckNewVersion.hdl:"
 msgid "A new version of SmartGit is available."
 msgstr "Доступна новая версия SmartGit"
 
-msgctxt "dlgQUpdateCheckNewVersion.tle"
+msgctxt "dlgQUpdateCheckNewVersion.tle:"
 msgid "Check for New Version"
 msgstr "Проверка наличия новой версии"
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.fur"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.fur:"
 msgid "You are already using the latest build."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.hdl"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.hdl:"
 msgid "No newer build found."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.tle"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.tle:"
 msgid "Check for Latest Build"
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.fur"
+msgctxt "dlgQUpdateCheckNowNewerVersion.fur:"
 msgid "You are already using the latest version."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.hdl"
+msgctxt "dlgQUpdateCheckNowNewerVersion.hdl:"
 msgid "No newer version found."
 msgstr ""
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.tle"
+msgctxt "dlgQUpdateCheckNowNewerVersion.tle:"
 msgid "Check for New Version"
 msgstr ""
 
@@ -653,15 +653,15 @@ msgctxt "dlgRewriteTextFiles.edt:"
 msgid "Line-Endings"
 msgstr "Окончания строк"
 
-msgctxt "dlgRewriteTextFiles.hdl"
+msgctxt "dlgRewriteTextFiles.hdl:"
 msgid "Rewrite text files with selected line-endings"
 msgstr "Перезаписывает текстовые файлы с указанными разделителями строк"
 
-msgctxt "dlgRewriteTextFiles.inf"
+msgctxt "dlgRewriteTextFiles.inf:"
 msgid "Select the line-endings that should be used to write the text files."
 msgstr "Выберите вид окончаний строк, который следует использовать при записи текстовых файлов."
 
-msgctxt "dlgRewriteTextFiles.tle"
+msgctxt "dlgRewriteTextFiles.tle:"
 msgid "Fix Line-Endings"
 msgstr "Исправление окончаний строк"
 
@@ -669,15 +669,15 @@ msgctxt "dlgScAboutUpdateInstallation.btn:"
 msgid "Upgrade Installation"
 msgstr ""
 
-msgctxt "dlgScAboutUpdateInstallation.fur"
+msgctxt "dlgScAboutUpdateInstallation.fur:"
 msgid "This will take a few moments and has to restart SmartGit."
 msgstr ""
 
-msgctxt "dlgScAboutUpdateInstallation.hdl"
+msgctxt "dlgScAboutUpdateInstallation.hdl:"
 msgid "Do you want to upgrade the installation directory to version $1?"
 msgstr ""
 
-msgctxt "dlgScAboutUpdateInstallation.tle"
+msgctxt "dlgScAboutUpdateInstallation.tle:"
 msgid "Upgrade Installation"
 msgstr ""
 
@@ -693,59 +693,59 @@ msgctxt "dlgScApplicationStarterRestart.btn:"
 msgid "Restart"
 msgstr ""
 
-msgctxt "dlgScApplicationStarterRestart.fur"
+msgctxt "dlgScApplicationStarterRestart.fur:"
 msgid "The downloaded program update should be applied now."
 msgstr ""
 
-msgctxt "dlgScApplicationStarterRestart.hdl"
+msgctxt "dlgScApplicationStarterRestart.hdl:"
 msgid "SmartGit requires a restart."
 msgstr ""
 
-msgctxt "dlgScApplicationStarterRestart.tle"
+msgctxt "dlgScApplicationStarterRestart.tle:"
 msgid "Restart"
 msgstr ""
 
-msgctxt "dlgScConflictSolverAdd.hdl"
+msgctxt "dlgScConflictSolverAdd.hdl:"
 msgid "Add conflict solver"
 msgstr "Добавить решатель конфликтов"
 
-msgctxt "dlgScConflictSolverAdd.tle"
+msgctxt "dlgScConflictSolverAdd.tle:"
 msgid "Add"
 msgstr "Добавление"
 
-msgctxt "dlgScConflictSolverEdit.hdl"
+msgctxt "dlgScConflictSolverEdit.hdl:"
 msgid "Edit conflict solver"
 msgstr "Редактировать решатель конфликтов"
 
-msgctxt "dlgScConflictSolverEdit.tle"
+msgctxt "dlgScConflictSolverEdit.tle:"
 msgid "Edit"
 msgstr "Изменение"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.fur"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.fur:"
 msgid "The merge file content contains mixed \\(inconsistent\\) line-endings. If these line-endings are intentionally mixed, be sure to not overwrite them while saving this file."
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl:"
 msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.chk"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.chk:"
 msgid "Don't warn me again"
 msgstr "Не предупреждать больше"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.fur"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.fur:"
 msgid "Not all conflicts have been resolved."
 msgstr "Не все конфликты были разрешены."
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.hdl"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.hdl:"
 msgid "Do you want to close the Conflict Solver?"
 msgstr "Вы хотите закрыть решение конфликтов?"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.tle"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.tle:"
 msgid "Unresolved Conflicts"
 msgstr "Неразрешенные конфликты"
 
@@ -761,7 +761,7 @@ msgctxt "dlgScConflictSolver(Add|Edit).edt:"
 msgid "File Pattern"
 msgstr "Шаблон имени файла"
 
-msgctxt "dlgScConflictSolver(Add|Edit).inf"
+msgctxt "dlgScConflictSolver(Add|Edit).inf:"
 msgid "Define the file pattern \\(e.g. \\*.txt\\) and select the merge tool which should be used to resolve conflicting files matching this pattern."
 msgstr "Определите шаблон имени файла \\(например \\*.txt\\) и выберите инструмент объединения, который должен использоваться для решения конфликтов объединения соответствующих файлов."
 
@@ -841,15 +841,15 @@ msgctxt "dlgScCustomizeAccelerators.edt:"
 msgid "Accelerator"
 msgstr ""
 
-msgctxt "dlgScCustomizeAccelerators.hdl"
+msgctxt "dlgScCustomizeAccelerators.hdl:"
 msgid "Customize Accelerators"
 msgstr ""
 
-msgctxt "dlgScCustomizeAccelerators.inf"
+msgctxt "dlgScCustomizeAccelerators.inf:"
 msgid "Double click on the menu item for which the accelerator should be changed, then press the accelerator keys and click the Assign button."
 msgstr ""
 
-msgctxt "dlgScCustomizeAccelerators.tle"
+msgctxt "dlgScCustomizeAccelerators.tle:"
 msgid "Customize"
 msgstr ""
 
@@ -901,7 +901,7 @@ msgctxt "dlgScCustomizeToolBar.mni:"
 msgid "Remove"
 msgstr "Убрать"
 
-msgctxt "dlgScCustomizeToolBar.tle"
+msgctxt "dlgScCustomizeToolBar.tle:"
 msgid "Configure Toolbar"
 msgstr "Настройка панели инструментов"
 
@@ -921,15 +921,15 @@ msgctxt "dlgScDevOpsCredentials.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgScDevOpsCredentials.hdl"
+msgctxt "dlgScDevOpsCredentials.hdl:"
 msgid "Login to '$1'"
 msgstr ""
 
-msgctxt "dlgScDevOpsCredentials.inf"
+msgctxt "dlgScDevOpsCredentials.inf:"
 msgid "Provide the user name and password for authenticating to JIRA."
 msgstr ""
 
-msgctxt "dlgScDevOpsCredentials.tle"
+msgctxt "dlgScDevOpsCredentials.tle:"
 msgid "Login to JIRA"
 msgstr ""
 
@@ -953,15 +953,15 @@ msgctxt "dlgScDevOpsSslClientCertificate.edt:"
 msgid "Passphrase"
 msgstr ""
 
-msgctxt "dlgScDevOpsSslClientCertificate.hdl"
+msgctxt "dlgScDevOpsSslClientCertificate.hdl:"
 msgid "Select the client certificate for $1"
 msgstr ""
 
-msgctxt "dlgScDevOpsSslClientCertificate.inf"
+msgctxt "dlgScDevOpsSslClientCertificate.inf:"
 msgid "Select the client certificate file for authenticating to JIRA."
 msgstr ""
 
-msgctxt "dlgScDevOpsSslClientCertificate.tle"
+msgctxt "dlgScDevOpsSslClientCertificate.tle:"
 msgid "JIRA Client Certificate"
 msgstr ""
 
@@ -997,7 +997,7 @@ msgctxt "dlgScDevOpsSslFingerprintNew.lbl:"
 msgid "When in doubt, contact your server administrator."
 msgstr ""
 
-msgctxt "dlgScDevOpsSslFingerprintNew.tle"
+msgctxt "dlgScDevOpsSslFingerprintNew.tle:"
 msgid "SSL Authentication"
 msgstr ""
 
@@ -1021,7 +1021,7 @@ msgctxt "dlgScDialogAssertionHandler.lbl:"
 msgid "SmartGit has crashed due to insufficient system memory"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandler.tle"
+msgctxt "dlgScDialogAssertionHandler.tle:"
 msgid "Native Crash Logs"
 msgstr ""
 
@@ -1037,7 +1037,7 @@ msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
 msgid "SmartGit has detected inconsistencies within its installation files \\(JAR files\\), what has most likely been caused by a faulty installation.\\n\\nPlease uninstall SmartGit completely, make sure there are no more installation files left \\(especially JAR files\\), then reinstall.\\n\\nIf the problem persists, send following log file as an attachment to smartgit@syntevo.com."
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerLinkageError.tle"
+msgctxt "dlgScDialogAssertionHandlerLinkageError.tle:"
 msgid "Internal Error"
 msgstr ""
 
@@ -1045,15 +1045,15 @@ msgctxt "dlgScDialogAssertionHandlerOutOfMemory.btn:"
 msgid "Force Exit"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur:"
 msgid "It is strongly recommended to restart SmartGit.\\n\\nTo increase the maximum memory limit edit $1, increase the value of the -Xmx option, for example to -Xmx1024m \\(or add it if not yet existing\\) and restart SmartGit."
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.hdl"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.hdl:"
 msgid "SmartGit ran out of memory!"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.tle"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.tle:"
 msgid "Out Of Memory"
 msgstr ""
 
@@ -1065,27 +1065,27 @@ msgctxt "dlgScEvaluationReminderContinue.btn:"
 msgid "Register"
 msgstr ""
 
-msgctxt "dlgScEvaluationReminderContinue.fur"
+msgctxt "dlgScEvaluationReminderContinue.fur:"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
 msgstr ""
 
-msgctxt "dlgScEvaluationReminderContinue.hdl"
+msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr ""
 
-msgctxt "dlgScEvaluationReminderContinue.tle"
+msgctxt "dlgScEvaluationReminderContinue.tle:"
 msgid "Evaluation"
 msgstr ""
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl:"
 msgid "Cannot run program \"$1\": $2"
 msgstr ""
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
-msgctxt "dlgScFileComparatorAdd.hdl"
+msgctxt "dlgScFileComparatorAdd.hdl:"
 msgid "Add external diff tool"
 msgstr "Добавление внешнего инструмента сравнения"
 
@@ -1101,11 +1101,11 @@ msgctxt "dlgScFileComparatorAdd.mni:"
 msgid "Base Title"
 msgstr "Имя базового"
 
-msgctxt "dlgScFileComparatorAdd.tle"
+msgctxt "dlgScFileComparatorAdd.tle:"
 msgid "Add"
 msgstr "Добавление"
 
-msgctxt "dlgScFileComparatorEdit.hdl"
+msgctxt "dlgScFileComparatorEdit.hdl:"
 msgid "Edit external diff tool"
 msgstr "Редактирование внешнего инструмента сравнения"
 
@@ -1121,7 +1121,7 @@ msgctxt "dlgScFileComparatorEdit.mni:"
 msgid "Base Title"
 msgstr "Имя базового"
 
-msgctxt "dlgScFileComparatorEdit.tle"
+msgctxt "dlgScFileComparatorEdit.tle:"
 msgid "Edit"
 msgstr ""
 
@@ -1137,7 +1137,7 @@ msgctxt "dlgScFileComparator(Add|Edit).edt:"
 msgid "File Pattern"
 msgstr "Шаблон имени файла"
 
-msgctxt "dlgScFileComparator(Add|Edit).inf"
+msgctxt "dlgScFileComparator(Add|Edit).inf:"
 msgid "Define the file pattern \\(e.g. \\*.png\\) and select the compare command which should be used to compare files matching the file pattern."
 msgstr "Определите шаблон имени файла \\(например \\*.png\\) и выберите команду, которая должна вызываться для сравнения соответствующих файлов."
 
@@ -1201,15 +1201,15 @@ msgctxt "dlgScFileCompareFileChanged.btn:"
 msgid "Save"
 msgstr "Сохранить"
 
-msgctxt "dlgScFileCompareFileChanged.fur"
+msgctxt "dlgScFileCompareFileChanged.fur:"
 msgid "Your changes will be lost, if you don't save them."
 msgstr "Изменения будут потеряны, если не сохранить их."
 
-msgctxt "dlgScFileCompareFileChanged.hdl"
+msgctxt "dlgScFileCompareFileChanged.hdl:"
 msgid "Do you want to save your changes?"
 msgstr "Вы хотите сохранить изменения?"
 
-msgctxt "dlgScFileCompareFileChanged.tle"
+msgctxt "dlgScFileCompareFileChanged.tle:"
 msgid "File Changed"
 msgstr "Файл изменен"
 
@@ -1229,15 +1229,15 @@ msgctxt "dlgScFileCompareSaveAll.chk:"
 msgid "Right file"
 msgstr ""
 
-msgctxt "dlgScFileCompareSaveAll.hdl"
+msgctxt "dlgScFileCompareSaveAll.hdl:"
 msgid "Save file changes"
 msgstr ""
 
-msgctxt "dlgScFileCompareSaveAll.inf"
+msgctxt "dlgScFileCompareSaveAll.inf:"
 msgid "Decide which file content to save."
 msgstr ""
 
-msgctxt "dlgScFileCompareSaveAll.tle"
+msgctxt "dlgScFileCompareSaveAll.tle:"
 msgid "Save Changes"
 msgstr ""
 
@@ -1245,11 +1245,11 @@ msgctxt "dlgScFilePatternsEdit.edt:"
 msgid "File Pattern"
 msgstr "Шаблон имени файла"
 
-msgctxt "dlgScFilePatternsEdit.hdl"
+msgctxt "dlgScFilePatternsEdit.hdl:"
 msgid "Language: $1"
 msgstr "Язык: $1"
 
-msgctxt "dlgScFilePatternsEdit.inf"
+msgctxt "dlgScFilePatternsEdit.inf:"
 msgid "File patterns are used to determine file language, which is used for syntax coloring."
 msgstr "Шаблоны имен файлов используются для определения языка файла, применяемого для синтаксической подсветки."
 
@@ -1257,7 +1257,7 @@ msgctxt "dlgScFilePatternsEdit.lbl:"
 msgid "Valid wildcards are ?\\u00a0\\(one arbitrary character\\) and \\*\\u00a0\\(any number of arbitrary characters\\). Separate multiple patterns by comma. Example:\\u00a0\\*.txt,\\u00a0\\*.html"
 msgstr "Допустимо использование специальных символов: ?\\u00a0\\(один произвольный символ\\) и \\*\\u00a0\\(несколько произвольных символов\\). Для разделения нескольких шаблонов используйте запятую.\\nПример:\\u00a0\\*.txt,\\u00a0\\*.html"
 
-msgctxt "dlgScFilePatternsEdit.tle"
+msgctxt "dlgScFilePatternsEdit.tle:"
 msgid "File Patterns"
 msgstr "Шаблоны имен файлов"
 
@@ -1265,7 +1265,7 @@ msgctxt "dlgScFindAction.edt:"
 msgid "Action name"
 msgstr ""
 
-msgctxt "dlgScFindAction.tle"
+msgctxt "dlgScFindAction.tle:"
 msgid "Find Command"
 msgstr ""
 
@@ -1285,15 +1285,15 @@ msgctxt "dlgScHostKeyVerifier.edt:"
 msgid "Server"
 msgstr ""
 
-msgctxt "dlgScHostKeyVerifier.fur"
+msgctxt "dlgScHostKeyVerifier.fur:"
 msgid "If you are unsure, contact your administrator."
 msgstr ""
 
-msgctxt "dlgScHostKeyVerifier.hdl"
+msgctxt "dlgScHostKeyVerifier.hdl:"
 msgid "Please confirm the SSH server fingerprint."
 msgstr ""
 
-msgctxt "dlgScHostKeyVerifier.tle"
+msgctxt "dlgScHostKeyVerifier.tle:"
 msgid "SSH Server Verification"
 msgstr ""
 
@@ -1329,11 +1329,11 @@ msgctxt "dlgScJiraCommitMessageSelect.col:"
 msgid "Summary"
 msgstr ""
 
-msgctxt "dlgScJiraCommitMessageSelect.hdl"
+msgctxt "dlgScJiraCommitMessageSelect.hdl:"
 msgid "Select commit message by JIRA issue"
 msgstr ""
 
-msgctxt "dlgScJiraCommitMessageSelect.inf"
+msgctxt "dlgScJiraCommitMessageSelect.inf:"
 msgid "The selected issue summary will be used as commit message."
 msgstr ""
 
@@ -1349,7 +1349,7 @@ msgctxt "dlgScJiraCommitMessageSelect.lbl:"
 msgid "Query Configuration"
 msgstr ""
 
-msgctxt "dlgScJiraCommitMessageSelect.tle"
+msgctxt "dlgScJiraCommitMessageSelect.tle:"
 msgid "Select Issue"
 msgstr ""
 
@@ -1377,15 +1377,15 @@ msgctxt "dlgScJiraResolveIssue.edt:"
 msgid "Summary"
 msgstr ""
 
-msgctxt "dlgScJiraResolveIssue.hdl"
+msgctxt "dlgScJiraResolveIssue.hdl:"
 msgid "Resolve issue $1"
 msgstr ""
 
-msgctxt "dlgScJiraResolveIssue.inf"
+msgctxt "dlgScJiraResolveIssue.inf:"
 msgid "Select whether to resolve this issue and for which version to mark as resolved."
 msgstr ""
 
-msgctxt "dlgScJiraResolveIssue.tle"
+msgctxt "dlgScJiraResolveIssue.tle:"
 msgid "Resolve JIRA Issue"
 msgstr ""
 
@@ -1401,11 +1401,11 @@ msgctxt "dlgScMasterPasswordChange.edt:"
 msgid "Retype New Master Password"
 msgstr "Повторите новый мастер-пароль"
 
-msgctxt "dlgScMasterPasswordChange.hdl"
+msgctxt "dlgScMasterPasswordChange.hdl:"
 msgid "Change or reset the master password"
 msgstr "Изменение или сброс мастер-пароля"
 
-msgctxt "dlgScMasterPasswordChange.inf"
+msgctxt "dlgScMasterPasswordChange.inf:"
 msgid "To change the master password, enter the current one. To go without a master password, leave the new field blank."
 msgstr "Для изменения мастер-пароля, введите текущий. Для отказа от использования мастер-пароля оставьте поле нового значения пустым."
 
@@ -1421,7 +1421,7 @@ msgctxt "dlgScMasterPasswordChange.rbt:"
 msgid "Set new master password"
 msgstr "Установить новый мастер-пароль"
 
-msgctxt "dlgScMasterPasswordChange.tle"
+msgctxt "dlgScMasterPasswordChange.tle:"
 msgid "Change Master Password"
 msgstr "Изменение мастер-пароля"
 
@@ -1433,11 +1433,11 @@ msgctxt "dlgScMasterPasswordCreate.edt:"
 msgid "Retype Again"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordCreate.hdl"
+msgctxt "dlgScMasterPasswordCreate.hdl:"
 msgid "Configure the master password for the encrypted password store"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordCreate.inf"
+msgctxt "dlgScMasterPasswordCreate.inf:"
 msgid "The master password is used to protect passwords and passphrases which are used to authenticate with servers."
 msgstr ""
 
@@ -1457,7 +1457,7 @@ msgctxt "dlgScMasterPasswordCreate.rbt:"
 msgid "Use the following master password"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordCreate.tle"
+msgctxt "dlgScMasterPasswordCreate.tle:"
 msgid "Master Password"
 msgstr ""
 
@@ -1465,39 +1465,39 @@ msgctxt "dlgScMasterPasswordEnter.edt:"
 msgid "Master Password"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordEnter.hdl"
+msgctxt "dlgScMasterPasswordEnter.hdl:"
 msgid "Enter the master password"
 msgstr ""
 
-msgctxt "dlgScMasterPasswordEnter.inf"
+msgctxt "dlgScMasterPasswordEnter.inf:"
 msgid "A stored password or passphrase has been requested from the password store."
 msgstr ""
 
-msgctxt "dlgScMasterPasswordEnter.tle"
+msgctxt "dlgScMasterPasswordEnter.tle:"
 msgid "Passwords"
 msgstr ""
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.fur"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.fur:"
 msgid "The process could not be started."
 msgstr ""
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.hdl"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr ""
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.tle"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.tle:"
 msgid "SmartGit Installation Update"
 msgstr ""
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.fur"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.fur:"
 msgid "Be sure to remember it, otherwise you won't be able to access your stored passwords anymore."
 msgstr ""
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.hdl"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.hdl:"
 msgid "The master password has been changed."
 msgstr ""
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.tle"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.tle:"
 msgid "Change Master Password"
 msgstr ""
 
@@ -1505,15 +1505,15 @@ msgctxt "dlgScPropertiesReset.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgScPropertiesReset.fur"
+msgctxt "dlgScPropertiesReset.fur:"
 msgid "The new values will be active after restarting SmartGit."
 msgstr ""
 
-msgctxt "dlgScPropertiesReset.hdl"
+msgctxt "dlgScPropertiesReset.hdl:"
 msgid "Do you want to reset $1 system properties to their defaults?"
 msgstr ""
 
-msgctxt "dlgScPropertiesReset.tle"
+msgctxt "dlgScPropertiesReset.tle:"
 msgid "Reset Properties"
 msgstr ""
 
@@ -1521,11 +1521,11 @@ msgctxt "dlgScPropertyEdit.edt:"
 msgid "Value"
 msgstr ""
 
-msgctxt "dlgScPropertyEdit.hdl"
+msgctxt "dlgScPropertyEdit.hdl:"
 msgid "Edit low-level property value"
 msgstr ""
 
-msgctxt "dlgScPropertyEdit.inf"
+msgctxt "dlgScPropertyEdit.inf:"
 msgid "Set the value for property '$1'"
 msgstr ""
 
@@ -1537,7 +1537,7 @@ msgctxt "dlgScPropertyEdit.rbt:"
 msgid "true"
 msgstr ""
 
-msgctxt "dlgScPropertyEdit.tle"
+msgctxt "dlgScPropertyEdit.tle:"
 msgid "Edit Property"
 msgstr ""
 
@@ -1577,7 +1577,7 @@ msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "User Count"
 msgstr ""
 
-msgctxt "dlgScRegisterFormLicenseConfirmDetails.tle"
+msgctxt "dlgScRegisterFormLicenseConfirmDetails.tle:"
 msgid "SmartGit License"
 msgstr ""
 
@@ -1585,27 +1585,27 @@ msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.btn:"
 msgid "Purchase Update"
 msgstr ""
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.fur"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.fur:"
 msgid "You may use an older SmartGit version or purchase an update license."
 msgstr ""
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.hdl"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.hdl:"
 msgid "The free update period for this license does not cover this version."
 msgstr ""
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.tle"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.tle:"
 msgid "SmartGit License"
 msgstr ""
 
-msgctxt "dlgScRegisterRequestRejected.fur"
+msgctxt "dlgScRegisterRequestRejected.fur:"
 msgid "The license server rejected the request. Please manually register the latest license file you've got by email or try again later."
 msgstr ""
 
-msgctxt "dlgScRegisterRequestRejected.hdl"
+msgctxt "dlgScRegisterRequestRejected.hdl:"
 msgid "Failed to update license file."
 msgstr ""
 
-msgctxt "dlgScRegisterRequestRejected.tle"
+msgctxt "dlgScRegisterRequestRejected.tle:"
 msgid "SmartGit License"
 msgstr ""
 
@@ -1633,15 +1633,15 @@ msgctxt "dlgScSetupLicense.edt:"
 msgid "License Server URL"
 msgstr ""
 
-msgctxt "dlgScSetupLicense.hdl"
+msgctxt "dlgScSetupLicense.hdl:"
 msgid "Register license file"
 msgstr "Регистрация файла лицензии"
 
-msgctxt "dlgScSetupLicense.inf"
+msgctxt "dlgScSetupLicense.inf:"
 msgid "Please provide your SmartGit license file you've received by email after purchase."
 msgstr "Укажите путь к файлу с лицензией, который вы получили на эл.почту после покупки."
 
-msgctxt "dlgScSetupLicense.tle"
+msgctxt "dlgScSetupLicense.tle:"
 msgid "SmartGit License"
 msgstr "Лицензия SmartGit"
 
@@ -1653,19 +1653,19 @@ msgctxt "dlgScSpellCheckDictionaryAdd.err:"
 msgid "Please select a dictionary file."
 msgstr ""
 
-msgctxt "dlgScSpellCheckDictionaryAdd.hdl"
+msgctxt "dlgScSpellCheckDictionaryAdd.hdl:"
 msgid "Add spell checker dictionary"
 msgstr "Добавление словаря проверки орфографии"
 
-msgctxt "dlgScSpellCheckDictionaryAdd.tle"
+msgctxt "dlgScSpellCheckDictionaryAdd.tle:"
 msgid "Add"
 msgstr "Добавление"
 
-msgctxt "dlgScSpellCheckDictionaryEdit.hdl"
+msgctxt "dlgScSpellCheckDictionaryEdit.hdl:"
 msgid "Edit spell checker dictionary"
 msgstr "Изменение словаря проверки орфографии"
 
-msgctxt "dlgScSpellCheckDictionaryEdit.tle"
+msgctxt "dlgScSpellCheckDictionaryEdit.tle:"
 msgid "Edit"
 msgstr "Изменение"
 
@@ -1677,7 +1677,7 @@ msgctxt "dlgScSpellCheckDictionary(Add|Edit).edt:"
 msgid "Name"
 msgstr "Имя"
 
-msgctxt "dlgScSpellCheckDictionary(Add|Edit).inf"
+msgctxt "dlgScSpellCheckDictionary(Add|Edit).inf:"
 msgid "Specify the MySpell dictionary file to use, e.g. \\*.dic from Mozilla Firefox' or Thunderbird's \"dictionary\" directory\\). The name is used when switching between different dictionaries."
 msgstr "Укажите путь к словарю формата MySpell \\(например, \\*.dic из каталога \"dictionary\" Mozilla Firefox или Thunderbird\\). Имя словаря используется при переключении между разными словарями."
 
@@ -1705,7 +1705,7 @@ msgctxt "dlgScSslFingerprint.lbl:"
 msgid "This might indicate a security problem! When in doubt, contact your server administrator."
 msgstr ""
 
-msgctxt "dlgScSslFingerprint.tle"
+msgctxt "dlgScSslFingerprint.tle:"
 msgid "Server Fingerprint"
 msgstr ""
 
@@ -1713,15 +1713,15 @@ msgctxt "dlgScTextFinderFindFromEnd.btn:"
 msgid "Find from End"
 msgstr "Искать с конца"
 
-msgctxt "dlgScTextFinderFindFromEnd.fur"
+msgctxt "dlgScTextFinderFindFromEnd.fur:"
 msgid "No occurrences have been found until the beginning of the document."
 msgstr "Достигнуто начало документа, больше ничего нет."
 
-msgctxt "dlgScTextFinderFindFromEnd.hdl"
+msgctxt "dlgScTextFinderFindFromEnd.hdl:"
 msgid "Do you want to continue from the end of the document?"
 msgstr "Продолжить поиск с конца документа?"
 
-msgctxt "dlgScTextFinderFindFromEnd.tle"
+msgctxt "dlgScTextFinderFindFromEnd.tle:"
 msgid "Find Text"
 msgstr "Поиск текста"
 
@@ -1729,23 +1729,23 @@ msgctxt "dlgScTextFinderFindFromStart.btn:"
 msgid "Find from Beginning"
 msgstr "Искать с начала"
 
-msgctxt "dlgScTextFinderFindFromStart.fur"
+msgctxt "dlgScTextFinderFindFromStart.fur:"
 msgid "No occurrences have been found until the end of the document."
 msgstr "Достигнут конец документа, больше ничего нет."
 
-msgctxt "dlgScTextFinderFindFromStart.hdl"
+msgctxt "dlgScTextFinderFindFromStart.hdl:"
 msgid "Do you want to continue from the beginning of the document?"
 msgstr "Продолжить поиск с начала документа?"
 
-msgctxt "dlgScTextFinderFindFromStart.tle"
+msgctxt "dlgScTextFinderFindFromStart.tle:"
 msgid "Find Text"
 msgstr "Поиск текста"
 
-msgctxt "dlgScTextFinderNothingFound.hdl"
+msgctxt "dlgScTextFinderNothingFound.hdl:"
 msgid "No \\(more\\) occurrences have been found."
 msgstr "Вхождений \\(больше\\) не обнаружено."
 
-msgctxt "dlgScTextFinderNothingFound.tle"
+msgctxt "dlgScTextFinderNothingFound.tle:"
 msgid "Find Text"
 msgstr "Поиск текста"
 
@@ -1753,11 +1753,11 @@ msgctxt "dlgScTextMultiComponentGoToLine.edt:"
 msgid "Line Number"
 msgstr "Номер строки"
 
-msgctxt "dlgScTextMultiComponentGoToLine.tle"
+msgctxt "dlgScTextMultiComponentGoToLine.tle:"
 msgid "Go to Line"
 msgstr "Переход к строке"
 
-msgctxt "dlgScTextMultiComponentSyntaxHighlightingSelection.tle"
+msgctxt "dlgScTextMultiComponentSyntaxHighlightingSelection.tle:"
 msgid "Select Syntax-Highlighting"
 msgstr "Выбор подсветки синтаксиса"
 
@@ -1869,43 +1869,43 @@ msgctxt "dlgScTextSettings.tab:"
 msgid "General"
 msgstr "Основные"
 
-msgctxt "dlgScTextSettings.tle"
+msgctxt "dlgScTextSettings.tle:"
 msgid "Settings"
 msgstr "Настройки"
 
-msgctxt "dlgScUpdateInstallationResumeFailure.fur"
+msgctxt "dlgScUpdateInstallationResumeFailure.fur:"
 msgid "The process could not be started."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationResumeFailure.hdl"
+msgctxt "dlgScUpdateInstallationResumeFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationResumeFailure.tle"
+msgctxt "dlgScUpdateInstallationResumeFailure.tle:"
 msgid "Upgrade"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.fur"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.fur:"
 msgid "The process could not be started."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.hdl"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle:"
 msgid "SmartGit Installation Update"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur:"
 msgid "Please get rid of '$1' manually and retry the upgrade."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.hdl"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.hdl:"
 msgid "Clearing updater directory failed."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.tle"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.tle:"
 msgid "SmartGit Installation Update"
 msgstr ""
 
@@ -1913,15 +1913,15 @@ msgctxt "dlgScUpdateInstallationUpgrade.btn:"
 msgid "Upgrade Now"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpgrade.fur"
+msgctxt "dlgScUpdateInstallationUpgrade.fur:"
 msgid "The new version $1 has been downloaded which needs to be installed."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpgrade.hdl"
+msgctxt "dlgScUpdateInstallationUpgrade.hdl:"
 msgid "Do you want to upgrade SmartGit now?"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpgrade.tle"
+msgctxt "dlgScUpdateInstallationUpgrade.tle:"
 msgid "Upgrade SmartGit"
 msgstr ""
 
@@ -1929,11 +1929,11 @@ msgctxt "dlgSelectDiff.col:"
 msgid "Command"
 msgstr ""
 
-msgctxt "dlgSelectDiff.hdl"
+msgctxt "dlgSelectDiff.hdl:"
 msgid "Select the diff tool"
 msgstr ""
 
-msgctxt "dlgSelectDiff.inf"
+msgctxt "dlgSelectDiff.inf:"
 msgid "Select which matching diff tool should be used."
 msgstr ""
 
@@ -1945,7 +1945,7 @@ msgctxt "dlgSelectDiff.lbl:"
 msgid "Diff tool:"
 msgstr ""
 
-msgctxt "dlgSelectDiff.tle"
+msgctxt "dlgSelectDiff.tle:"
 msgid "File Compare"
 msgstr ""
 
@@ -1953,15 +1953,15 @@ msgctxt "dlgSgAbortBisectingConfirm.btn:"
 msgid "Abort Bisect"
 msgstr ""
 
-msgctxt "dlgSgAbortBisectingConfirm.fur"
+msgctxt "dlgSgAbortBisectingConfirm.fur:"
 msgid "Your working tree is in 'bisecting' state. You may abort it to get out of this state.\\n\\nAborting will checkout the branch or commit before starting bisect."
 msgstr ""
 
-msgctxt "dlgSgAbortBisectingConfirm.hdl"
+msgctxt "dlgSgAbortBisectingConfirm.hdl:"
 msgid "Do you want to reset your working tree?"
 msgstr ""
 
-msgctxt "dlgSgAbortBisectingConfirm.tle"
+msgctxt "dlgSgAbortBisectingConfirm.tle:"
 msgid "Abort"
 msgstr ""
 
@@ -1969,15 +1969,15 @@ msgctxt "dlgSgAbortCherryPickingConfirm.btn:"
 msgid "Abort Cherry-Pick"
 msgstr ""
 
-msgctxt "dlgSgAbortCherryPickingConfirm.fur"
+msgctxt "dlgSgAbortCherryPickingConfirm.fur:"
 msgid "Your working tree is in 'cherry-picking' state. You may abort it to get out of this state and freshly start over with the cherry-picking afterwards.\\n\\nAborting will clean any local modification \\(by invoking 'git cherry-pick --abort'\\)!"
 msgstr ""
 
-msgctxt "dlgSgAbortCherryPickingConfirm.hdl"
+msgctxt "dlgSgAbortCherryPickingConfirm.hdl:"
 msgid "Do you want to abort the current cherry-pick?"
 msgstr ""
 
-msgctxt "dlgSgAbortCherryPickingConfirm.tle"
+msgctxt "dlgSgAbortCherryPickingConfirm.tle:"
 msgid "Abort"
 msgstr ""
 
@@ -1985,15 +1985,15 @@ msgctxt "dlgSgAbortMergingConfirm.btn:"
 msgid "Abort Merge"
 msgstr "Прервать объединение"
 
-msgctxt "dlgSgAbortMergingConfirm.fur"
+msgctxt "dlgSgAbortMergingConfirm.fur:"
 msgid "Your working tree is in 'merging' state. You may abort it to get out of this state and freshly start over with the merge afterwards.\\n\\nAborting will try to reconstruct the pre-merge state \\(by invoking 'git merge --abort'\\)!"
 msgstr "Рабочий каталог находится в состоянии 'объединения'. Вы можете прервать операцию, чтобы выйти из этого состояния и после этого начать снова. \\n\\nПри отмене будет предпринята попытка восстановить состояние до слияния \\(путем вызова 'git merge --abort'\\)."
 
-msgctxt "dlgSgAbortMergingConfirm.hdl"
+msgctxt "dlgSgAbortMergingConfirm.hdl:"
 msgid "Do you want to abort the current merge?"
 msgstr "Вы хотите прервать текущее объединение?"
 
-msgctxt "dlgSgAbortMergingConfirm.tle"
+msgctxt "dlgSgAbortMergingConfirm.tle:"
 msgid "Abort"
 msgstr "Прерывание объединения"
 
@@ -2001,15 +2001,15 @@ msgctxt "dlgSgAbortRebasingConfirm.btn:"
 msgid "Abort Rebase"
 msgstr "Прервать перемещение"
 
-msgctxt "dlgSgAbortRebasingConfirm.fur"
+msgctxt "dlgSgAbortRebasingConfirm.fur:"
 msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 msgstr "Рабочий каталог находится в состоянии 'перемещения'. Вы можете прервать перемещение. Если хотите просто пропустить текущий патч, используйте Ветки\\|Переместить\\|Пропустить.\\n\\nПри отмене будут удалены любые локальные изменения \\(путем вызова 'git rebase --abort'\\)!"
 
-msgctxt "dlgSgAbortRebasingConfirm.hdl"
+msgctxt "dlgSgAbortRebasingConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
 msgstr "Вы хотите прервать перемещение?"
 
-msgctxt "dlgSgAbortRebasingConfirm.tle"
+msgctxt "dlgSgAbortRebasingConfirm.tle:"
 msgid "Abort"
 msgstr ""
 
@@ -2021,7 +2021,7 @@ msgctxt "dlgSgAbortRevertingConfirm.btn:"
 msgid "Abort Revert"
 msgstr "Прервать откат изменений"
 
-msgctxt "dlgSgAbortRevertingConfirm.fur"
+msgctxt "dlgSgAbortRevertingConfirm.fur:"
 msgid "Your working tree is in 'reverting' state. You may abort it to get out of this state and freshly start over with the revert afterwards.\\n\\nAborting will clean any local modification \\(by invoking 'git reset --hard'\\)!"
 msgstr "Рабочий каталог находится в состоянии 'отката изменений'. Вы можете прервать операцию и выйти из этого состояния, чтобы выполнить эту операцию позднее.\\n\\nПрерывание операции очистит все изменения \\(вызовом 'git reset --hard'\\)!"
 
@@ -2105,31 +2105,31 @@ msgctxt "dlgSgAbout.tab:"
 msgid "Licensee"
 msgstr "Лицензиат"
 
-msgctxt "dlgSgAbout.tle"
+msgctxt "dlgSgAbout.tle:"
 msgid "About SmartGit"
 msgstr "О SmartGit"
 
-msgctxt "dlgSgApplicationAlreadyRunning.fur"
+msgctxt "dlgSgApplicationAlreadyRunning.fur:"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
 msgstr ""
 
-msgctxt "dlgSgApplicationAlreadyRunning.hdl"
+msgctxt "dlgSgApplicationAlreadyRunning.hdl:"
 msgid "It seems that SmartGit is already running."
 msgstr ""
 
-msgctxt "dlgSgApplicationAlreadyRunning.tle"
+msgctxt "dlgSgApplicationAlreadyRunning.tle:"
 msgid "SmartGit"
 msgstr ""
 
-msgctxt "dlgSgApplicationUpgradeError.fur"
+msgctxt "dlgSgApplicationUpgradeError.fur:"
 msgid "The process could not be started."
 msgstr ""
 
-msgctxt "dlgSgApplicationUpgradeError.hdl"
+msgctxt "dlgSgApplicationUpgradeError.hdl:"
 msgid "Launching updater directly failed."
 msgstr ""
 
-msgctxt "dlgSgApplicationUpgradeError.tle"
+msgctxt "dlgSgApplicationUpgradeError.tle:"
 msgid "Upgrade"
 msgstr ""
 
@@ -2137,15 +2137,15 @@ msgctxt "dlgSgAuthenticationRemoveAllCredentials.btn:"
 msgid "Remove All"
 msgstr "Удалить все"
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.fur"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.fur:"
 msgid "You will have to re-enter all authentication details."
 msgstr "Вам придется заново ввести все данные для аутентификации"
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.hdl"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.hdl:"
 msgid "Do you want to remove all known credentials?"
 msgstr "Вы хотите удалить все известные учетные записи?"
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.tle"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.tle:"
 msgid "Remove All"
 msgstr "Удаление всех учетных записей"
 
@@ -2153,7 +2153,7 @@ msgctxt "dlgSgAuthenticationShowPassword.edt:"
 msgid "Password"
 msgstr ""
 
-msgctxt "dlgSgAuthenticationShowPassword.tle"
+msgctxt "dlgSgAuthenticationShowPassword.tle:"
 msgid "Password for $1"
 msgstr ""
 
@@ -2165,11 +2165,11 @@ msgctxt "dlgSgAzureGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgAzureGenerateToken.hdl"
+msgctxt "dlgSgAzureGenerateToken.hdl:"
 msgid "Enter the generated code"
 msgstr ""
 
-msgctxt "dlgSgAzureGenerateToken.inf"
+msgctxt "dlgSgAzureGenerateToken.inf:"
 msgid "Authenticate at Azure DevOps and enter the generated token."
 msgstr ""
 
@@ -2177,15 +2177,15 @@ msgctxt "dlgSgAzureGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at Azure DevOps and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgAzureGenerateToken.tle"
+msgctxt "dlgSgAzureGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr ""
 
-msgctxt "dlgSgAzureRefreshFailed.hdl"
+msgctxt "dlgSgAzureRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr ""
 
-msgctxt "dlgSgAzureRefreshFailed.tle"
+msgctxt "dlgSgAzureRefreshFailed.tle:"
 msgid "Azure DevOps"
 msgstr ""
 
@@ -2197,15 +2197,15 @@ msgctxt "dlgSgBisectResult.btn:"
 msgid "Leave Bisect"
 msgstr ""
 
-msgctxt "dlgSgBisectResult.fur"
+msgctxt "dlgSgBisectResult.fur:"
 msgid "$1"
 msgstr ""
 
-msgctxt "dlgSgBisectResult.hdl"
+msgctxt "dlgSgBisectResult.hdl:"
 msgid "Bisect has determined the first bad commit."
 msgstr ""
 
-msgctxt "dlgSgBisectResult.tle"
+msgctxt "dlgSgBisectResult.tle:"
 msgid "Bisect Finished"
 msgstr ""
 
@@ -2217,15 +2217,15 @@ msgctxt "dlgSgBisectStartConfirm.btn:"
 msgid "Start Bisect"
 msgstr ""
 
-msgctxt "dlgSgBisectStartConfirm.fur"
+msgctxt "dlgSgBisectStartConfirm.fur:"
 msgid "You need to mark 1 commit as good and 1 commit as bad before Git can start the binary search."
 msgstr ""
 
-msgctxt "dlgSgBisectStartConfirm.hdl"
+msgctxt "dlgSgBisectStartConfirm.hdl:"
 msgid "Should the bisect be started with a bad commit?"
 msgstr ""
 
-msgctxt "dlgSgBisectStartConfirm.tle"
+msgctxt "dlgSgBisectStartConfirm.tle:"
 msgid "Start Bisect"
 msgstr ""
 
@@ -2237,11 +2237,11 @@ msgctxt "dlgSgBitbucketGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgBitbucketGenerateToken.hdl"
+msgctxt "dlgSgBitbucketGenerateToken.hdl:"
 msgid "Enter the generated code"
 msgstr ""
 
-msgctxt "dlgSgBitbucketGenerateToken.inf"
+msgctxt "dlgSgBitbucketGenerateToken.inf:"
 msgid "Authenticate at Bitbucket and enter the generated token"
 msgstr ""
 
@@ -2249,15 +2249,15 @@ msgctxt "dlgSgBitbucketGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at Bitbucket and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgBitbucketGenerateToken.tle"
+msgctxt "dlgSgBitbucketGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr ""
 
-msgctxt "dlgSgBitbucketRefreshFailed.hdl"
+msgctxt "dlgSgBitbucketRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr ""
 
-msgctxt "dlgSgBitbucketRefreshFailed.tle"
+msgctxt "dlgSgBitbucketRefreshFailed.tle:"
 msgid "Bitbucket"
 msgstr ""
 
@@ -2305,11 +2305,11 @@ msgctxt "dlgSgBranchAddCheckout.hdl:"
 msgid "Create new branch at current branch \\(HEAD\\)"
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckout.inf"
+msgctxt "dlgSgBranchAddCheckout.inf:"
 msgid "Enter the name of the local branch to create."
 msgstr "Введите имя для создания локальной ветки."
 
-msgctxt "dlgSgBranchAddCheckout.tle"
+msgctxt "dlgSgBranchAddCheckout.tle:"
 msgid "Add Branch"
 msgstr "Создание ветки"
 
@@ -2317,27 +2317,27 @@ msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.tle"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.tle:"
 msgid "Add Branch"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.fur"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.fur:"
 msgid "By default, SmartGit disallows to delete the current branch. To skip this restriction, switch to a different branch or set the low-level property 'branch.delete.allowToDeleteCurrentBranch'."
 msgstr "По умолчанию, SmartGit запрещает удалять текущую ветку. Для обхода данного ограничения переключитесь на другую ветку, либо измените низкоуровневый параметр 'branch.delete.allowToDeleteCurrentBranch'."
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.hdl"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.hdl:"
 msgid "You can't delete the current branch."
 msgstr "Вы не можете удалить текущую ветку."
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.tle"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.tle:"
 msgid "Delete"
 msgstr "Удаление"
 
@@ -2369,7 +2369,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr "Вы можете потерять неотправленные изменения, восстановить ветку\\(и\\) будет затруднительно!"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
 
@@ -2377,7 +2377,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr "Вы хотите удалить $1 локальные ветки?"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle:"
 msgid "Delete"
 msgstr "Удалить"
 
@@ -2409,7 +2409,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.fur:"
 msgid "Your local branch is tracking branch '$1'. Decide whether you also want to delete this branch from the remote repository."
 msgstr "Локальная ветка отслеживает '$1'. Решите, хотите ли также удалить отслеживаемую ветку во внешнем репозитории."
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
 
@@ -2417,7 +2417,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "Вы хотите удалить локальную ветку '$1'?"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle:"
 msgid "Delete"
 msgstr "Удаление"
 
@@ -2425,7 +2425,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.btn:"
 msgid "Delete"
 msgstr "Удалить"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.tle"
+msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.tle:"
 msgid "Delete"
 msgstr "Удаление"
 
@@ -2433,7 +2433,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "Удалить"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr "Удалить во внешнем репозитории '$1'"
 
@@ -2445,11 +2445,11 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur:"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
 msgstr "Если не удалить ветку во внешнем репозитории, то она может вернуться при следующем получении обновлений."
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the branch '$1'?"
 msgstr "Хотите удалить ветку '$1'?"
 
@@ -2461,7 +2461,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle:"
 msgid "Delete"
 msgstr "Удаление"
 
@@ -2469,15 +2469,15 @@ msgctxt "dlgSgBranchTrackingResetConfirm.btn:"
 msgid "Stop Tracking"
 msgstr "Прекратить отслеживание"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.fur"
+msgctxt "dlgSgBranchTrackingResetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "Необходимая конфигурация будет зафиксирована в файле .git/config."
 
-msgctxt "dlgSgBranchTrackingResetConfirm.hdl"
+msgctxt "dlgSgBranchTrackingResetConfirm.hdl:"
 msgid "Should branch '$1' stop tracking '$2'?"
 msgstr "Прекратить отслеживание веткой '$1' ветки '$2'?"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.tle"
+msgctxt "dlgSgBranchTrackingResetConfirm.tle:"
 msgid "Stop Tracking"
 msgstr "Прекращение отслеживания"
 
@@ -2485,15 +2485,15 @@ msgctxt "dlgSgBranchTrackingSetConfirm.btn:"
 msgid "Configure"
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingSetConfirm.fur"
+msgctxt "dlgSgBranchTrackingSetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingSetConfirm.hdl"
+msgctxt "dlgSgBranchTrackingSetConfirm.hdl:"
 msgid "Do you want to configure '$1' to track '$2'?"
 msgstr ""
 
-msgctxt "dlgSgBranchTrackingSetConfirm.tle"
+msgctxt "dlgSgBranchTrackingSetConfirm.tle:"
 msgid "Set Tracked Branch"
 msgstr ""
 
@@ -2513,11 +2513,11 @@ msgctxt "dlgSgBugReportSettings.err:"
 msgid "Sending 'crash footprints' is required for preview builds, because their main purposes is to get as much as possible bugs reported and fixed before release."
 msgstr ""
 
-msgctxt "dlgSgBugReportSettings.hdl"
+msgctxt "dlgSgBugReportSettings.hdl:"
 msgid "Crash Reporting"
 msgstr ""
 
-msgctxt "dlgSgBugReportSettings.inf"
+msgctxt "dlgSgBugReportSettings.inf:"
 msgid "Please help to improve SmartGit's quality by automatically sending 'crash footprints'."
 msgstr ""
 
@@ -2529,7 +2529,7 @@ msgctxt "dlgSgBugReportSettings.lbl:"
 msgid "Sent data contains \\*no potentially sensitive information\\* like user names, email addresses, file contents, file paths or server names."
 msgstr ""
 
-msgctxt "dlgSgBugReportSettings.tle"
+msgctxt "dlgSgBugReportSettings.tle:"
 msgid "SmartGit"
 msgstr ""
 
@@ -2541,15 +2541,15 @@ msgctxt "dlgSgCheckout.btn:"
 msgid "Check Out"
 msgstr ""
 
-msgctxt "dlgSgCheckout.hdl"
+msgctxt "dlgSgCheckout.hdl:"
 msgid "Check out a commit"
 msgstr ""
 
-msgctxt "dlgSgCheckout.inf"
+msgctxt "dlgSgCheckout.inf:"
 msgid "Select the commit to check out. This allows to switch \\(back\\) the working tree to any commit."
 msgstr ""
 
-msgctxt "dlgSgCheckout.tle"
+msgctxt "dlgSgCheckout.tle:"
 msgid "Check Out"
 msgstr ""
 
@@ -2561,15 +2561,15 @@ msgctxt "dlgSgCheckoutFastForwardMerge.btn:"
 msgid "Just Checkout"
 msgstr "Только переключиться"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.fur"
+msgctxt "dlgSgCheckoutFastForwardMerge.fur:"
 msgid "Fast-forward-merging automatically moves the branch forward to the tracked remote branch."
 msgstr "Быстрое слияние автоматически перемещает ветку вперед к отслеживаемой внешней ветке."
 
-msgctxt "dlgSgCheckoutFastForwardMerge.hdl"
+msgctxt "dlgSgCheckoutFastForwardMerge.hdl:"
 msgid "Do you want to fast-forward-merge remote changes after checking out '$1'?"
 msgstr "Хотите выполнить быстрое слияние внешних изменений после переключения на '$1'?"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.tle"
+msgctxt "dlgSgCheckoutFastForwardMerge.tle:"
 msgid "Check Out"
 msgstr "Переключение"
 
@@ -2577,19 +2577,19 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.btn:"
 msgid "Checkout"
 msgstr "Переключиться"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.chk"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.chk:"
 msgid "Don't show again"
 msgstr "Не спрашивать снова"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.fur"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.fur:"
 msgid "This will make '$1' your current branch."
 msgstr "Текущей веткой станет '$1'"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl:"
 msgid "Do you want to checkout the branch '$1'?"
 msgstr "Переключиться на ветку '$1'?"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.tle"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.tle:"
 msgid "Check Out"
 msgstr "Переключение"
 
@@ -2621,7 +2621,7 @@ msgctxt "dlgSgCheckoutTarget.hdl:"
 msgid "Checkout remote branch"
 msgstr ""
 
-msgctxt "dlgSgCheckoutTarget.inf"
+msgctxt "dlgSgCheckoutTarget.inf:"
 msgid "Create and checkout a new local branch for the selected commit"
 msgstr "Создает локальную ветку для выбранного коммита и переключается на нее"
 
@@ -2641,7 +2641,7 @@ msgctxt "dlgSgCheckoutTarget.rbt:"
 msgid "Don't create local branch \\(just work read-only\\)"
 msgstr "Не создавать локальную ветку \\(только для чтения\\)"
 
-msgctxt "dlgSgCheckoutTarget.tle"
+msgctxt "dlgSgCheckoutTarget.tle:"
 msgid "Check Out"
 msgstr "Переключение"
 
@@ -2669,15 +2669,15 @@ msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr ""
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr ""
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.tle"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.tle:"
 msgid "Check Out"
 msgstr ""
 
@@ -2685,7 +2685,7 @@ msgctxt "dlgSgCherryPickConfigurationFile.btn:"
 msgid "Cherry-Pick"
 msgstr ""
 
-msgctxt "dlgSgCherryPickConfigurationFile.fur"
+msgctxt "dlgSgCherryPickConfigurationFile.fur:"
 msgid "Only changes of these files will be cherry-picked \\(without committing\\)."
 msgstr ""
 
@@ -2697,7 +2697,7 @@ msgctxt "dlgSgCherryPickConfigurationFile.hdl:"
 msgid "Do you want to cherry-pick changes of '$1'?"
 msgstr ""
 
-msgctxt "dlgSgCherryPickConfigurationFile.tle"
+msgctxt "dlgSgCherryPickConfigurationFile.tle:"
 msgid "Cherry-Pick"
 msgstr ""
 
@@ -2709,35 +2709,35 @@ msgctxt "dlgSgCherryPickConfirmation.btn:"
 msgid "Cherry-Pick"
 msgstr "Забрать \\(cherry-pick\\)"
 
-msgctxt "dlgSgCherryPickConfirmation.chk"
+msgctxt "dlgSgCherryPickConfirmation.chk:"
 msgid "Append source commit ID to commit message"
 msgstr "Добавить идентификатор исходного коммита к сообщению коммита"
 
-msgctxt "dlgSgCherryPickConfirmation.fur"
+msgctxt "dlgSgCherryPickConfirmation.fur:"
 msgid "This will cherry-pick the selected commit into the Working Tree."
 msgstr "При выполнении этой операции, изменения выбранного коммита будут перенесены в рабочий каталог."
 
-msgctxt "dlgSgCherryPickConfirmation.hdl"
+msgctxt "dlgSgCherryPickConfirmation.hdl:"
 msgid "Do you want to cherry-pick?"
 msgstr "Вы хотите забрать этот коммит?"
 
-msgctxt "dlgSgCherryPickConfirmation.tle"
+msgctxt "dlgSgCherryPickConfirmation.tle:"
 msgid "Cherry-Pick"
 msgstr "Cherry-pick"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.chk"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.fur"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.fur:"
 msgid "You may need to resolve the conflicts before proceeding."
 msgstr ""
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.hdl"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.hdl:"
 msgid "Cherry-picking failed because of conflicts."
 msgstr ""
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.tle"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.tle:"
 msgid "Cherry Pick"
 msgstr ""
 
@@ -2745,15 +2745,15 @@ msgctxt "dlgSgCherryPickUnpushedCommits.btn:"
 msgid "Cherry-Pick"
 msgstr ""
 
-msgctxt "dlgSgCherryPickUnpushedCommits.fur"
+msgctxt "dlgSgCherryPickUnpushedCommits.fur:"
 msgid "At least one of the selected commits has not been pushed yet, hence cherry-pick is only local and won't be translated to SVN \\(mergeinfo\\)."
 msgstr ""
 
-msgctxt "dlgSgCherryPickUnpushedCommits.hdl"
+msgctxt "dlgSgCherryPickUnpushedCommits.hdl:"
 msgid "Do you want to cherry-pick unpushed commits?"
 msgstr ""
 
-msgctxt "dlgSgCherryPickUnpushedCommits.tle"
+msgctxt "dlgSgCherryPickUnpushedCommits.tle:"
 msgid "Cherry-Pick"
 msgstr ""
 
@@ -2773,11 +2773,11 @@ msgctxt "dlgSgClean.edt:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgClean.hdl"
+msgctxt "dlgSgClean.hdl:"
 msgid "Delete unversioned files"
 msgstr "Удаление непроиндексированных файлов"
 
-msgctxt "dlgSgClean.inf"
+msgctxt "dlgSgClean.inf:"
 msgid "Select which unversioned files should be deleted."
 msgstr "Выберите непроиндексированные файлы, которые будут удалены."
 
@@ -2801,7 +2801,7 @@ msgctxt "dlgSgClean.rbt:"
 msgid "Untracked"
 msgstr "Неотслеживаемые"
 
-msgctxt "dlgSgClean.tle"
+msgctxt "dlgSgClean.tle:"
 msgid "Clean Working Tree"
 msgstr "Очистка рабочего каталога"
 
@@ -2809,27 +2809,27 @@ msgctxt "dlgSgCleanDeleteFiles.btn:"
 msgid "Delete Files"
 msgstr "Удалить файлы"
 
-msgctxt "dlgSgCleanDeleteFiles.fur"
+msgctxt "dlgSgCleanDeleteFiles.fur:"
 msgid "Git reported following files and directories to be deleted:"
 msgstr "Git предоставил следующий список файлов и каталогов для удаления:"
 
-msgctxt "dlgSgCleanDeleteFiles.hdl"
+msgctxt "dlgSgCleanDeleteFiles.hdl:"
 msgid "Do you want to delete these files?"
 msgstr "Удалить эти файлы?"
 
-msgctxt "dlgSgCleanDeleteFiles.tle"
+msgctxt "dlgSgCleanDeleteFiles.tle:"
 msgid "Clean Working Tree"
 msgstr "Очистка рабочего каталога"
 
-msgctxt "dlgSgCleanNoFilesFound.fur"
+msgctxt "dlgSgCleanNoFilesFound.fur:"
 msgid "Your repository only seems to contain tracked files."
 msgstr ""
 
-msgctxt "dlgSgCleanNoFilesFound.hdl"
+msgctxt "dlgSgCleanNoFilesFound.hdl:"
 msgid "No files found to be deleted."
 msgstr ""
 
-msgctxt "dlgSgCleanNoFilesFound.tle"
+msgctxt "dlgSgCleanNoFilesFound.tle:"
 msgid "Clean Working Tree"
 msgstr ""
 
@@ -2861,7 +2861,7 @@ msgctxt "dlgSgClone.chk:"
 msgid "Map SVN trunk, tags and branches to Git"
 msgstr ""
 
-msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\""
+msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
 msgid "Skip large files \\(\"partial clone\"\\)"
 msgstr "Пропустить большие файлы \\(\"частичное клонирование\"\\)"
 
@@ -3009,7 +3009,7 @@ msgctxt "dlgSgClone.rbt:"
 msgid "Remote repository"
 msgstr ""
 
-msgctxt "dlgSgClone.tle"
+msgctxt "dlgSgClone.tle:"
 msgid "Clone"
 msgstr "Клонирование"
 
@@ -3025,15 +3025,15 @@ msgctxt "dlgSgClone.ttpPartialWarning:"
 msgid "This functionality depends on the capabilities of your server."
 msgstr ""
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.fur"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.fur:"
 msgid "Please select an empty, local directory for the new repository."
 msgstr ""
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.hdl"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.hdl:"
 msgid "The selected directory is a Git repository."
 msgstr ""
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.tle"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.tle:"
 msgid "Input Validation"
 msgstr ""
 
@@ -3045,15 +3045,15 @@ msgctxt "dlgSgCloneRepositoryType.btn:"
 msgid "SVN"
 msgstr ""
 
-msgctxt "dlgSgCloneRepositoryType.fur"
+msgctxt "dlgSgCloneRepositoryType.fur:"
 msgid "The specified URL protocol is ambiguous and may refer to different types of repositories."
 msgstr ""
 
-msgctxt "dlgSgCloneRepositoryType.hdl"
+msgctxt "dlgSgCloneRepositoryType.hdl:"
 msgid "Select the type of repository you are going to clone."
 msgstr ""
 
-msgctxt "dlgSgCloneRepositoryType.tle"
+msgctxt "dlgSgCloneRepositoryType.tle:"
 msgid "Clone"
 msgstr ""
 
@@ -3065,11 +3065,11 @@ msgctxt "dlgSgCloneSetCredentialHelper.btn:"
 msgid "Set SmartGit as Credential-Helper"
 msgstr ""
 
-msgctxt "dlgSgCloneSetCredentialHelper.fur"
+msgctxt "dlgSgCloneSetCredentialHelper.fur:"
 msgid "If selected, SmartGit will be set as `credential.helper` in the `.git\\\\/config` of newly cloned repositories that are cloned directly from a configured Hosting Provider. Executing remote Git commands \\(e.g. \\*pull\\* or \\*push\\*\\) in the terminal or a shell script will then use the credentials known to SmartGit.\\n\\nThis repository setting will only affect new clones and takes precedence over any `credential.helper` configuration in your user `~\\\\/.gitconfig`.\\n\\nFor already cloned repositories the setting \\*Use SmartGit as credential helper\\* can be changed in \\*Repository \\| Settings\\*.\\n\\n\\*When to select?\\*\\nIf you solely use SmartGit as your GUI client and you use Git from the command line, we suggest selecting this option. It will simplify the authentication process when accessing platforms like GitHub.\\n\\n\\*When not to set?\\*\\nIf you also use other GUI clients, adding this configuration may disrupt the authentication of these tools and should be avoided.\\n\\nIf you do not use Git on command line or other GUI clients, selecting this option serves no purpose and is not recommended."
 msgstr ""
 
-msgctxt "dlgSgCloneSetCredentialHelper.hdl"
+msgctxt "dlgSgCloneSetCredentialHelper.hdl:"
 msgid "Do you want to configure SmartGit as credential helper?"
 msgstr ""
 
@@ -3077,19 +3077,19 @@ msgctxt "dlgSgCloneSetCredentialHelper.mni:"
 msgid "Copy"
 msgstr ""
 
-msgctxt "dlgSgCloneSetCredentialHelper.tle"
+msgctxt "dlgSgCloneSetCredentialHelper.tle:"
 msgid "Clone"
 msgstr ""
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.fur"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.fur:"
 msgid "SmartGit now continues to fetch all other revisions in the background. You may safely start working with the repository now; only log-related operations will be affected by this intermediate state.\\n\\nOnce SmartGit has finished the background part of the clone, it will let you know in the notifications area \\(status bar\\) and you can complete the clone there."
 msgstr ""
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.hdl"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.hdl:"
 msgid "HEAD revision has been successfully cloned."
 msgstr ""
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.tle"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.tle:"
 msgid "Clone"
 msgstr ""
 
@@ -3153,11 +3153,11 @@ msgctxt "dlgSgCommit.err:"
 msgid "Select at least one file to commit."
 msgstr ""
 
-msgctxt "dlgSgCommit.hdl"
+msgctxt "dlgSgCommit.hdl:"
 msgid "Commit local or staged changes"
 msgstr "Фиксация локальных или проиндексированных изменений"
 
-msgctxt "dlgSgCommit.inf"
+msgctxt "dlgSgCommit.inf:"
 msgid "Select the files you want to commit and provide a commit message."
 msgstr "Выберите файлы, которые хотите зафиксировать и введите текст сообщения коммита."
 
@@ -3197,7 +3197,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Merge commit \\(multiple parents\\)"
 msgstr ""
 
-msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\""
+msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
 msgid "Simple commit \\(one parent, \"squash\"\\)"
 msgstr ""
 
@@ -3205,7 +3205,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Staged Changes"
 msgstr "Проиндексированные изменения"
 
-msgctxt "dlgSgCommit.tle"
+msgctxt "dlgSgCommit.tle:"
 msgid "Commit"
 msgstr "Фиксация изменений"
 
@@ -3221,27 +3221,27 @@ msgctxt "dlgSgCommitAmendAlreadyPushedCommit.btn:"
 msgid "Amend"
 msgstr "Изменить"
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.fur"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.fur:"
 msgid "If you amend a pushed commit, you will need to force-push it later. This might overwrite other users' changes."
 msgstr "Если изменить отправленный коммит, то необходимо будет воспользоваться принудительной отправкой изменений. Это действие может перезаписать изменения, внесенные другими пользователями."
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.hdl"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.hdl:"
 msgid "Do you want to amend an already pushed commit?"
 msgstr "Вы хотите изменить уже отправленный коммит?"
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.tle"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.tle:"
 msgid "Commit"
 msgstr "Фиксация изменений"
 
-msgctxt "dlgSgCommitCantAmend.fur"
+msgctxt "dlgSgCommitCantAmend.fur:"
 msgid "Can't modify an already pushed commit. If you know what you are doing and want to enable it, select the option 'Allow modifying pushed commits' in the preferences."
 msgstr ""
 
-msgctxt "dlgSgCommitCantAmend.hdl"
+msgctxt "dlgSgCommitCantAmend.hdl:"
 msgid "Can't amend commit."
 msgstr ""
 
-msgctxt "dlgSgCommitCantAmend.tle"
+msgctxt "dlgSgCommitCantAmend.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3253,15 +3253,15 @@ msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.btn:"
 msgid "Create Commit"
 msgstr ""
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.fur"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.fur:"
 msgid "The repository is in 'rebasing' state. Instead of creating an additional commit as part of your rebased commits, you will usually just want continue the rebase."
 msgstr ""
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.hdl"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.hdl:"
 msgid "Do you want to continue the rebase or create an additional commit?"
 msgstr ""
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.tle"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -3269,15 +3269,15 @@ msgctxt "dlgSgCommitDirectlyTo.btn:"
 msgid "Commit Anyway"
 msgstr ""
 
-msgctxt "dlgSgCommitDirectlyTo.fur"
+msgctxt "dlgSgCommitDirectlyTo.fur:"
 msgid "You have Git-Flow configured and committing to the Git-Flow master branch should not happen directly but only with the help of the Git-Flow commands and merging.\\n\\nIf in doubt, please contact your administrator."
 msgstr ""
 
-msgctxt "dlgSgCommitDirectlyTo.hdl"
+msgctxt "dlgSgCommitDirectlyTo.hdl:"
 msgid "Do you want to commit directly to 'master'?"
 msgstr ""
 
-msgctxt "dlgSgCommitDirectlyTo.tle"
+msgctxt "dlgSgCommitDirectlyTo.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3297,27 +3297,27 @@ msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.chk:"
 msgid "Include untracked files"
 msgstr "Включить неотслеживаемые файлы"
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.fur"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.fur:"
 msgid "No file is staged yet. To commit all \\(visible\\) working tree changes, click Commit All. To stage individual changes, click Cancel."
 msgstr "Нет проиндексированных файлов. Для фиксации всех \\(видимых\\) изменений в рабочем каталоге нажмите Зафиксировать все. Если хотите проиндексировать отдельные, нажмите Отмена."
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.hdl"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.hdl:"
 msgid "Do you want to commit all \\(visible\\) working tree changes?"
 msgstr "Хотите зафиксировать все \\(видимые\\) изменения в рабочем каталоге?"
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.tle"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.tle:"
 msgid "Commit"
 msgstr "Фиксация изменений"
 
-msgctxt "dlgSgCommitIndexNoFilesFound.fur"
+msgctxt "dlgSgCommitIndexNoFilesFound.fur:"
 msgid "There is nothing to commit."
 msgstr ""
 
-msgctxt "dlgSgCommitIndexNoFilesFound.hdl"
+msgctxt "dlgSgCommitIndexNoFilesFound.hdl:"
 msgid "There is nothing to commit."
 msgstr ""
 
-msgctxt "dlgSgCommitIndexNoFilesFound.tle"
+msgctxt "dlgSgCommitIndexNoFilesFound.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3329,27 +3329,27 @@ msgctxt "dlgSgCommitMessageContainsComments.btn:"
 msgid "Strip Comments"
 msgstr "Удалить комментарии"
 
-msgctxt "dlgSgCommitMessageContainsComments.fur"
+msgctxt "dlgSgCommitMessageContainsComments.fur:"
 msgid "The commit message contains lines starting with # which Git would treat as comment \\(and thus strip from the message\\).\\n\\nFor advanced comment-handling you may consider to use Git's config option 'core.commentChar'.\\n\\nIf you always want to keep or strip comment lines, you can configure this in the Preferences."
 msgstr "Сообщение коммита содержит строки, начинающиеся с #, что воспринимается git как комментарии \\(они удаляются из итогового сообщения\\).\\n\\nМожно изменить настройку git 'core.commentChar', чтобы другой символ воспринимался как комментарий.\\n\\nЕсли хотите всегда сохранять или удалять строки комментариев, то можете настроить в меню Параметры."
 
-msgctxt "dlgSgCommitMessageContainsComments.hdl"
+msgctxt "dlgSgCommitMessageContainsComments.hdl:"
 msgid "Should comment lines be committed as-is?"
 msgstr "Должны ли строки комментариев сохраняться как есть?"
 
-msgctxt "dlgSgCommitMessageContainsComments.tle"
+msgctxt "dlgSgCommitMessageContainsComments.tle:"
 msgid "Commit"
 msgstr "Фиксация изменений"
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.fur"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.fur:"
 msgid "Neither staged files nor locally changed files were found."
 msgstr ""
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.hdl"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.hdl:"
 msgid "There is nothing to commit."
 msgstr ""
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.tle"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3365,7 +3365,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.chk:"
 msgid "Add 'fixup!' prefix for easier automatic squashing using Interactive Rebase"
 msgstr ""
 
-msgctxt "dlgSgCommitSelectMessageFromLog.hdl"
+msgctxt "dlgSgCommitSelectMessageFromLog.hdl:"
 msgid "Select a commit"
 msgstr "Выберите коммит"
 
@@ -3373,7 +3373,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
 msgid "No repository selected."
 msgstr ""
 
-msgctxt "dlgSgCommitSelectMessageFromLog.inf"
+msgctxt "dlgSgCommitSelectMessageFromLog.inf:"
 msgid "Choose the commit whose message should be used."
 msgstr "Выберите коммит, сообщение которого будет использовано."
 
@@ -3433,7 +3433,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.tbt:"
 msgid "Interpret the search pattern as regular expression."
 msgstr "Интерпретировать строку поиска как регулярное выражение."
 
-msgctxt "dlgSgCommitSelectMessageFromLog.tle"
+msgctxt "dlgSgCommitSelectMessageFromLog.tle:"
 msgid "Select Commit Message"
 msgstr "Выбор сообщения коммита"
 
@@ -3445,15 +3445,15 @@ msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.btn:"
 msgid "Commit File"
 msgstr ""
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.fur"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.fur:"
 msgid "You either can commit the single selected file or all \\(visible\\) changed files."
 msgstr ""
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.hdl"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.hdl:"
 msgid "What do you want to commit?"
 msgstr ""
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.tle"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -3461,15 +3461,15 @@ msgctxt "dlgSgCommitToDetachedHead.btn:"
 msgid "Commit Anyway"
 msgstr "Зафиксировать сейчас"
 
-msgctxt "dlgSgCommitToDetachedHead.fur"
+msgctxt "dlgSgCommitToDetachedHead.fur:"
 msgid "The repository HEAD currently does not point to a branch, but directly refers to a commit \\(SHA\\). When committing, the newly created commit will only be reachable by its SHA and hence may get lost easily.\\n\\nInstead of committing now, you should first create a branch for your current HEAD and commit afterwards."
 msgstr "HEAD репозитория в настоящий момент не указывает на ветку, а ссылается на коммит \\(SHA\\). При фиксации изменений созданный коммит будет доступен только по SHA и может быть потерян.\\n\\nВместо фиксации изменений, следует создать ветку, а только потом выполнить фиксацию."
 
-msgctxt "dlgSgCommitToDetachedHead.hdl"
+msgctxt "dlgSgCommitToDetachedHead.hdl:"
 msgid "Do you want to commit to a detached HEAD?"
 msgstr "Хотите зафиксировать отдельный HEAD?"
 
-msgctxt "dlgSgCommitToDetachedHead.tle"
+msgctxt "dlgSgCommitToDetachedHead.tle:"
 msgid "Commit"
 msgstr "Фиксация изменений"
 
@@ -3481,23 +3481,23 @@ msgctxt "dlgSgCompareTwoFiles.btn:"
 msgid "Compare with Repository"
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFiles.fur"
+msgctxt "dlgSgCompareTwoFiles.fur:"
 msgid "The files can be compared to their repository content or to each other."
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFiles.hdl"
+msgctxt "dlgSgCompareTwoFiles.hdl:"
 msgid "Should the selected two files be compared with each other?"
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFiles.tle"
+msgctxt "dlgSgCompareTwoFiles.tle:"
 msgid "Compare"
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.fur"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.fur:"
 msgid "To prevent overwriting intentional mixed line-endings, editing and saving is disabled."
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl:"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr ""
 
@@ -3505,15 +3505,15 @@ msgctxt "dlgSgConflictResolverExternalStarted.btn:"
 msgid "Mark Resolved"
 msgstr ""
 
-msgctxt "dlgSgConflictResolverExternalStarted.fur"
+msgctxt "dlgSgConflictResolverExternalStarted.fur:"
 msgid "The external conflict solver has been started. After you have resolved the conflict, you may now mark the file as resolved."
 msgstr ""
 
-msgctxt "dlgSgConflictResolverExternalStarted.hdl"
+msgctxt "dlgSgConflictResolverExternalStarted.hdl:"
 msgid "Do you want to mark the file as resolved?"
 msgstr ""
 
-msgctxt "dlgSgConflictResolverExternalStarted.tle"
+msgctxt "dlgSgConflictResolverExternalStarted.tle:"
 msgid "External Conflict Solver"
 msgstr ""
 
@@ -3525,15 +3525,15 @@ msgctxt "dlgSgConflictSolverMarkResolved.btn:"
 msgid "Mark Resolved"
 msgstr "Пометить решенным"
 
-msgctxt "dlgSgConflictSolverMarkResolved.fur"
+msgctxt "dlgSgConflictSolverMarkResolved.fur:"
 msgid "To complete a conflict resolution, the file needs to be marked as resolved \\(git stage\\). Until marked as resolved, the file remains in conflicted state and you can try other conflict resolutions."
 msgstr "Для завершения, файл должен быть помечен как решенный \\(проиндексирован\\). Пока файл не будет помечен как решенный, он останется в конфликтном состоянии, а вы сможете попробовать другие способы решения конфликта."
 
-msgctxt "dlgSgConflictSolverMarkResolved.hdl"
+msgctxt "dlgSgConflictSolverMarkResolved.hdl:"
 msgid "Do you want to mark the file as resolved?"
 msgstr "Пометить файл решенным?"
 
-msgctxt "dlgSgConflictSolverMarkResolved.tle"
+msgctxt "dlgSgConflictSolverMarkResolved.tle:"
 msgid "Mark Resolved"
 msgstr "Решение"
 
@@ -3545,15 +3545,15 @@ msgctxt "dlgSgConflictSolverStageForCommit.btn:"
 msgid "Stage"
 msgstr ""
 
-msgctxt "dlgSgConflictSolverStageForCommit.fur"
+msgctxt "dlgSgConflictSolverStageForCommit.fur:"
 msgid "Staging is necessary to resolve the file's conflict status."
 msgstr ""
 
-msgctxt "dlgSgConflictSolverStageForCommit.hdl"
+msgctxt "dlgSgConflictSolverStageForCommit.hdl:"
 msgid "Do you want to stage the file for commit now?"
 msgstr ""
 
-msgctxt "dlgSgConflictSolverStageForCommit.tle"
+msgctxt "dlgSgConflictSolverStageForCommit.tle:"
 msgid "Stage for Commit"
 msgstr ""
 
@@ -3617,7 +3617,7 @@ msgctxt "dlgSgCustomizeProjectUi.tab:"
 msgid "Toolbar"
 msgstr ""
 
-msgctxt "dlgSgCustomizeProjectUi.tle"
+msgctxt "dlgSgCustomizeProjectUi.tle:"
 msgid "Customize"
 msgstr ""
 
@@ -3629,23 +3629,23 @@ msgctxt "dlgSgDeleteDirTrash.btn:"
 msgid "Move to Trash"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.fur"
+msgctxt "dlgSgDeleteDirTrash.fur:"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.hdl"
+msgctxt "dlgSgDeleteDirTrash.hdl:"
 msgid "Do you want to delete '$1' recursively?"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.tle"
+msgctxt "dlgSgDeleteDirTrash.tle:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgDeleteFileTrash.hdl"
+msgctxt "dlgSgDeleteFileTrash.hdl:"
 msgid "Do you want to delete '$1'?"
 msgstr "Удалить файл '$1'?"
 
-msgctxt "dlgSgDeleteFilesTrash.hdl"
+msgctxt "dlgSgDeleteFilesTrash.hdl:"
 msgid "Do you want to delete the $1 selected files?"
 msgstr ""
 
@@ -3669,11 +3669,11 @@ msgctxt "dlgSgDiscard.edt:"
 msgid "Revert to"
 msgstr "Вернуться к"
 
-msgctxt "dlgSgDiscard.hdl"
+msgctxt "dlgSgDiscard.hdl:"
 msgid "Discard local or staged changes"
 msgstr "Отмена локальных или индексированных изменений"
 
-msgctxt "dlgSgDiscard.inf"
+msgctxt "dlgSgDiscard.inf:"
 msgid "Select the files for which changes should be discarded and whether to set them back to Index or HEAD state."
 msgstr "Выберите файлы, изменения которых нужно отменить, а также укажите, стоит ли вернуть их к состоянию индекса или HEAD."
 
@@ -3713,39 +3713,39 @@ msgctxt "dlgSgDiscard.rbt:"
 msgid "Index"
 msgstr "Индекс"
 
-msgctxt "dlgSgDiscard.tle"
+msgctxt "dlgSgDiscard.tle:"
 msgid "Discard"
 msgstr "Отмена изменений"
 
-msgctxt "dlgSgDiscardNoFilesFound.fur"
+msgctxt "dlgSgDiscardNoFilesFound.fur:"
 msgid "Neither staged files nor locally changed files were found."
 msgstr "Нет не локальных, ни проиндексированных изменений, которые можно было бы отменить"
 
-msgctxt "dlgSgDiscardNoFilesFound.hdl"
+msgctxt "dlgSgDiscardNoFilesFound.hdl:"
 msgid "There is nothing to discard."
 msgstr "Нечего отменять"
 
-msgctxt "dlgSgDiscardNoFilesFound.tle"
+msgctxt "dlgSgDiscardNoFilesFound.tle:"
 msgid "Discard"
 msgstr "Отмена изменений"
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.fur"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.fur:"
 msgid "You have selected to discard only the Index changes of one or more files. However, at least one of the files is also modified in the working tree. It is not possible to discard only Index changes in this case.\\n\\nIf you actually want to discard the working tree changes, select the file in the working tree table."
 msgstr ""
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.hdl"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.hdl:"
 msgid "Discarding Index changes is not possible."
 msgstr ""
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToHead.hdl"
+msgctxt "dlgSgDiscardRevertToHead.hdl:"
 msgid "Do you want to reset $1 files back to their HEAD state?"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToIndex.hdl"
+msgctxt "dlgSgDiscardRevertToIndex.hdl:"
 msgid "Do you want to reset $1 files back to their Index state?"
 msgstr ""
 
@@ -3753,15 +3753,15 @@ msgctxt "dlgSgDiscardRevertTo(Head|Index).btn:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertTo(Head|Index).fur"
+msgctxt "dlgSgDiscardRevertTo(Head|Index).fur:"
 msgid "The content might be hard to restore!"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertTo(Head|Index).tle"
+msgctxt "dlgSgDiscardRevertTo(Head|Index).tle:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgErrorUtilsClientException.fur"
+msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
 msgstr ""
 
@@ -3785,11 +3785,11 @@ msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "svn: $1"
 msgstr ""
 
-msgctxt "dlgSgErrorUtilsClientException.hdl"
+msgctxt "dlgSgErrorUtilsClientException.hdl:"
 msgid "Executing a command has failed."
 msgstr ""
 
-msgctxt "dlgSgErrorUtilsClientException.tle"
+msgctxt "dlgSgErrorUtilsClientException.tle:"
 msgid "Command Failed"
 msgstr ""
 
@@ -3797,19 +3797,19 @@ msgctxt "dlgSgExitConfirmation.btn:"
 msgid "Exit Now"
 msgstr "Выйти"
 
-msgctxt "dlgSgExitConfirmation.chk"
+msgctxt "dlgSgExitConfirmation.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgExitConfirmation.fur"
+msgctxt "dlgSgExitConfirmation.fur:"
 msgid "By closing the last window you will exit SmartGit."
 msgstr "После закрытия последнего окна SmartGit завершит работу."
 
-msgctxt "dlgSgExitConfirmation.hdl"
+msgctxt "dlgSgExitConfirmation.hdl:"
 msgid "Do you want to exit SmartGit now?"
 msgstr "Вы хотите выйти из SmartGit?"
 
-msgctxt "dlgSgExitConfirmation.tle"
+msgctxt "dlgSgExitConfirmation.tle:"
 msgid "Exit"
 msgstr "Выход"
 
@@ -3817,19 +3817,19 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.btn:"
 msgid "Force Opening"
 msgstr ""
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl:"
 msgid "Could not open Conflict Solver for '$1', because it seems to be no text file."
 msgstr ""
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle:"
 msgid "Conflict Solver"
 msgstr ""
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.hdl"
+msgctxt "dlgSgFileCompareInvokerFailedIO.hdl:"
 msgid "'$1' could not be invoked."
 msgstr ""
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.tle"
+msgctxt "dlgSgFileCompareInvokerFailedIO.tle:"
 msgid "Open"
 msgstr ""
 
@@ -3837,19 +3837,19 @@ msgctxt "dlgSgFileCompareNoChanges.btn:"
 msgid "Open"
 msgstr "Открыть"
 
-msgctxt "dlgSgFileCompareNoChanges.chk"
+msgctxt "dlgSgFileCompareNoChanges.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgFileCompareNoChanges.fur"
+msgctxt "dlgSgFileCompareNoChanges.fur:"
 msgid "Both file contents are byte-wise equal.\\nTo see the file contents anyway, click 'Open'."
 msgstr "Оба варианта файла одинаковы на бинарном уровне. \\Чтобы все равно просмотреть содержимое файла, нажмите 'Открыть'."
 
-msgctxt "dlgSgFileCompareNoChanges.hdl"
+msgctxt "dlgSgFileCompareNoChanges.hdl:"
 msgid "Open the file compare though no changes will be shown?"
 msgstr "Открыть сравнение файла без отображения отличий?"
 
-msgctxt "dlgSgFileCompareNoChanges.tle"
+msgctxt "dlgSgFileCompareNoChanges.tle:"
 msgid "File Compare"
 msgstr "Сравнение файлов"
 
@@ -3857,7 +3857,7 @@ msgctxt "dlgSgFindObject.edt:"
 msgid "Repository Path, Commit ID or Ref"
 msgstr ""
 
-msgctxt "dlgSgFindObject.tle"
+msgctxt "dlgSgFindObject.tle:"
 msgid "Find Object"
 msgstr ""
 
@@ -3865,15 +3865,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.btn:"
 msgid "Fast-Forward"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur:"
 msgid "The local branch '$1' is behind its tracked branch '$2'. You may fast-forward now or do it manually later, e.g. by checking out the branch '$3'."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl:"
 msgid "Should branch '$1' be fast-forwarded to '$2'?"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.tle:"
 msgid "Start Feature"
 msgstr ""
 
@@ -3881,15 +3881,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.btn:"
 msgid "Replace"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur:"
 msgid "The local branch '$1' seems to contain more recent but rewritten commits of remote branch '$2'.\\n\\nIf you are not sure whether the local branch is actually more recent than the remote branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl:"
 msgid "Should branch '$1' replace remote branch '$2'?"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.tle:"
 msgid "Finish Feature"
 msgstr ""
 
@@ -3897,15 +3897,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur:"
 msgid "The remote branch '$1' seems to contain more recent but rewritten commits of local branch '$2'.\\n\\nIf you are not sure whether the remote branch is actually more recent than the local branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl:"
 msgid "Should branch '$1' be reset to remote branch '$2'?"
 msgstr ""
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.tle:"
 msgid "Finish Feature"
 msgstr ""
 
@@ -3957,11 +3957,11 @@ msgctxt "dlgSgFlowConfigure.edt:"
 msgid "Version Tags"
 msgstr "Метки версий"
 
-msgctxt "dlgSgFlowConfigure.hdl"
+msgctxt "dlgSgFlowConfigure.hdl:"
 msgid "Configure the branch naming scheme"
 msgstr "Настройка схемы именования веток"
 
-msgctxt "dlgSgFlowConfigure.inf"
+msgctxt "dlgSgFlowConfigure.inf:"
 msgid "Configure how your feature, release and hotfix branches should be named."
 msgstr "Настройте, как будут именоваться ветки задач, релизов, хотфиксов и т.д."
 
@@ -3977,7 +3977,7 @@ msgctxt "dlgSgFlowConfigure.rbt:"
 msgid "Light \\(just feature branches\\)"
 msgstr "Легкий \\(только ветки задач\\)"
 
-msgctxt "dlgSgFlowConfigure.tle"
+msgctxt "dlgSgFlowConfigure.tle:"
 msgid "Configure Git-Flow"
 msgstr "Настройка Git-Flow"
 
@@ -3989,15 +3989,15 @@ msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.btn:"
 msgid "Switch-Off Git-Flow"
 msgstr "Отключить"
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.fur"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.fur:"
 msgid "Git-Flow is already configured for this repository. You may change the Git-Flow configuration or switch-off the Git-Flow features. In both cases, the file ~/.git/config will be modified accordingly."
 msgstr "Git-Flow настроен в репозитории. Вы можете изменить настройки или отключить функции Git-Flow. В любом случае, файл ~/.git/config будет изменен."
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.hdl"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.hdl:"
 msgid "Do you want to change or switch-off the Git-Flow configuration?"
 msgstr "Вы хотите изменить настройки или отключить Git-Flow?"
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.tle"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.tle:"
 msgid "Configure Git-Flow"
 msgstr "Настройка Git-Flow"
 
@@ -4025,7 +4025,7 @@ msgctxt "dlgSgFlowFeatureFinish.edt:"
 msgid "Commit Message"
 msgstr "Сообщение коммита"
 
-msgctxt "dlgSgFlowFeatureFinish.hdl"
+msgctxt "dlgSgFlowFeatureFinish.hdl:"
 msgid "Finish current feature"
 msgstr "Завершение работы над текущей задачей"
 
@@ -4057,7 +4057,7 @@ msgctxt "dlgSgFlowFeatureFinish.rbt:"
 msgid "Rebase onto '$1'"
 msgstr "Переместить поверх '$1'"
 
-msgctxt "dlgSgFlowFeatureFinish.tle"
+msgctxt "dlgSgFlowFeatureFinish.tle:"
 msgid "Finish Feature"
 msgstr "Завершение задачи"
 
@@ -4081,11 +4081,11 @@ msgctxt "dlgSgFlowFeatureStart.err:"
 msgid "Invalid feature name: The name must not end with a slash or dot."
 msgstr "Ошибка: имя не может заканчиваться слэшем или точкой."
 
-msgctxt "dlgSgFlowFeatureStart.hdl"
+msgctxt "dlgSgFlowFeatureStart.hdl:"
 msgid "Start a new feature"
 msgstr "Начало работы над новой задачей"
 
-msgctxt "dlgSgFlowFeatureStart.inf"
+msgctxt "dlgSgFlowFeatureStart.inf:"
 msgid "Enter the name of the new feature branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Введите имя новой ветки задачи. В результате будет создана новая ветка из ветки '$1'"
 
@@ -4093,7 +4093,7 @@ msgctxt "dlgSgFlowFeatureStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "Итоговое имя ветки: $1"
 
-msgctxt "dlgSgFlowFeatureStart.tle"
+msgctxt "dlgSgFlowFeatureStart.tle:"
 msgid "Start Feature"
 msgstr "Начать задачу"
 
@@ -4161,7 +4161,7 @@ msgctxt "dlgSgFlowHotfixFinish.inf:"
 msgid "Choose how to finish the hotfix branch '$1'."
 msgstr ""
 
-msgctxt "dlgSgFlowHotfixFinish.tle"
+msgctxt "dlgSgFlowHotfixFinish.tle:"
 msgid "Finish Hotfix"
 msgstr "Выпуск хотфикса"
 
@@ -4185,11 +4185,11 @@ msgctxt "dlgSgFlowHotfixStart.edt:"
 msgid "Hotfix Name"
 msgstr "Имя хотфикса"
 
-msgctxt "dlgSgFlowHotfixStart.hdl"
+msgctxt "dlgSgFlowHotfixStart.hdl:"
 msgid "Start a new hotfix"
 msgstr "Создание нового хотфикса"
 
-msgctxt "dlgSgFlowHotfixStart.inf"
+msgctxt "dlgSgFlowHotfixStart.inf:"
 msgid "Enter the name of the new hotfix branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Введите имя новой ветки хотфикса. В результате будет создана новая ветка из ветки '$1'"
 
@@ -4197,7 +4197,7 @@ msgctxt "dlgSgFlowHotfixStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "Итоговое имя ветки: $1"
 
-msgctxt "dlgSgFlowHotfixStart.tle"
+msgctxt "dlgSgFlowHotfixStart.tle:"
 msgid "Start Hotfix"
 msgstr "Начало хотфикса"
 
@@ -4209,7 +4209,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.chk:"
 msgid "Fetch latest '$1' commits from remote repository"
 msgstr "Получить последние изменения ветки '$1' с внешнего репозитория"
 
-msgctxt "dlgSgFlowIntegrateDevelop.hdl"
+msgctxt "dlgSgFlowIntegrateDevelop.hdl:"
 msgid "Integrate commits from '$1'"
 msgstr "Включение коммитов ветки '$1'"
 
@@ -4233,7 +4233,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.rbt:"
 msgid "Rebase current feature onto '$1'"
 msgstr "Переместить текущую ветку поверх '$1'"
 
-msgctxt "dlgSgFlowIntegrateDevelop.tle"
+msgctxt "dlgSgFlowIntegrateDevelop.tle:"
 msgid "Integrate Develop"
 msgstr "Включение develop"
 
@@ -4293,7 +4293,7 @@ msgctxt "dlgSgFlowReleaseFinish.inf:"
 msgid "Choose how to finish the release branch '$1'."
 msgstr ""
 
-msgctxt "dlgSgFlowReleaseFinish.tle"
+msgctxt "dlgSgFlowReleaseFinish.tle:"
 msgid "Finish Release"
 msgstr "Выпуск релиза"
 
@@ -4317,11 +4317,11 @@ msgctxt "dlgSgFlowReleaseStart.edt:"
 msgid "Release Name"
 msgstr "Имя релиза"
 
-msgctxt "dlgSgFlowReleaseStart.hdl"
+msgctxt "dlgSgFlowReleaseStart.hdl:"
 msgid "Start a new release"
 msgstr "Начать выпуск нового релиза"
 
-msgctxt "dlgSgFlowReleaseStart.inf"
+msgctxt "dlgSgFlowReleaseStart.inf:"
 msgid "Enter the name of the new release branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Введите имя новой ветки релиза. В результате будет создано ответвление новой ветки от ветки '$1'"
 
@@ -4329,7 +4329,7 @@ msgctxt "dlgSgFlowReleaseStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "Итоговое имя ветки: $1"
 
-msgctxt "dlgSgFlowReleaseStart.tle"
+msgctxt "dlgSgFlowReleaseStart.tle:"
 msgid "Start Release"
 msgstr "Начало релиза"
 
@@ -4353,11 +4353,11 @@ msgctxt "dlgSgFlowSupportStart.edt:"
 msgid "Support Name"
 msgstr "Имя"
 
-msgctxt "dlgSgFlowSupportStart.hdl"
+msgctxt "dlgSgFlowSupportStart.hdl:"
 msgid "Start a new support"
 msgstr "Создание новой сервисной ветки"
 
-msgctxt "dlgSgFlowSupportStart.inf"
+msgctxt "dlgSgFlowSupportStart.inf:"
 msgid "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Введите имя новой сервисной ветки. В результате будет создана новая ветка из ветки '$1'"
 
@@ -4365,7 +4365,7 @@ msgctxt "dlgSgFlowSupportStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "Итоговое имя ветки: $1"
 
-msgctxt "dlgSgFlowSupportStart.tle"
+msgctxt "dlgSgFlowSupportStart.tle:"
 msgid "Start Support"
 msgstr "Создание сервисной ветки"
 
@@ -4385,15 +4385,15 @@ msgctxt "dlgSgGarbageCollector.chk:"
 msgid "Optimize repository more aggressively \\(may take a while\\)"
 msgstr "Агрессивная оптимизация репозитория \\(может занять длительное время\\)"
 
-msgctxt "dlgSgGarbageCollector.hdl"
+msgctxt "dlgSgGarbageCollector.hdl:"
 msgid "Run Garbage Collector"
 msgstr "Запуск сборщика мусора"
 
-msgctxt "dlgSgGarbageCollector.inf"
+msgctxt "dlgSgGarbageCollector.inf:"
 msgid "Running the Git garbage collector will prune unreachable objects and optimize the local repository in order to reduce disk space and increase performance."
 msgstr "Выполнение сборщика мусора git удаляет устаревшие объекты и оптимизирует локальный репозиторий для снижения занимаемого места и повышения производительности."
 
-msgctxt "dlgSgGarbageCollector.tle"
+msgctxt "dlgSgGarbageCollector.tle:"
 msgid "Run Garbage Collector"
 msgstr "Запуск сборщика мусора"
 
@@ -4401,15 +4401,15 @@ msgctxt "dlgSgGarbageCollectorDeleteAllStashes.btn:"
 msgid "Delete Stashes"
 msgstr ""
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.fur"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.fur:"
 msgid "Expiring the reflog now will also delete all stashes."
 msgstr ""
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.hdl"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.hdl:"
 msgid "Do you want to also delete all stashes?"
 msgstr ""
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle:"
 msgid "Run Garbage Collector"
 msgstr ""
 
@@ -4433,11 +4433,11 @@ msgctxt "dlgSgGitHubGenerateToken.edt:"
 msgid "Password"
 msgstr ""
 
-msgctxt "dlgSgGitHubGenerateToken.hdl"
+msgctxt "dlgSgGitHubGenerateToken.hdl:"
 msgid "Generate a new API token for GitHub"
 msgstr ""
 
-msgctxt "dlgSgGitHubGenerateToken.inf"
+msgctxt "dlgSgGitHubGenerateToken.inf:"
 msgid "Authenticate at GitHub and grant access to SmartGit."
 msgstr ""
 
@@ -4453,7 +4453,7 @@ msgctxt "dlgSgGitHubGenerateToken.rbt:"
 msgid "Authenticate with your GitHub account and password"
 msgstr ""
 
-msgctxt "dlgSgGitHubGenerateToken.tle"
+msgctxt "dlgSgGitHubGenerateToken.tle:"
 msgid "Generate API Token"
 msgstr ""
 
@@ -4473,15 +4473,15 @@ msgctxt "dlgSgGitHubPullRequestCreate.edt:"
 msgid "Title and Description"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestCreate.hdl"
+msgctxt "dlgSgGitHubPullRequestCreate.hdl:"
 msgid "Create a Pull Request"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestCreate.inf"
+msgctxt "dlgSgGitHubPullRequestCreate.inf:"
 msgid "Send pull request to another repository or branch."
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestCreate.tle"
+msgctxt "dlgSgGitHubPullRequestCreate.tle:"
 msgid "Create Pull Request"
 msgstr ""
 
@@ -4497,11 +4497,11 @@ msgctxt "dlgSgGitHubPullRequestMerge.edt:"
 msgid "Commit Message"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestMerge.hdl"
+msgctxt "dlgSgGitHubPullRequestMerge.hdl:"
 msgid "Merge a Pull Request"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestMerge.inf"
+msgctxt "dlgSgGitHubPullRequestMerge.inf:"
 msgid "Choose how to merge the selected Pull Request."
 msgstr ""
 
@@ -4529,7 +4529,7 @@ msgctxt "dlgSgGitHubPullRequestMerge.rbt:"
 msgid "Merge to Local Repository"
 msgstr ""
 
-msgctxt "dlgSgGitHubPullRequestMerge.tle"
+msgctxt "dlgSgGitHubPullRequestMerge.tle:"
 msgid "Merge Pull Request"
 msgstr ""
 
@@ -4545,11 +4545,11 @@ msgctxt "dlgSgGitLabGenerateToken.edt:"
 msgid "Token"
 msgstr ""
 
-msgctxt "dlgSgGitLabGenerateToken.hdl"
+msgctxt "dlgSgGitLabGenerateToken.hdl:"
 msgid "Generate a new API token for GitLab"
 msgstr ""
 
-msgctxt "dlgSgGitLabGenerateToken.inf"
+msgctxt "dlgSgGitLabGenerateToken.inf:"
 msgid "Paste the OAuth code from your browser."
 msgstr ""
 
@@ -4557,7 +4557,7 @@ msgctxt "dlgSgGitLabGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at GitLab and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgGitLabGenerateToken.tle"
+msgctxt "dlgSgGitLabGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr ""
 
@@ -4573,39 +4573,39 @@ msgctxt "dlgSgGitLabMergeRequestCreate.edt:"
 msgid "Title and Description"
 msgstr ""
 
-msgctxt "dlgSgGitLabMergeRequestCreate.hdl"
+msgctxt "dlgSgGitLabMergeRequestCreate.hdl:"
 msgid "Create a Merge Request"
 msgstr ""
 
-msgctxt "dlgSgGitLabMergeRequestCreate.inf"
+msgctxt "dlgSgGitLabMergeRequestCreate.inf:"
 msgid "Send merge request to another repository or branch."
 msgstr ""
 
-msgctxt "dlgSgGitLabMergeRequestCreate.tle"
+msgctxt "dlgSgGitLabMergeRequestCreate.tle:"
 msgid "Create Merge Request"
 msgstr ""
 
-msgctxt "dlgSgGitLabRefreshFailed.fur"
+msgctxt "dlgSgGitLabRefreshFailed.fur:"
 msgid "Your SmartGit Hosting Provider configuration for GitLab is probably invalid.\\n\\nReview your settings in the Preferences."
 msgstr ""
 
-msgctxt "dlgSgGitLabRefreshFailed.hdl"
+msgctxt "dlgSgGitLabRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr ""
 
-msgctxt "dlgSgGitLabRefreshFailed.tle"
+msgctxt "dlgSgGitLabRefreshFailed.tle:"
 msgid "GitLab"
 msgstr ""
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.fur"
+msgctxt "dlgSgGitLabSettingsInvalidToken.fur:"
 msgid "Use a Personal Access Token from your GitLab account."
 msgstr ""
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.hdl"
+msgctxt "dlgSgGitLabSettingsInvalidToken.hdl:"
 msgid "Please enter a Personal Access Token for your GitLab account."
 msgstr ""
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.tle"
+msgctxt "dlgSgGitLabSettingsInvalidToken.tle:"
 msgid "Input Validation"
 msgstr ""
 
@@ -4617,31 +4617,31 @@ msgctxt "dlgSgHeadMessageListenerReplaceMessage.btn:"
 msgid "Replace This Time"
 msgstr "Заменить в этот раз"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.chk"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.chk:"
 msgid "Never replace if a message is already entered"
 msgstr "Никогда не заменяйте сообщение, если оно уже введено"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.fur"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.fur:"
 msgid "If the commit message input field is empty, the HEAD commit's message will be re-used automatically."
 msgstr "Если поле ввода сообщения коммита пусто, то сообщение коммита HEAD будет использовано повторно."
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.hdl"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.hdl:"
 msgid "Replace entered commit message with the HEAD commit's message?"
 msgstr "Заменить введенное сообщение сообщением HEAD коммита?"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle:"
 msgid "Commit"
 msgstr "Фиксация изменений"
 
-msgctxt "dlgSgHistoryCommitCantBeModified.fur"
+msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
 msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
 msgstr ""
 
-msgctxt "dlgSgHistoryCommitCantBeModified.hdl"
+msgctxt "dlgSgHistoryCommitCantBeModified.hdl:"
 msgid "At least one selected commit can't be modified."
 msgstr "По крайней мере один из выбранных коммитов не может быть изменен."
 
-msgctxt "dlgSgHistoryCommitCantBeModified.tle"
+msgctxt "dlgSgHistoryCommitCantBeModified.tle:"
 msgid "Modify Commit"
 msgstr "Изменение коммита"
 
@@ -4673,15 +4673,15 @@ msgctxt "dlgSgHistoryEditAuthor.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditAuthor.hdl"
+msgctxt "dlgSgHistoryEditAuthor.hdl:"
 msgid "Edit commit author"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditAuthor.inf"
+msgctxt "dlgSgHistoryEditAuthor.inf:"
 msgid "Enter the new commit author and its email address."
 msgstr ""
 
-msgctxt "dlgSgHistoryEditAuthor.tle"
+msgctxt "dlgSgHistoryEditAuthor.tle:"
 msgid "Edit Author"
 msgstr ""
 
@@ -4705,11 +4705,11 @@ msgctxt "dlgSgHistoryEditMessage.edt:"
 msgid "Commit Message"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditMessage.hdl"
+msgctxt "dlgSgHistoryEditMessage.hdl:"
 msgid "Edit commit message"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditMessage.inf"
+msgctxt "dlgSgHistoryEditMessage.inf:"
 msgid "Enter the new commit message."
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgctxt "dlgSgHistoryEditMessage.mni:"
 msgid "Rewrap"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditMessage.tle"
+msgctxt "dlgSgHistoryEditMessage.tle:"
 msgid "Edit Message"
 msgstr ""
 
@@ -4753,19 +4753,19 @@ msgctxt "dlgSgHistoryModifyConfirm.btn:"
 msgid "Modify"
 msgstr "Изменить"
 
-msgctxt "dlgSgHistoryModifyConfirm.chk"
+msgctxt "dlgSgHistoryModifyConfirm.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgHistoryModifyConfirm.fur"
+msgctxt "dlgSgHistoryModifyConfirm.fur:"
 msgid "This allows you to step by step walk from the selected commit to HEAD and modify them by amend-committing."
 msgstr "Вы можете последовательно переходить от выбранного коммита к HEAD, внося изменения."
 
-msgctxt "dlgSgHistoryModifyConfirm.hdl"
+msgctxt "dlgSgHistoryModifyConfirm.hdl:"
 msgid "Do you want to modify the commits?"
 msgstr "Вы хотите изменить коммиты?"
 
-msgctxt "dlgSgHistoryModifyConfirm.tle"
+msgctxt "dlgSgHistoryModifyConfirm.tle:"
 msgid "Modify Commit"
 msgstr "Изменение коммита"
 
@@ -4777,15 +4777,15 @@ msgctxt "dlgSgHistoryModifySplitConfirm.btn:"
 msgid "Split"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifySplitConfirm.fur"
+msgctxt "dlgSgHistoryModifySplitConfirm.fur:"
 msgid "'Modify' will stop after the commit.\\n\\n'Split' will put the changes into the Index. You may discard some changes that should go into the second commit.\\n\\nAfter you've done the changes, process the remaining commits by continuing the rebase."
 msgstr ""
 
-msgctxt "dlgSgHistoryModifySplitConfirm.hdl"
+msgctxt "dlgSgHistoryModifySplitConfirm.hdl:"
 msgid "Do you want to modify or split commit $1?"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifySplitConfirm.tle"
+msgctxt "dlgSgHistoryModifySplitConfirm.tle:"
 msgid "Modify or Split Commit"
 msgstr ""
 
@@ -4793,15 +4793,15 @@ msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.btn:"
 msgid "Force Push"
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl:"
 msgid "Do you want to replace the remote branch by commit $1?"
 msgstr ""
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.tle"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.tle:"
 msgid "Push Up To"
 msgstr ""
 
@@ -4809,15 +4809,15 @@ msgctxt "dlgSgHistoryPushCommitsUpToCommit.btn:"
 msgid "Push"
 msgstr "Отправить"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur:"
 msgid "All commits up to the selected commit will be pushed to the remote repository."
 msgstr "Все коммиты до выбранного будут отправлены во внешний репозиторий."
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl:"
 msgid "Do you want to push changes up to commit $1?"
 msgstr "Вы хотите отправить изменения коммита $1?"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.tle"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.tle:"
 msgid "Push Up To"
 msgstr "Отправка изменений"
 
@@ -4825,11 +4825,11 @@ msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.btn:"
 msgid "Modify Pushed Commits"
 msgstr "Изменить отправленные коммиты"
 
-msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.fur"
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.fur:"
 msgid "Commits which are already pushed are known to other users and may have been used by them to build theirs commits upon. When modifying such commits, these users may run into unexpected conflicts later."
 msgstr "Коммиты уже отправлены и другие пользователи уже могли воспользоваться их изменениями. При изменении коммитов с последующей отправкой, такие пользователи могут столкнуться с неожиданными конфликтами."
 
-msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl"
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl:"
 msgid "Do you want to modify commits which are already pushed?"
 msgstr "Вы хотите изменить ранее отправленные коммиты?"
 
@@ -4865,19 +4865,19 @@ msgctxt "dlgSgHistorySplitConfirm.btn:"
 msgid "Split"
 msgstr ""
 
-msgctxt "dlgSgHistorySplitConfirm.chk"
+msgctxt "dlgSgHistorySplitConfirm.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgHistorySplitConfirm.fur"
+msgctxt "dlgSgHistorySplitConfirm.fur:"
 msgid "This will put the commit's changes into the Index. Unstage those changes that should go into a second commit, then commit the staged changes. Commit the remaining changes in a second \\(or third\\) commit.\\n\\nAfter you are done, process the remaining commits by continuing the rebase."
 msgstr ""
 
-msgctxt "dlgSgHistorySplitConfirm.hdl"
+msgctxt "dlgSgHistorySplitConfirm.hdl:"
 msgid "Do you want to split the selected commit into multiple commits?"
 msgstr ""
 
-msgctxt "dlgSgHistorySplitConfirm.tle"
+msgctxt "dlgSgHistorySplitConfirm.tle:"
 msgid "Split Commit"
 msgstr ""
 
@@ -4905,11 +4905,11 @@ msgctxt "dlgSgHistorySquash.edt:"
 msgid "Commit Message"
 msgstr ""
 
-msgctxt "dlgSgHistorySquash.hdl"
+msgctxt "dlgSgHistorySquash.hdl:"
 msgid "Squash multiple commits"
 msgstr ""
 
-msgctxt "dlgSgHistorySquash.inf"
+msgctxt "dlgSgHistorySquash.inf:"
 msgid "The selected commits will be replaced by one squashed commit containing all changes of the individual commits."
 msgstr ""
 
@@ -4921,7 +4921,7 @@ msgctxt "dlgSgHistorySquash.mni:"
 msgid "Log"
 msgstr ""
 
-msgctxt "dlgSgHistorySquash.tle"
+msgctxt "dlgSgHistorySquash.tle:"
 msgid "Squash Commits"
 msgstr ""
 
@@ -5073,7 +5073,7 @@ msgctxt "dlgSgHostingProviderAdd.lbl:"
 msgid "You can review Azure DevOps applications in the Authorizations section located at the bottom left of your \\[https://aex.dev.azure.com/me profile\\]."
 msgstr ""
 
-msgctxt "dlgSgHostingProviderAdd.tle"
+msgctxt "dlgSgHostingProviderAdd.tle:"
 msgid "Add Hosting Provider"
 msgstr "Добавление хостинг-провайдера"
 
@@ -5177,11 +5177,11 @@ msgctxt "dlgSgHostingProviderEdit.err:"
 msgid "The provided SSL client certificate path is invalid."
 msgstr ""
 
-msgctxt "dlgSgHostingProviderEdit.hdl"
+msgctxt "dlgSgHostingProviderEdit.hdl:"
 msgid "Configure $1 account"
 msgstr ""
 
-msgctxt "dlgSgHostingProviderEdit.inf"
+msgctxt "dlgSgHostingProviderEdit.inf:"
 msgid "Please specify your credentials to connect to $1."
 msgstr ""
 
@@ -5285,7 +5285,7 @@ msgctxt "dlgSgHostingProviderSelectRepository.mni:"
 msgid "Repository"
 msgstr ""
 
-msgctxt "dlgSgHostingProviderSelectRepository.tle"
+msgctxt "dlgSgHostingProviderSelectRepository.tle:"
 msgid "GitHub Projects"
 msgstr ""
 
@@ -5293,15 +5293,15 @@ msgctxt "dlgSgHostingProvider(Add|Edit).lbl:"
 msgid "Optional SSL configuration"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur:"
 msgid "The OAuth-access token could not be requested. Most likely your $1 configuration has changed and SmartGit's stored OAuth credentials are invalid.\\n\\nTo resolve, recreate the $2 hosting provider in the Preferences.\\n\\nDetails:\\n\\n$3"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl:"
 msgid "$1 OAuth-authentication failed"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.tle"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.tle:"
 msgid "HTTP authentication"
 msgstr ""
 
@@ -5321,15 +5321,15 @@ msgctxt "dlgSgHttpPasswordCredentials.edt:"
 msgid "User Name"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordCredentials.hdl"
+msgctxt "dlgSgHttpPasswordCredentials.hdl:"
 msgid "Login to '$1'"
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordCredentials.inf"
+msgctxt "dlgSgHttpPasswordCredentials.inf:"
 msgid "Provide the user name and password for authenticating to the repository."
 msgstr ""
 
-msgctxt "dlgSgHttpPasswordCredentials.tle"
+msgctxt "dlgSgHttpPasswordCredentials.tle:"
 msgid "Login"
 msgstr ""
 
@@ -5337,15 +5337,15 @@ msgctxt "dlgSgIgnoreChanged.btn:"
 msgid "Discard Changes"
 msgstr ""
 
-msgctxt "dlgSgIgnoreChanged.fur"
+msgctxt "dlgSgIgnoreChanged.fur:"
 msgid "The changes will be discarded when proceeding!"
 msgstr ""
 
-msgctxt "dlgSgIgnoreChanged.hdl"
+msgctxt "dlgSgIgnoreChanged.hdl:"
 msgid "Are you sure to remove changed files?"
 msgstr ""
 
-msgctxt "dlgSgIgnoreChanged.tle"
+msgctxt "dlgSgIgnoreChanged.tle:"
 msgid "Ignore"
 msgstr ""
 
@@ -5369,15 +5369,15 @@ msgctxt "dlgSgIgnoreDirectoryConfirm.edt:"
 msgid "Ignore File"
 msgstr ""
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.fur"
+msgctxt "dlgSgIgnoreDirectoryConfirm.fur:"
 msgid "The directory name will be added to the ignore file. If the ignore file does not exist, it will be created."
 msgstr ""
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.hdl"
+msgctxt "dlgSgIgnoreDirectoryConfirm.hdl:"
 msgid "Do you want to ignore directory '$1'?"
 msgstr ""
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.tle"
+msgctxt "dlgSgIgnoreDirectoryConfirm.tle:"
 msgid "Ignore"
 msgstr ""
 
@@ -5385,11 +5385,11 @@ msgctxt "dlgSgIgnoreEdit.btn:"
 msgid "Edit"
 msgstr "Изменить"
 
-msgctxt "dlgSgIgnoreEdit.hdl"
+msgctxt "dlgSgIgnoreEdit.hdl:"
 msgid "Edit Git ignore file"
 msgstr "Редактирование файла игнора git"
 
-msgctxt "dlgSgIgnoreEdit.inf"
+msgctxt "dlgSgIgnoreEdit.inf:"
 msgid "Select the Git ignore file to edit."
 msgstr ""
 
@@ -5401,7 +5401,7 @@ msgctxt "dlgSgIgnoreEdit.mni:"
 msgid "Reveal"
 msgstr ""
 
-msgctxt "dlgSgIgnoreEdit.tle"
+msgctxt "dlgSgIgnoreEdit.tle:"
 msgid "Edit Ignore File"
 msgstr "Изменение файла игнора"
 
@@ -5433,11 +5433,11 @@ msgctxt "dlgSgIgnoreFile.err:"
 msgid "The pattern must match all selected file names. For instance, '$1' is not matched."
 msgstr ""
 
-msgctxt "dlgSgIgnoreFile.hdl"
+msgctxt "dlgSgIgnoreFile.hdl:"
 msgid "Mark files to be ignored"
 msgstr "Пометка файлов для игнорирования"
 
-msgctxt "dlgSgIgnoreFile.inf"
+msgctxt "dlgSgIgnoreFile.inf:"
 msgid "Choose whether to ignore only the selected file or all files matching the specified pattern. Tracked files will be removed \\(stopped from tracking\\)."
 msgstr "Выберите, нужно игнорировать только этот файл или все файлы, соответствующие указанному шаблону. Отслеживаемые файлы будут удалены \\(отслеживание прекратится\\)."
 
@@ -5453,7 +5453,7 @@ msgctxt "dlgSgIgnoreFile.rbt:"
 msgid "Ignore explicitly \\(e.g. 'Makefile'\\)"
 msgstr "Игнорировать явно \\(например 'Makefile'\\)"
 
-msgctxt "dlgSgIgnoreFile.tle"
+msgctxt "dlgSgIgnoreFile.tle:"
 msgid "Ignore"
 msgstr "Игнорирование"
 
@@ -5461,11 +5461,11 @@ msgctxt "dlgSgIgnoreFile.wrn:"
 msgid "Because of performance reasons it is recommended to ignore by pattern - if possible."
 msgstr ""
 
-msgctxt "dlgSgIndexEditorMixedLineEndings.fur"
+msgctxt "dlgSgIndexEditorMixedLineEndings.fur:"
 msgid "At least one of the file contents contains mixed \\(inconsistent\\) line-endings. To prevent overwriting intentional mixed line-endings, editing and saving is disabled."
 msgstr ""
 
-msgctxt "dlgSgIndexEditorMixedLineEndings.hdl"
+msgctxt "dlgSgIndexEditorMixedLineEndings.hdl:"
 msgid "The file is not editable because of mixed line-endings."
 msgstr ""
 
@@ -5477,15 +5477,15 @@ msgctxt "dlgSgIndexEditorSaveOrDiscard.btn:"
 msgid "Save"
 msgstr ""
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.fur"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.fur:"
 msgid "Your changes will be lost, if you don't save them now."
 msgstr ""
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.hdl"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.hdl:"
 msgid "Do you want to save your changes?"
 msgstr ""
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.tle"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.tle:"
 msgid "Close"
 msgstr ""
 
@@ -5497,27 +5497,27 @@ msgctxt "dlgSgJournalDoubleClick.btn:"
 msgid "Open Log"
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.fur"
+msgctxt "dlgSgJournalDoubleClick.fur:"
 msgid "Select either to check out '$1' or to open the Log for the selected commit."
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.hdl"
+msgctxt "dlgSgJournalDoubleClick.hdl:"
 msgid "Do you want to check out '$1'?"
 msgstr ""
 
-msgctxt "dlgSgJournalDoubleClick.tle"
+msgctxt "dlgSgJournalDoubleClick.tle:"
 msgid "Journal"
 msgstr ""
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.fur"
+msgctxt "dlgSgJournalFormCommitCantBeModified.fur:"
 msgid "Not part of your head's first-parent history"
 msgstr ""
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.hdl"
+msgctxt "dlgSgJournalFormCommitCantBeModified.hdl:"
 msgid "At least one selected commit can't be modified."
 msgstr ""
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.tle"
+msgctxt "dlgSgJournalFormCommitCantBeModified.tle:"
 msgid "Edit Author"
 msgstr ""
 
@@ -5525,15 +5525,15 @@ msgctxt "dlgSgLfsInstallConfirm.btn:"
 msgid "Install"
 msgstr "Установить"
 
-msgctxt "dlgSgLfsInstallConfirm.fur"
+msgctxt "dlgSgLfsInstallConfirm.fur:"
 msgid "This will configure hooks and filters required for LFS."
 msgstr "При выполненнии этой операции будут созданы и настроены хуки и необходимые фильтры для LFS."
 
-msgctxt "dlgSgLfsInstallConfirm.hdl"
+msgctxt "dlgSgLfsInstallConfirm.hdl:"
 msgid "Would you like to initialize this repository for Large File Support \\(LFS\\)?"
 msgstr "Хотите инициализировать этот репозиторий для поддержки больших файлов \\(LFS\\)?"
 
-msgctxt "dlgSgLfsInstallConfirm.tle"
+msgctxt "dlgSgLfsInstallConfirm.tle:"
 msgid "LFS Install"
 msgstr "Установка LFS"
 
@@ -5541,15 +5541,15 @@ msgctxt "dlgSgLfsPruneConfirm.btn:"
 msgid "Prune"
 msgstr "Удалить"
 
-msgctxt "dlgSgLfsPruneConfirm.fur"
+msgctxt "dlgSgLfsPruneConfirm.fur:"
 msgid "This will call the remote to ensure that any LFS files to be deleted have copies on the remote before actually deleting them."
 msgstr "Перед удалением локальных файлов, будет выполнена проверка наличия во внешнем репозитории копий всех удаляемых LFS файлов."
 
-msgctxt "dlgSgLfsPruneConfirm.hdl"
+msgctxt "dlgSgLfsPruneConfirm.hdl:"
 msgid "Would you like to delete old LFS files from the local storage?"
 msgstr "Хотите удалить устаревшие LFS файлы из локального хранилища?"
 
-msgctxt "dlgSgLfsPruneConfirm.tle"
+msgctxt "dlgSgLfsPruneConfirm.tle:"
 msgid "LFS Prune"
 msgstr "Очистка LFS от устаревшего"
 
@@ -5561,15 +5561,15 @@ msgctxt "dlgSgLfsTrack.err:"
 msgid "File '$1' does not match the specified pattern."
 msgstr ""
 
-msgctxt "dlgSgLfsTrack.hdl"
+msgctxt "dlgSgLfsTrack.hdl:"
 msgid "Mark a file or pattern as tracked"
 msgstr ""
 
-msgctxt "dlgSgLfsTrack.inf"
+msgctxt "dlgSgLfsTrack.inf:"
 msgid "Specify the file name pattern that should be handled by Large File Support \\(LFS\\)."
 msgstr ""
 
-msgctxt "dlgSgLfsTrack.tle"
+msgctxt "dlgSgLfsTrack.tle:"
 msgid "LFS Track"
 msgstr ""
 
@@ -5577,27 +5577,27 @@ msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.btn:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur:"
 msgid "You are about to apply lines from the Index to the working tree file '$1'. The modifications will be saved immediately."
 msgstr ""
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.hdl"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.hdl:"
 msgid "Do you really want to revert changes in the working tree file?"
 msgstr ""
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.tle"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.tle:"
 msgid "Revert Working Tree File"
 msgstr ""
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.fur"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.fur:"
 msgid "It's not possible to perform the requested operation on an empty repository."
 msgstr ""
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.hdl"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.hdl:"
 msgid "The repository is empty."
 msgstr ""
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.tle"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.tle:"
 msgid "Save Stash"
 msgstr ""
 
@@ -5613,7 +5613,7 @@ msgctxt "dlgSgLogCheckoutFileAs.edt:"
 msgid "Target File"
 msgstr ""
 
-msgctxt "dlgSgLogCheckoutFileAs.hdl"
+msgctxt "dlgSgLogCheckoutFileAs.hdl:"
 msgid "Save the repository file"
 msgstr ""
 
@@ -5625,11 +5625,11 @@ msgctxt "dlgSgLogCheckoutFileAs.inf:"
 msgid "Select whether to save the file state Before or After the selected commit."
 msgstr ""
 
-msgctxt "dlgSgLogCheckoutFileAs.tle"
+msgctxt "dlgSgLogCheckoutFileAs.tle:"
 msgid "Save File As"
 msgstr ""
 
-msgctxt "dlgSgLogCommentDeleteConfirm.hdl"
+msgctxt "dlgSgLogCommentDeleteConfirm.hdl:"
 msgid "Do you really want to delete comment '$1'?"
 msgstr ""
 
@@ -5637,15 +5637,15 @@ msgctxt "dlgSgLogComment(|s)DeleteConfirm.btn:"
 msgid "Delete Comment"
 msgstr ""
 
-msgctxt "dlgSgLogComment(|s)DeleteConfirm.fur"
+msgctxt "dlgSgLogComment(|s)DeleteConfirm.fur:"
 msgid "Comments can't be restored after deletion."
 msgstr ""
 
-msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle"
+msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle:"
 msgid "Delete Comment"
 msgstr ""
 
-msgctxt "dlgSgLogCommentsDeleteConfirm.hdl"
+msgctxt "dlgSgLogCommentsDeleteConfirm.hdl:"
 msgid "Do you really want to delete $1 comments?"
 msgstr ""
 
@@ -5657,15 +5657,15 @@ msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.btn:"
 msgid "Compare With Each Other"
 msgstr "Сравнить друг с другом"
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.fur"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.fur:"
 msgid "You may compare the selected files against each other or open up two separate compares for each file against its previous state."
 msgstr "Вы можете сравнить выбранные два файла между собой или открыть два отдельных сравнения для сравнения с предыдущим состоянием для каждого файла."
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.hdl"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.hdl:"
 msgid "Do you want to compare the selected files against each other?"
 msgstr "Нужно сравнить выбранные файлы друг с другом?"
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.tle"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.tle:"
 msgid "Compare"
 msgstr "Сравнение"
 
@@ -5681,15 +5681,15 @@ msgctxt "dlgSgLogCompareWithWorkingTree.edt:"
 msgid "Working Tree File"
 msgstr "Файл в рабочем каталоге"
 
-msgctxt "dlgSgLogCompareWithWorkingTree.hdl"
+msgctxt "dlgSgLogCompareWithWorkingTree.hdl:"
 msgid "Compare repository file with local file"
 msgstr "Сравнение файла в репозитории с локальным"
 
-msgctxt "dlgSgLogCompareWithWorkingTree.inf"
+msgctxt "dlgSgLogCompareWithWorkingTree.inf:"
 msgid "Select whether to compare with the repository file as it was Before or After the selected commit."
 msgstr "Выберите вариант: сравнить с файлом репозитория, которым он был до или после выбранного коммита."
 
-msgctxt "dlgSgLogCompareWithWorkingTree.tle"
+msgctxt "dlgSgLogCompareWithWorkingTree.tle:"
 msgid "Compare with Working Tree"
 msgstr "Сравнение в рабочем каталоге"
 
@@ -5697,11 +5697,11 @@ msgctxt "dlgSgLogGraphRootSwitch.chk:"
 msgid "Include tracked remote branches"
 msgstr "Включить отслеживаемые внешние ветки"
 
-msgctxt "dlgSgLogGraphRootSwitch.hdl"
+msgctxt "dlgSgLogGraphRootSwitch.hdl:"
 msgid "Select shown branches"
 msgstr "Выберите отображаемые ветки"
 
-msgctxt "dlgSgLogGraphRootSwitch.inf"
+msgctxt "dlgSgLogGraphRootSwitch.inf:"
 msgid "Select the branches for which to show commits in the graph."
 msgstr "Выберите ветки, коммиты по которым будут отображаться в графе."
 
@@ -5709,7 +5709,7 @@ msgctxt "dlgSgLogGraphRootSwitch.mni:"
 msgid "Toggle"
 msgstr ""
 
-msgctxt "dlgSgLogGraphRootSwitch.tle"
+msgctxt "dlgSgLogGraphRootSwitch.tle:"
 msgid "Select Branches"
 msgstr "Выбор веток"
 
@@ -5721,23 +5721,23 @@ msgctxt "dlgSgLogOpenFailedRepository.fur:"
 msgid "Is the repository still valid?"
 msgstr ""
 
-msgctxt "dlgSgLogOpenFailedRepository.hdl"
+msgctxt "dlgSgLogOpenFailedRepository.hdl:"
 msgid "Repository could not be opened."
 msgstr "Репозиторий не может быть открыт."
 
-msgctxt "dlgSgLogOpenFailedRepository.tle"
+msgctxt "dlgSgLogOpenFailedRepository.tle:"
 msgid "Log"
 msgstr "Информация"
 
-msgctxt "dlgSgLogOpenFailedSubmodule.fur"
+msgctxt "dlgSgLogOpenFailedSubmodule.fur:"
 msgid "Is the repository still valid?"
 msgstr ""
 
-msgctxt "dlgSgLogOpenFailedSubmodule.hdl"
+msgctxt "dlgSgLogOpenFailedSubmodule.hdl:"
 msgid "Submodule could not be opened."
 msgstr ""
 
-msgctxt "dlgSgLogOpenFailedSubmodule.tle"
+msgctxt "dlgSgLogOpenFailedSubmodule.tle:"
 msgid "Log"
 msgstr ""
 
@@ -5749,15 +5749,15 @@ msgctxt "dlgSgLogOpenNewWindow.btn:"
 msgid "New Window"
 msgstr ""
 
-msgctxt "dlgSgLogOpenNewWindow.fur"
+msgctxt "dlgSgLogOpenNewWindow.fur:"
 msgid "There is already an existing Log window which can be revealed."
 msgstr ""
 
-msgctxt "dlgSgLogOpenNewWindow.hdl"
+msgctxt "dlgSgLogOpenNewWindow.hdl:"
 msgid "Do you want to open a new Log window?"
 msgstr ""
 
-msgctxt "dlgSgLogOpenNewWindow.tle"
+msgctxt "dlgSgLogOpenNewWindow.tle:"
 msgid "Log"
 msgstr ""
 
@@ -5769,15 +5769,15 @@ msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.btn:"
 msgid "Submodule Log"
 msgstr ""
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.fur"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.fur:"
 msgid "The history of submodule updates will show changes to the submodule link \\('GITLINK'\\) from the parent repository's perspective. The Log for the submodule repository will show all commits which have occurred in the submodule repository itself."
 msgstr ""
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.hdl"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.hdl:"
 msgid "Do you want to show the history of submodule updates or the Log for the submodule repository?"
 msgstr ""
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.tle"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.tle:"
 msgid "Open Log"
 msgstr ""
 
@@ -5785,15 +5785,15 @@ msgctxt "dlgSgLogRefActionsDeleteConfirm.btn:"
 msgid "Delete Branch"
 msgstr ""
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.fur"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr ""
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl:"
 msgid "Do you really want to delete the local branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.tle"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.tle:"
 msgid "Delete Local Branch"
 msgstr ""
 
@@ -5805,15 +5805,15 @@ msgctxt "dlgSgLogRefreshRepositoryInvalid.btn:"
 msgid "Remove Repository"
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.fur"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.fur:"
 msgid "This could mean that the repository at\\n\\n$1was removed or renamed outside SmartGit."
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl:"
 msgid "The opened repository '$1' became invalid."
 msgstr ""
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.tle"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.tle:"
 msgid "Refresh"
 msgstr ""
 
@@ -5833,11 +5833,11 @@ msgctxt "dlgSgMerge.btn:"
 msgid "Squash-Merge"
 msgstr ""
 
-msgctxt "dlgSgMerge.hdl"
+msgctxt "dlgSgMerge.hdl:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "dlgSgMerge.inf"
+msgctxt "dlgSgMerge.inf:"
 msgid "Select the branch or commit to merge and how they should be merged into the Working Tree."
 msgstr ""
 
@@ -5853,7 +5853,7 @@ msgctxt "dlgSgMerge.mni:"
 msgid "Refresh"
 msgstr ""
 
-msgctxt "dlgSgMerge.tle"
+msgctxt "dlgSgMerge.tle:"
 msgid "Merge"
 msgstr ""
 
@@ -5861,15 +5861,15 @@ msgctxt "dlgSgMergeConfirmNoCommit.btn:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "dlgSgMergeConfirmNoCommit.fur"
+msgctxt "dlgSgMergeConfirmNoCommit.fur:"
 msgid "The selected revisions\\(s\\) will be merged to the working tree.\\n\\nNote that merging directly to the GitFlow-master branch is not recommended. Instead, you should start a hotfix."
 msgstr ""
 
-msgctxt "dlgSgMergeConfirmNoCommit.hdl"
+msgctxt "dlgSgMergeConfirmNoCommit.hdl:"
 msgid "Do you want to perform the merge?"
 msgstr ""
 
-msgctxt "dlgSgMergeConfirmNoCommit.tle"
+msgctxt "dlgSgMergeConfirmNoCommit.tle:"
 msgid "Merge"
 msgstr ""
 
@@ -5889,7 +5889,7 @@ msgctxt "dlgSgMergeHowToMerge.btn:"
 msgid "Squash-Merge"
 msgstr "Создать объединенный коммит \\(squash\\)"
 
-msgctxt "dlgSgMergeHowToMerge.fur"
+msgctxt "dlgSgMergeHowToMerge.fur:"
 msgid "If there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
 msgstr "Если нет конфликтов, то Git автоматически создает коммит слияния. Вместо этого, вы можете выбрать ручное объединение в рабочем каталоге, выбрав один из вариантов.\\nВариант 'Объединить в рабочем каталоге' подготовит коммит слияния, а 'Создать объединенный коммит \\(squash\\)' создаст обычный коммит \\(отбросив информацию о том, какие коммиты были объединены\\). В обоих случаях, изменения необходимо будет зафиксировать вручную."
 
@@ -5901,19 +5901,19 @@ msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from tag '$1'?"
 msgstr "Как объединить с меткой '$1'?"
 
-msgctxt "dlgSgMergeHowToMerge.tle"
+msgctxt "dlgSgMergeHowToMerge.tle:"
 msgid "Merge"
 msgstr "Объединение"
 
-msgctxt "dlgSgMergeNoop.fur"
+msgctxt "dlgSgMergeNoop.fur:"
 msgid "Merging a commit's own history into itself is technically allowed by Git but it's a no-op and will not give a new commit nor any other meaningful changes."
 msgstr "Технически, git позволяет выполнить слияние самим с собой, но это не приведет ни к созданию коммита, ни к другим значимым изменениям."
 
-msgctxt "dlgSgMergeNoop.hdl"
+msgctxt "dlgSgMergeNoop.hdl:"
 msgid "There is nothing to merge."
 msgstr "Нечего объединять"
 
-msgctxt "dlgSgMergeNoop.tle"
+msgctxt "dlgSgMergeNoop.tle:"
 msgid "Merge"
 msgstr "Объединение"
 
@@ -5925,15 +5925,15 @@ msgctxt "dlgSgOpenRepository.err:"
 msgid "Please specify the root directory of a Git repository."
 msgstr ""
 
-msgctxt "dlgSgOpenRepository.hdl"
+msgctxt "dlgSgOpenRepository.hdl:"
 msgid "Add existing or create new repository"
 msgstr "Добавление существующего репозитория либо создание нового"
 
-msgctxt "dlgSgOpenRepository.inf"
+msgctxt "dlgSgOpenRepository.inf:"
 msgid "Specify the local Git repository to open. To create a new repository, specify an empty directory."
 msgstr "Укажите путь к локальному репозиторию Git для открытия. Для создания нового репозитория, укажите пустой каталог."
 
-msgctxt "dlgSgOpenRepository.tle"
+msgctxt "dlgSgOpenRepository.tle:"
 msgid "Add or Create Repository"
 msgstr "Добавление или создание репозитория"
 
@@ -5941,27 +5941,27 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.btn:"
 msgid "Initialize"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.fur"
+msgctxt "dlgSgOpenRepositoryInitializeGit.fur:"
 msgid "The specified directory does not appear to be a valid Git repository."
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.hdl"
+msgctxt "dlgSgOpenRepositoryInitializeGit.hdl:"
 msgid "Should '$1' be initialized as a new Git repository?"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.tle"
+msgctxt "dlgSgOpenRepositoryInitializeGit.tle:"
 msgid "Add or Create Repository"
 msgstr ""
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur:"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr ""
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.hdl"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.hdl:"
 msgid "Can't open SVN working copy, please re-clone with SmartGit."
 msgstr ""
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.tle"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.tle:"
 msgid "Add or Create Repository"
 msgstr ""
 
@@ -6193,15 +6193,15 @@ msgctxt "dlgSgOutput.tle:"
 msgid "Output"
 msgstr ""
 
-msgctxt "dlgSgPingRepositoryFailed.fur"
+msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr ""
 
-msgctxt "dlgSgPingRepositoryFailed.hdl"
+msgctxt "dlgSgPingRepositoryFailed.hdl:"
 msgid "Could not connect to the repository '$1'."
 msgstr "Не удалось подключиться к репозиторию '$1'."
 
-msgctxt "dlgSgPingRepositoryFailed.tle"
+msgctxt "dlgSgPingRepositoryFailed.tle:"
 msgid "Clone"
 msgstr "Клонирование"
 
@@ -7409,7 +7409,7 @@ msgctxt "dlgSgPreferences.tab:"
 msgid "User"
 msgstr "Пользователь"
 
-msgctxt "dlgSgPreferences.tle"
+msgctxt "dlgSgPreferences.tle:"
 msgid "Preferences"
 msgstr "Параметры"
 
@@ -7473,7 +7473,7 @@ msgctxt "dlgSgProcessKiller.lbl:"
 msgid "If you think the process is hanging, click the 'Kill Process' button, otherwise 'Wait'."
 msgstr ""
 
-msgctxt "dlgSgProcessKiller.tle"
+msgctxt "dlgSgProcessKiller.tle:"
 msgid "Process Not Responding"
 msgstr ""
 
@@ -7485,15 +7485,15 @@ msgctxt "dlgSgProviderCommentEdit.edt:"
 msgid "Text"
 msgstr ""
 
-msgctxt "dlgSgProviderCommentEdit.hdl"
+msgctxt "dlgSgProviderCommentEdit.hdl:"
 msgid "Edit GitHub comment"
 msgstr ""
 
-msgctxt "dlgSgProviderCommentEdit.inf"
+msgctxt "dlgSgProviderCommentEdit.inf:"
 msgid "Enter the text of the comment."
 msgstr ""
 
-msgctxt "dlgSgProviderCommentEdit.tle"
+msgctxt "dlgSgProviderCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr ""
 
@@ -7505,7 +7505,7 @@ msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.inf"
+msgctxt "dlgSgProviderGenerateToken.inf:"
 msgid "Authenticate at GitLab and grant access to SmartGit."
 msgstr ""
 
@@ -7517,19 +7517,19 @@ msgctxt "dlgSgProviderGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at GitLab and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.tle"
+msgctxt "dlgSgProviderGenerateToken.tle:"
 msgid "Generate API Token"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.fur"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.fur:"
 msgid "The repository is no GitHub-fork and there are no other remotes which are forks of this repository."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.hdl"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.hdl:"
 msgid "No target repositories found."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.tle"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.tle:"
 msgid "Create Pull Request"
 msgstr ""
 
@@ -7541,15 +7541,15 @@ msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.btn:"
 msgid "Skip"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.fur"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.fur:"
 msgid "You have local commits which are not yet present in the server-side Provider repository. Unless you push them now, these local commits will not be included in the merge request."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.hdl"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.hdl:"
 msgid "Do you want to push your local commits first?"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.tle"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.tle:"
 msgid "Create Merge Request"
 msgstr ""
 
@@ -7557,15 +7557,15 @@ msgctxt "dlgSgProviderPullRequestDropConfirmMr.btn:"
 msgid "Drop"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur:"
 msgid "The merge request itself will not be deleted on the server."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl:"
 msgid "Do you really want to drop the local commits of merge request $1?"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.tle"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.tle:"
 msgid "Drop Merge Request"
 msgstr ""
 
@@ -7573,15 +7573,15 @@ msgctxt "dlgSgProviderPullRequestDropConfirmPr.btn:"
 msgid "Drop"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur:"
 msgid "The pull request itself will not be deleted on the server."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl:"
 msgid "Do you want to drop the local commits of pull request $1?"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.tle"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.tle:"
 msgid "Drop Pull Request"
 msgstr ""
 
@@ -7593,15 +7593,15 @@ msgctxt "dlgSgProviderPullRequestRetractMr.edt:"
 msgid "Comment"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractMr.hdl"
+msgctxt "dlgSgProviderPullRequestRetractMr.hdl:"
 msgid "Retract Merge Request"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractMr.inf"
+msgctxt "dlgSgProviderPullRequestRetractMr.inf:"
 msgid "Enter the comment which will be logged with the closed merge request."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractMr.tle"
+msgctxt "dlgSgProviderPullRequestRetractMr.tle:"
 msgid "Retract Merge Request"
 msgstr ""
 
@@ -7613,15 +7613,15 @@ msgctxt "dlgSgProviderPullRequestRetractPr.edt:"
 msgid "Comment"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractPr.hdl"
+msgctxt "dlgSgProviderPullRequestRetractPr.hdl:"
 msgid "Retract Pull Request"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractPr.inf"
+msgctxt "dlgSgProviderPullRequestRetractPr.inf:"
 msgid "Enter the comment which will be logged with the closed pull request."
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestRetractPr.tle"
+msgctxt "dlgSgProviderPullRequestRetractPr.tle:"
 msgid "Retract Pull Request"
 msgstr ""
 
@@ -7653,7 +7653,7 @@ msgctxt "dlgSgPull.edt:"
 msgid "Fetch From"
 msgstr "Получить из"
 
-msgctxt "dlgSgPull.hdl"
+msgctxt "dlgSgPull.hdl:"
 msgid "Pull commits from a remote repository"
 msgstr "Получение изменений с внешнего репозитория"
 
@@ -7665,7 +7665,7 @@ msgctxt "dlgSgPull.inf:"
 msgid "Select the remote repository to pull. In contrast to Fetch Only, Pull will also incorporate the fetched changes \\(expand the options below to configure\\)."
 msgstr ""
 
-msgctxt "dlgSgPull.tle"
+msgctxt "dlgSgPull.tle:"
 msgid "Pull"
 msgstr "Получение изменений"
 
@@ -7677,11 +7677,11 @@ msgctxt "dlgSgPullConfiguration.chk:"
 msgid "Remember as default for other repositories"
 msgstr ""
 
-msgctxt "dlgSgPullConfiguration.hdl"
+msgctxt "dlgSgPullConfiguration.hdl:"
 msgid "Configure how to pull"
 msgstr ""
 
-msgctxt "dlgSgPullConfiguration.inf"
+msgctxt "dlgSgPullConfiguration.inf:"
 msgid "Specify whether to merge or rebase on Pull for the current repository."
 msgstr ""
 
@@ -7701,7 +7701,7 @@ msgctxt "dlgSgPullConfiguration.rbt:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgPullConfiguration.tle"
+msgctxt "dlgSgPullConfiguration.tle:"
 msgid "Configure Pull"
 msgstr ""
 
@@ -7713,15 +7713,15 @@ msgctxt "dlgSgPullMergeInsteadOfRebase.btn:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.fur"
+msgctxt "dlgSgPullMergeInsteadOfRebase.fur:"
 msgid "Amongst the changes to rebase there is merge-commit $1. Rebasing merge-commits can easily cause troubles."
 msgstr ""
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.hdl"
+msgctxt "dlgSgPullMergeInsteadOfRebase.hdl:"
 msgid "Do you want to merge your local changes instead of rebasing?"
 msgstr ""
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.tle"
+msgctxt "dlgSgPullMergeInsteadOfRebase.tle:"
 msgid "Pull"
 msgstr ""
 
@@ -7729,15 +7729,15 @@ msgctxt "dlgSgPullNoRemoteRepository.btn:"
 msgid "Add Remote"
 msgstr ""
 
-msgctxt "dlgSgPullNoRemoteRepository.fur"
+msgctxt "dlgSgPullNoRemoteRepository.fur:"
 msgid "You first need to add a remote repository to pull from."
 msgstr ""
 
-msgctxt "dlgSgPullNoRemoteRepository.hdl"
+msgctxt "dlgSgPullNoRemoteRepository.hdl:"
 msgid "No remote repository has been found."
 msgstr ""
 
-msgctxt "dlgSgPullNoRemoteRepository.tle"
+msgctxt "dlgSgPullNoRemoteRepository.tle:"
 msgid "Pull"
 msgstr ""
 
@@ -7757,15 +7757,15 @@ msgctxt "dlgSgPullOrJustFetch.chk:"
 msgid "Update existing and fetch new tags"
 msgstr ""
 
-msgctxt "dlgSgPullOrJustFetch.fur"
+msgctxt "dlgSgPullOrJustFetch.fur:"
 msgid "You can change the Pull behavior in the Repository Settings."
 msgstr ""
 
-msgctxt "dlgSgPullOrJustFetch.hdl"
+msgctxt "dlgSgPullOrJustFetch.hdl:"
 msgid "Do you want to pull or just fetch $1 repositories?"
 msgstr ""
 
-msgctxt "dlgSgPullOrJustFetch.tle"
+msgctxt "dlgSgPullOrJustFetch.tle:"
 msgid "Pull"
 msgstr ""
 
@@ -7773,11 +7773,11 @@ msgctxt "dlgSgPullSubmoduleUpdate.btn:"
 msgid "Pull"
 msgstr ""
 
-msgctxt "dlgSgPullSubmoduleUpdate.fur"
+msgctxt "dlgSgPullSubmoduleUpdate.fur:"
 msgid "The git infrastructure for this submodule will be initialized and all commits will be pulled."
 msgstr ""
 
-msgctxt "dlgSgPullSubmoduleUpdate.tle"
+msgctxt "dlgSgPullSubmoduleUpdate.tle:"
 msgid "Pull Submodule"
 msgstr ""
 
@@ -7785,19 +7785,19 @@ msgctxt "dlgSgPushConfirmSingleBranch.btn:"
 msgid "Push"
 msgstr "Отправить"
 
-msgctxt "dlgSgPushConfirmSingleBranch.chk"
+msgctxt "dlgSgPushConfirmSingleBranch.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgPushConfirmSingleBranch.fur"
+msgctxt "dlgSgPushConfirmSingleBranch.fur:"
 msgid "1 branch will be pushed to '$1'."
 msgstr "1 ветка будет отправлена в '$1'."
 
-msgctxt "dlgSgPushConfirmSingleBranch.hdl"
+msgctxt "dlgSgPushConfirmSingleBranch.hdl:"
 msgid "Do you want to push branch '$1'?"
 msgstr "Вы хотите отправить ветку '$1'?"
 
-msgctxt "dlgSgPushConfirmSingleBranch.tle"
+msgctxt "dlgSgPushConfirmSingleBranch.tle:"
 msgid "Push"
 msgstr "Отправка"
 
@@ -7805,11 +7805,11 @@ msgctxt "dlgSgPushConfirmSingleTag.btn:"
 msgid "Push"
 msgstr "Отправить"
 
-msgctxt "dlgSgPushConfirmSingleTag.chk"
+msgctxt "dlgSgPushConfirmSingleTag.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgPushConfirmSingleTag.tle"
+msgctxt "dlgSgPushConfirmSingleTag.tle:"
 msgid "Push"
 msgstr "Отправка"
 
@@ -7817,15 +7817,15 @@ msgctxt "dlgSgPushForced.btn:"
 msgid "Force Push"
 msgstr "Принудительно отправить"
 
-msgctxt "dlgSgPushForced.fur"
+msgctxt "dlgSgPushForced.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr "Отправка во внешнюю ветку не является перемоткой вперед, поэтому отправка должна быть принудительной. Коммиты во внешней ветке будут потеряны."
 
-msgctxt "dlgSgPushForced.hdl"
+msgctxt "dlgSgPushForced.hdl:"
 msgid "Do you want to force-push \\(replace\\) the remote branch?"
 msgstr ""
 
-msgctxt "dlgSgPushForced.tle"
+msgctxt "dlgSgPushForced.tle:"
 msgid "Push"
 msgstr ""
 
@@ -7833,15 +7833,15 @@ msgctxt "dlgSgPushForcedSvn.btn:"
 msgid "Force Push"
 msgstr ""
 
-msgctxt "dlgSgPushForcedSvn.fur"
+msgctxt "dlgSgPushForcedSvn.fur:"
 msgid "You are about to replace the remote branch. Revisions of that branch might not be \\(easily\\) accessible anymore."
 msgstr ""
 
-msgctxt "dlgSgPushForcedSvn.hdl"
+msgctxt "dlgSgPushForcedSvn.hdl:"
 msgid "Do you want to force-push \\(replace\\) the remote branch?"
 msgstr ""
 
-msgctxt "dlgSgPushForcedSvn.tle"
+msgctxt "dlgSgPushForcedSvn.tle:"
 msgid "Push"
 msgstr ""
 
@@ -7849,19 +7849,19 @@ msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.btn:"
 msgid "Push"
 msgstr ""
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.chk"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.chk:"
 msgid "Overwrite remote changes"
 msgstr ""
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.fur"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.fur:"
 msgid "You are about to replace the remote branch, which contains commits that you haven't seen at all. Maybe you want to merge/rebase onto the remote changes before?"
 msgstr ""
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.hdl"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.hdl:"
 msgid "Do you really want to overwrite the remote branch?"
 msgstr ""
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.tle"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.tle:"
 msgid "Push"
 msgstr ""
 
@@ -7869,39 +7869,39 @@ msgctxt "dlgSgPushToAddRemote.btn:"
 msgid "Add Remote"
 msgstr ""
 
-msgctxt "dlgSgPushToAddRemote.fur"
+msgctxt "dlgSgPushToAddRemote.fur:"
 msgid "There is no remote repository configured yet. To push, you first need to configure that. After having added the remote, invoke Push again."
 msgstr ""
 
-msgctxt "dlgSgPushToAddRemote.hdl"
+msgctxt "dlgSgPushToAddRemote.hdl:"
 msgid "Do you want to add a remote?"
 msgstr ""
 
-msgctxt "dlgSgPushToAddRemote.tle"
+msgctxt "dlgSgPushToAddRemote.tle:"
 msgid "Push To"
 msgstr ""
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.fur"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.fur:"
 msgid "There is no other Git-remote to which branches of the selected remote could be pushed."
 msgstr "Другого внешнего репозитория, куда можно было бы отправить изменения, нет."
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.hdl"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.hdl:"
 msgid "No more Git remote found."
 msgstr "Других внешних репозиториев нет."
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.tle"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.tle:"
 msgid "Push To"
 msgstr "Отправка изменений"
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.fur"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.fur:"
 msgid "You can only push tags or local branches."
 msgstr "Можно отправлять только метки или локальные ветки."
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.hdl"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.hdl:"
 msgid "No tags or local branches to push."
 msgstr "Нет меток или локальных веток для отправки."
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.tle"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.tle:"
 msgid "Push To"
 msgstr "Отправка изменений"
 
@@ -7945,7 +7945,7 @@ msgctxt "dlgSgPushToRef.hdl:"
 msgid "Push local commits to a remote repository"
 msgstr "Отправка изменений во внешний репозиторий"
 
-msgctxt "dlgSgPushToRef.inf"
+msgctxt "dlgSgPushToRef.inf:"
 msgid "Select the target repository where to push the ref\\(s\\)."
 msgstr "Выберите целевой репозиторий для отправки ссылки."
 
@@ -7957,7 +7957,7 @@ msgctxt "dlgSgPushToRef.rbt:"
 msgid "Tracked or matching branch"
 msgstr "Отслеживаемая или совпадающая ветка"
 
-msgctxt "dlgSgPushToRef.tle"
+msgctxt "dlgSgPushToRef.tle:"
 msgid "Push To"
 msgstr "Отправка изменений"
 
@@ -7977,15 +7977,15 @@ msgctxt "dlgSgPushToRemote.edt:"
 msgid "Target Repository"
 msgstr "Репозиторий доставки"
 
-msgctxt "dlgSgPushToRemote.hdl"
+msgctxt "dlgSgPushToRemote.hdl:"
 msgid "Push '$1' branches to another remote"
 msgstr "Отправка веток '$1' в другой внешний репозиторий"
 
-msgctxt "dlgSgPushToRemote.inf"
+msgctxt "dlgSgPushToRemote.inf:"
 msgid "All branches of '$1' \\(as locally represented by the corresponding remote branches\\) will be pushed to the target repository."
 msgstr "Все ветки '$1' \\(локальные, связанные с внешними\\) будут отправлены в указанный репозиторий."
 
-msgctxt "dlgSgPushToRemote.tle"
+msgctxt "dlgSgPushToRemote.tle:"
 msgid "Push To"
 msgstr "Отправка изменений"
 
@@ -7993,15 +7993,15 @@ msgctxt "dlgSgPushToRemoteRemoveTargetBranches.btn:"
 msgid "Remove"
 msgstr "Удалять"
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.fur"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.fur:"
 msgid "Removed branches and their commits in the target remote which will be lost afterwards."
 msgstr "Удаление веток и их коммитов в указанном внешнем репозитории может привести к потере изменений."
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.hdl"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.hdl:"
 msgid "Do you really want to remove target remote branches?"
 msgstr "Вы точно хотите удалить целевые внешние ветки?"
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.tle"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.tle:"
 msgid "Push To"
 msgstr "Отправка изменений"
 
@@ -8009,19 +8009,19 @@ msgctxt "dlgSgPushToRemoteResetTargetBranches.btn:"
 msgid "Force Push"
 msgstr "Принудительная отправка"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.chk"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.fur"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.fur:"
 msgid "Forcing push will overwrite branches and their commits in the target remote which will be lost afterwards."
 msgstr "Принудительная отправка приведет к перезаписыванию ветвей и их коммитов в указанном внешнем репозитории, все отличия будут утеряны."
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.hdl"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.hdl:"
 msgid "Do you really want to reset the target remote branches?"
 msgstr "Вы точно хотите сбросить состояние внешних веток?"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.tle"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.tle:"
 msgid "Push To"
 msgstr "Отправка изменений"
 
@@ -8033,15 +8033,15 @@ msgctxt "dlgSgPushTrackingConfigureSingle.btn:"
 msgid "Skip"
 msgstr ""
 
-msgctxt "dlgSgPushTrackingConfigureSingle.fur"
+msgctxt "dlgSgPushTrackingConfigureSingle.fur:"
 msgid "For your current branch tracking \\(its corresponding remote branch\\) has not been configured yet. Configuring tracking will keep your local branches in sync with the remote branches."
 msgstr ""
 
-msgctxt "dlgSgPushTrackingConfigureSingle.hdl"
+msgctxt "dlgSgPushTrackingConfigureSingle.hdl:"
 msgid "Do you want to configure tracking for '$1' branch?"
 msgstr ""
 
-msgctxt "dlgSgPushTrackingConfigureSingle.tle"
+msgctxt "dlgSgPushTrackingConfigureSingle.tle:"
 msgid "Push"
 msgstr ""
 
@@ -8053,15 +8053,15 @@ msgctxt "dlgSgRebase.btn:"
 msgid "Rebase HEAD to"
 msgstr ""
 
-msgctxt "dlgSgRebase.hdl"
+msgctxt "dlgSgRebase.hdl:"
 msgid "Rebase HEAD to"
 msgstr ""
 
-msgctxt "dlgSgRebase.inf"
+msgctxt "dlgSgRebase.inf:"
 msgid "Select the commit to which the HEAD commits should be rebased."
 msgstr ""
 
-msgctxt "dlgSgRebase.tle"
+msgctxt "dlgSgRebase.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8069,15 +8069,15 @@ msgctxt "dlgSgRebaseConfirmUnreachable.btn:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseConfirmUnreachable.fur"
+msgctxt "dlgSgRebaseConfirmUnreachable.fur:"
 msgid "You only might be able to access this commit using the 'Recyclable Commits' option of the Branches view."
 msgstr ""
 
-msgctxt "dlgSgRebaseConfirmUnreachable.hdl"
+msgctxt "dlgSgRebaseConfirmUnreachable.hdl:"
 msgid "The Commit $1 would become unreachable by refs."
 msgstr ""
 
-msgctxt "dlgSgRebaseConfirmUnreachable.tle"
+msgctxt "dlgSgRebaseConfirmUnreachable.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8085,19 +8085,19 @@ msgctxt "dlgSgRebaseContinueAfterSplittingCommit.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur:"
 msgid "The splitting of commit $1 still is in progress and all changes of this commit have been applied."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.hdl"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.hdl:"
 msgid "Do you want to continue after splitting the commit?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.tle"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8105,31 +8105,31 @@ msgctxt "dlgSgRebaseContinueConfirm.btn:"
 msgid "Continue Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConfirm.chk"
+msgctxt "dlgSgRebaseContinueConfirm.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgRebaseContinueConfirm.fur"
+msgctxt "dlgSgRebaseContinueConfirm.fur:"
 msgid "Continue the rebase operation after having resolved all conflicts."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConfirm.hdl"
+msgctxt "dlgSgRebaseContinueConfirm.hdl:"
 msgid "Do you want to continue the rebase?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConfirm.tle"
+msgctxt "dlgSgRebaseContinueConfirm.tle:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConflicts.fur"
+msgctxt "dlgSgRebaseContinueConflicts.fur:"
 msgid "Please resolve all conflicts before continuing the rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConflicts.hdl"
+msgctxt "dlgSgRebaseContinueConflicts.hdl:"
 msgid "Can't continue rebase with conflicts."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueConflicts.tle"
+msgctxt "dlgSgRebaseContinueConflicts.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8137,19 +8137,19 @@ msgctxt "dlgSgRebaseContinueNothingToCommitContinue.btn:"
 msgid "Continue Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.chk"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.fur:"
 msgid "The repository is in 'rebasing' state and there is nothing to commit, so you may just continue the Rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.hdl:"
 msgid "Do you want to continue the rebase?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8157,15 +8157,15 @@ msgctxt "dlgSgRebaseContinueNothingToCommitSkip.btn:"
 msgid "Skip Commit"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.fur:"
 msgid "The repository is in 'rebasing' state, but there is nothing to commit, so you may just skip this rebased commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.hdl:"
 msgid "Do you want to skip this rebased commit?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8177,15 +8177,15 @@ msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.btn:"
 msgid "Preserve"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.fur"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.fur:"
 msgid "Your working tree contains untracked files. You may either choose to preserve them in the working tree or include them for the rebased commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.hdl"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.hdl:"
 msgid "Do you want to preserve untracked files in your working tree?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.tle"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8193,15 +8193,15 @@ msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.fur"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.fur:"
 msgid "Rebase Continue will store all working tree changes in the commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.hdl"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.hdl:"
 msgid "Do you want the working tree changes to be part of the new commit?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.tle"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8209,15 +8209,15 @@ msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.fur"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.fur:"
 msgid "Rebase Continue will store both, staged changes and the working tree changes, in the new commit!\\n\\nIf the staged changes should go to a seperate commit, first commit them, and then invoke Continue again."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.hdl"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.hdl:"
 msgid "Do you want the working tree changes to be applied, too?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.tle"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8229,31 +8229,31 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.btn:"
 msgid "Put Changes into Index"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur:"
 msgid "The splitting of commit $1 still is in progress, but not all changes of this commit have been applied.\\n\\nIf this is intentional, you can continue. Otherwise, you should click 'Put Changes into Index' and review your changes."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.hdl"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.hdl:"
 msgid "Do you want to continue splitting the commit without applying all changes?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle:"
 msgid "Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) onto the selected commit."
 msgstr "Все коммиты рабочего каталога ветки '$1' \\(HEAD\\) будут применены поверх выбранного коммита."
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl:"
 msgid "Do you want to rebase '$1' onto the selected commit?"
 msgstr "Вы хотите переместить '$1' поверх выбранного коммита?"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) to '$2'."
 msgstr "Все коммиты рабочего каталога ветки '$1' \\(HEAD\\) будут применены поверх '$2'."
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl:"
 msgid "Do you want to rebase '$1' to '$2'?"
 msgstr "Вы хотите переместить '$1' поверх '$2'?"
 
@@ -8265,7 +8265,7 @@ msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).btn:"
 msgid "Rebase Interactively"
 msgstr "Переместить интерактивно"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).tle"
+msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).tle:"
 msgid "Rebase HEAD to Selected Commit"
 msgstr "Перемещение HEAD поверх выбранного коммита"
 
@@ -8309,11 +8309,11 @@ msgctxt "dlgSgRebaseInteractive.col:"
 msgid "Message"
 msgstr "Сообщение"
 
-msgctxt "dlgSgRebaseInteractive.hdl"
+msgctxt "dlgSgRebaseInteractive.hdl:"
 msgid "Rewrite History"
 msgstr "Перезапись истории"
 
-msgctxt "dlgSgRebaseInteractive.inf"
+msgctxt "dlgSgRebaseInteractive.inf:"
 msgid "Reorder or squash commits according to your needs."
 msgstr ""
 
@@ -8329,19 +8329,19 @@ msgctxt "dlgSgRebaseInteractive.mni:"
 msgid "To Top Commit"
 msgstr "В верхний коммит"
 
-msgctxt "dlgSgRebaseInteractive.tle"
+msgctxt "dlgSgRebaseInteractive.tle:"
 msgid "Rebase Interactive"
 msgstr "Интерактивное перемещение"
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.fur"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.fur:"
 msgid "You need to select the first commit in the current branch's history that should be modified. All commits between this commit and HEAD must have exactly one parent."
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.hdl"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.hdl:"
 msgid "Changing the initial commit is not supported by the interactive rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.tle"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.tle:"
 msgid "Rebase Interactive"
 msgstr ""
 
@@ -8353,15 +8353,15 @@ msgctxt "dlgSgRebaseInteractiveMessage.edt:"
 msgid "New Message"
 msgstr "Новое сообщение"
 
-msgctxt "dlgSgRebaseInteractiveMessage.hdl"
+msgctxt "dlgSgRebaseInteractiveMessage.hdl:"
 msgid "Edit commit message"
 msgstr "Изменить сообщение коммита"
 
-msgctxt "dlgSgRebaseInteractiveMessage.inf"
+msgctxt "dlgSgRebaseInteractiveMessage.inf:"
 msgid "Provide the new message for the commit."
 msgstr "Введите новое сообщение для коммита."
 
-msgctxt "dlgSgRebaseInteractiveMessage.tle"
+msgctxt "dlgSgRebaseInteractiveMessage.tle:"
 msgid "Edit Message"
 msgstr "Изменение сообщения коммита"
 
@@ -8369,39 +8369,39 @@ msgctxt "dlgSgRebaseInteractiveRemoveCommit.btn:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur:"
 msgid "It might become hard or impossible to recover the commit again."
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl:"
 msgid "Do you want to remove the selected commit $1?"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.tle"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.tle:"
 msgid "Remove Commit"
 msgstr ""
 
-msgctxt "dlgSgRebaseNoop.fur"
+msgctxt "dlgSgRebaseNoop.fur:"
 msgid "Rebasing a commit onto itself is technically allowed by Git but it's a no-op and will not give a new commit nor any other meaningful changes."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoop.hdl"
+msgctxt "dlgSgRebaseNoop.hdl:"
 msgid "There is nothing to rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoop.tle"
+msgctxt "dlgSgRebaseNoop.tle:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "dlgSgRebaseNoopSelf.fur"
+msgctxt "dlgSgRebaseNoopSelf.fur:"
 msgid "Rebasing a commit onto itself is allowed by Git but will not create a new commit or any meaningful changes."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoopSelf.hdl"
+msgctxt "dlgSgRebaseNoopSelf.hdl:"
 msgid "There is nothing to rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoopSelf.tle"
+msgctxt "dlgSgRebaseNoopSelf.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8413,15 +8413,15 @@ msgctxt "dlgSgRebaseTagCommit.btn:"
 msgid "Skip Tag"
 msgstr ""
 
-msgctxt "dlgSgRebaseTagCommit.fur"
+msgctxt "dlgSgRebaseTagCommit.fur:"
 msgid "After the rebase, the remaining commit won't be reachable anymore."
 msgstr ""
 
-msgctxt "dlgSgRebaseTagCommit.hdl"
+msgctxt "dlgSgRebaseTagCommit.hdl:"
 msgid "Should commit $1 be tagged?"
 msgstr ""
 
-msgctxt "dlgSgRebaseTagCommit.tle"
+msgctxt "dlgSgRebaseTagCommit.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8429,15 +8429,15 @@ msgctxt "dlgSgRebasingAbortConfirm.btn:"
 msgid "Abort Rebase"
 msgstr ""
 
-msgctxt "dlgSgRebasingAbortConfirm.fur"
+msgctxt "dlgSgRebasingAbortConfirm.fur:"
 msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase HEAD To instead.\\n\\nAborting will clean any local modification \\(by invoking 'git reset --hard'\\)!"
 msgstr ""
 
-msgctxt "dlgSgRebasingAbortConfirm.hdl"
+msgctxt "dlgSgRebasingAbortConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
 msgstr ""
 
-msgctxt "dlgSgRebasingAbortConfirm.tle"
+msgctxt "dlgSgRebasingAbortConfirm.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8449,11 +8449,11 @@ msgctxt "dlgSgRecursiveStage.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgRecursiveStage.hdl"
+msgctxt "dlgSgRecursiveStage.hdl:"
 msgid "Save working tree changes in the Index for later commit"
 msgstr "Сохранение изменений рабочего каталога в индексе для последующей фиксации"
 
-msgctxt "dlgSgRecursiveStage.inf"
+msgctxt "dlgSgRecursiveStage.inf:"
 msgid "Select the files to stage to the Index."
 msgstr "Выберите файлы для индексирования"
 
@@ -8469,7 +8469,7 @@ msgctxt "dlgSgRecursiveStage.mni:"
 msgid "Toggle"
 msgstr ""
 
-msgctxt "dlgSgRecursiveStage.tle"
+msgctxt "dlgSgRecursiveStage.tle:"
 msgid "Stage"
 msgstr "Индексирование"
 
@@ -8481,15 +8481,15 @@ msgctxt "dlgSgRecursiveUnstage.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgRecursiveUnstage.hdl"
+msgctxt "dlgSgRecursiveUnstage.hdl:"
 msgid "Revert staged changes from the Index to the working tree"
 msgstr "Перенос проиндексированных изменений обратно в рабочий каталог"
 
-msgctxt "dlgSgRecursiveUnstage.inf"
+msgctxt "dlgSgRecursiveUnstage.inf:"
 msgid "Select the files to unstage from the Index."
 msgstr "Выберите файлы для удаления из индекса"
 
-msgctxt "dlgSgRecursiveUnstage.tle"
+msgctxt "dlgSgRecursiveUnstage.tle:"
 msgid "Unstage"
 msgstr "Удаление из индекса"
 
@@ -8505,15 +8505,15 @@ msgctxt "dlgSgRemoteDeleteConfirm.btn:"
 msgid "Delete"
 msgstr "Удалить"
 
-msgctxt "dlgSgRemoteDeleteConfirm.fur"
+msgctxt "dlgSgRemoteDeleteConfirm.fur:"
 msgid "This will just delete the link to the remote repository."
 msgstr "Эта операция удалит ссылку на внешний репозиторий."
 
-msgctxt "dlgSgRemoteDeleteConfirm.hdl"
+msgctxt "dlgSgRemoteDeleteConfirm.hdl:"
 msgid "Do you want to delete the remote repository '$1'?"
 msgstr "Вы хотите удалить внешний репозиторий '$1'?"
 
-msgctxt "dlgSgRemoteDeleteConfirm.tle"
+msgctxt "dlgSgRemoteDeleteConfirm.tle:"
 msgid "Delete Remote Repository"
 msgstr "Удаление внешнего репозитория"
 
@@ -8525,27 +8525,27 @@ msgctxt "dlgSgRemoteFetchMore.col:"
 msgid "Branch"
 msgstr ""
 
-msgctxt "dlgSgRemoteFetchMore.hdl"
+msgctxt "dlgSgRemoteFetchMore.hdl:"
 msgid "Fetch remote branches"
 msgstr "Получение внешних веток"
 
-msgctxt "dlgSgRemoteFetchMore.inf"
+msgctxt "dlgSgRemoteFetchMore.inf:"
 msgid "Select the branches to fetch from the remote repository."
 msgstr "Выберите ветки для получения с внешнего репозитория."
 
-msgctxt "dlgSgRemoteFetchMore.tle"
+msgctxt "dlgSgRemoteFetchMore.tle:"
 msgid "Fetch More"
 msgstr "Получение дополнительных веток"
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.fur"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.fur:"
 msgid "All branches which are present in the remote repository are already locally present as well."
 msgstr "Все ветки внешнего репозитория уже присутствуют в локальном."
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.hdl"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.hdl:"
 msgid "There are no more remote branches to fetch."
 msgstr "Нет больше внешних веток для получения."
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.tle"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.tle:"
 msgid "Fetch More"
 msgstr "Получение дополнительных веток"
 
@@ -8557,15 +8557,15 @@ msgctxt "dlgSgRemoteProperties.edt:"
 msgid "URL or Path"
 msgstr ""
 
-msgctxt "dlgSgRemoteProperties.hdl"
+msgctxt "dlgSgRemoteProperties.hdl:"
 msgid "Configure remote properties"
 msgstr "Настройка параметров внешнего репозитория"
 
-msgctxt "dlgSgRemoteProperties.inf"
+msgctxt "dlgSgRemoteProperties.inf:"
 msgid "Change the URL and other properties for the remote."
 msgstr "Измените URL или другие параметры внешнего репозитория."
 
-msgctxt "dlgSgRemoteProperties.tle"
+msgctxt "dlgSgRemoteProperties.tle:"
 msgid "Remote Properties"
 msgstr "Параметры внешнего репозитория"
 
@@ -8573,15 +8573,15 @@ msgctxt "dlgSgRemoteSelect.edt:"
 msgid "Remote"
 msgstr ""
 
-msgctxt "dlgSgRemoteSelect.hdl"
+msgctxt "dlgSgRemoteSelect.hdl:"
 msgid "Initialize remote review database"
 msgstr ""
 
-msgctxt "dlgSgRemoteSelect.inf"
+msgctxt "dlgSgRemoteSelect.inf:"
 msgid "Select the remote repository for which you want to initialize the review database."
 msgstr ""
 
-msgctxt "dlgSgRemoteSelect.tle"
+msgctxt "dlgSgRemoteSelect.tle:"
 msgid "Initialize Remote"
 msgstr ""
 
@@ -8597,15 +8597,15 @@ msgctxt "dlgSgRemoteSetDepth.err:"
 msgid "Please enter a valid commit count."
 msgstr ""
 
-msgctxt "dlgSgRemoteSetDepth.hdl"
+msgctxt "dlgSgRemoteSetDepth.hdl:"
 msgid "Set repository depth"
 msgstr "Установите глубину истории"
 
-msgctxt "dlgSgRemoteSetDepth.inf"
+msgctxt "dlgSgRemoteSetDepth.inf:"
 msgid "Use a large number \\(e.g. 100000\\) to set an unlimited depth."
 msgstr "Используйте большое значение \\(например 100000\\) для снятия ограничения на глубину"
 
-msgctxt "dlgSgRemoteSetDepth.tle"
+msgctxt "dlgSgRemoteSetDepth.tle:"
 msgid "Set Depth"
 msgstr "Установка глубины истории"
 
@@ -8625,11 +8625,11 @@ msgctxt "dlgSgRemotesAdd.edt:"
 msgid "URL or Path"
 msgstr "URL или путь"
 
-msgctxt "dlgSgRemotesAdd.hdl"
+msgctxt "dlgSgRemotesAdd.hdl:"
 msgid "Add a remote repository"
 msgstr "Добавить внешний репозиторий"
 
-msgctxt "dlgSgRemotesAdd.inf"
+msgctxt "dlgSgRemotesAdd.inf:"
 msgid "Enter the URL and a short name for the remote repository."
 msgstr "Введите адрес и короткое имя внешнего репозитория"
 
@@ -8665,19 +8665,19 @@ msgctxt "dlgSgRemotesAdd.mni:"
 msgid "Select Local Repository"
 msgstr ""
 
-msgctxt "dlgSgRemotesAdd.tle"
+msgctxt "dlgSgRemotesAdd.tle:"
 msgid "Add Remote Repository"
 msgstr "Добавление внешнего репозитория"
 
-msgctxt "dlgSgRemotesNoRemoteDetected.fur"
+msgctxt "dlgSgRemotesNoRemoteDetected.fur:"
 msgid "To perform the operation the repository configuration for $1 must contain one uniquely determined remote."
 msgstr ""
 
-msgctxt "dlgSgRemotesNoRemoteDetected.hdl"
+msgctxt "dlgSgRemotesNoRemoteDetected.hdl:"
 msgid "No remote detected."
 msgstr ""
 
-msgctxt "dlgSgRemotesNoRemoteDetected.tle"
+msgctxt "dlgSgRemotesNoRemoteDetected.tle:"
 msgid "Push Up To"
 msgstr ""
 
@@ -8697,15 +8697,15 @@ msgctxt "dlgSgRemove.col:"
 msgid "Name"
 msgstr "Имя"
 
-msgctxt "dlgSgRemove.hdl"
+msgctxt "dlgSgRemove.hdl:"
 msgid "Remove files from the repository"
 msgstr "Убрать файл из репозитория"
 
-msgctxt "dlgSgRemove.inf"
+msgctxt "dlgSgRemove.inf:"
 msgid "Select the files you want to remove from the repository or working tree \\(stopped from tracking\\)."
 msgstr "Выберите файлы для удаления из репозитория или рабочего каталога \\(прекращается их отслеживание\\)"
 
-msgctxt "dlgSgRemove.tle"
+msgctxt "dlgSgRemove.tle:"
 msgid "Remove"
 msgstr "Убрать файл"
 
@@ -8717,15 +8717,15 @@ msgctxt "dlgSgRenameBranch.edt:"
 msgid "Name"
 msgstr "Имя"
 
-msgctxt "dlgSgRenameBranch.hdl"
+msgctxt "dlgSgRenameBranch.hdl:"
 msgid "Rename branch"
 msgstr "Переименование ветки"
 
-msgctxt "dlgSgRenameBranch.inf"
+msgctxt "dlgSgRenameBranch.inf:"
 msgid "Enter the new name for the branch '$1'."
 msgstr "Введите новое имя для ветки '$1'."
 
-msgctxt "dlgSgRenameBranch.tle"
+msgctxt "dlgSgRenameBranch.tle:"
 msgid "Rename"
 msgstr "Переименование"
 
@@ -8737,15 +8737,15 @@ msgctxt "dlgSgRenameFile.edt:"
 msgid "Path"
 msgstr "Путь"
 
-msgctxt "dlgSgRenameFile.hdl"
+msgctxt "dlgSgRenameFile.hdl:"
 msgid "Move or Rename the file"
 msgstr "Перемещение/переименование файла"
 
-msgctxt "dlgSgRenameFile.inf"
+msgctxt "dlgSgRenameFile.inf:"
 msgid "Enter the new path and name of the file."
 msgstr "Введите новый путь и имя файла"
 
-msgctxt "dlgSgRenameFile.tle"
+msgctxt "dlgSgRenameFile.tle:"
 msgid "Move or Rename"
 msgstr "Переименование или перемещение"
 
@@ -8757,15 +8757,15 @@ msgctxt "dlgSgRenameRemote.edt:"
 msgid "Name"
 msgstr "Имя"
 
-msgctxt "dlgSgRenameRemote.hdl"
+msgctxt "dlgSgRenameRemote.hdl:"
 msgid "Change the name of an existing remote"
 msgstr "Изменить имя существующего внешнего репозитория"
 
-msgctxt "dlgSgRenameRemote.inf"
+msgctxt "dlgSgRenameRemote.inf:"
 msgid "Provide the new name of the selected remote."
 msgstr "Укажите новое имя для выбранного внешнего репозитория."
 
-msgctxt "dlgSgRenameRemote.tle"
+msgctxt "dlgSgRenameRemote.tle:"
 msgid "Rename Remote Repository"
 msgstr "Переименование внешнего репозитория"
 
@@ -8777,15 +8777,15 @@ msgctxt "dlgSgRenameRepository.edt:"
 msgid "Name"
 msgstr "Имя"
 
-msgctxt "dlgSgRenameRepository.hdl"
+msgctxt "dlgSgRenameRepository.hdl:"
 msgid "Rename repository"
 msgstr "Переименование репозитория"
 
-msgctxt "dlgSgRenameRepository.inf"
+msgctxt "dlgSgRenameRepository.inf:"
 msgid "Provide the new name for the repository. The repository directory will not be renamed."
 msgstr "Укажите новое имя репозитория. Каталог репозитория не изменится."
 
-msgctxt "dlgSgRenameRepository.tle"
+msgctxt "dlgSgRenameRepository.tle:"
 msgid "Rename"
 msgstr "Переименование"
 
@@ -8805,11 +8805,11 @@ msgctxt "dlgSgRepositoriesSearch.edt:"
 msgid "Search In"
 msgstr "Искать в"
 
-msgctxt "dlgSgRepositoriesSearch.hdl"
+msgctxt "dlgSgRepositoriesSearch.hdl:"
 msgid "Search existing local repositories"
 msgstr "Поиск существующих локальных репозиториев"
 
-msgctxt "dlgSgRepositoriesSearch.inf"
+msgctxt "dlgSgRepositoriesSearch.inf:"
 msgid "Select a root directory where the search should start and click 'Start Search'."
 msgstr "Выберите корневой каталог, в котором будет осуществлен поиск, и нажмите 'Найти'"
 
@@ -8845,7 +8845,7 @@ msgctxt "dlgSgRepositoriesSearch.mni:"
 msgid "Toggle"
 msgstr ""
 
-msgctxt "dlgSgRepositoriesSearch.tle"
+msgctxt "dlgSgRepositoriesSearch.tle:"
 msgid "Search for Repositories"
 msgstr "Поиск репозиториев"
 
@@ -8857,15 +8857,15 @@ msgctxt "dlgSgRepositoryAddGroup.edt:"
 msgid "Group Name"
 msgstr "Имя группы"
 
-msgctxt "dlgSgRepositoryAddGroup.hdl"
+msgctxt "dlgSgRepositoryAddGroup.hdl:"
 msgid "Enter the group name"
 msgstr "Ввод имени группы"
 
-msgctxt "dlgSgRepositoryAddGroup.inf"
+msgctxt "dlgSgRepositoryAddGroup.inf:"
 msgid "After having created the group, you can move repositories inside it."
 msgstr "После создания группы вы сможете поместить в нее репозитории."
 
-msgctxt "dlgSgRepositoryAddGroup.tle"
+msgctxt "dlgSgRepositoryAddGroup.tle:"
 msgid "Add Group"
 msgstr "Создание группы"
 
@@ -8877,15 +8877,15 @@ msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Close"
 msgstr ""
 
-msgctxt "dlgSgRepositoryClose.fur"
+msgctxt "dlgSgRepositoryClose.fur:"
 msgid "Note that currently running Git processes might not be interrupted."
 msgstr ""
 
-msgctxt "dlgSgRepositoryClose.hdl"
+msgctxt "dlgSgRepositoryClose.hdl:"
 msgid "Do you really want to close now?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryClose.tle"
+msgctxt "dlgSgRepositoryClose.tle:"
 msgid "Close"
 msgstr ""
 
@@ -8893,19 +8893,19 @@ msgctxt "dlgSgRepositoryFrameCloseWithoutPush.btn:"
 msgid "Close Now"
 msgstr ""
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.chk"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.fur"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.fur:"
 msgid "You have pushable commits. Maybe you want to push them before closing this window."
 msgstr ""
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.hdl"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.hdl:"
 msgid "Do you want to close without having pushed commits?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.tle"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.tle:"
 msgid "Close"
 msgstr ""
 
@@ -8913,91 +8913,91 @@ msgctxt "dlgSgRepositoryOpen.btn:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlgSgRepositoryOpen.fur"
+msgctxt "dlgSgRepositoryOpen.fur:"
 msgid "If it is relocated, remove it and add its new location."
 msgstr ""
 
-msgctxt "dlgSgRepositoryOpen.hdl"
+msgctxt "dlgSgRepositoryOpen.hdl:"
 msgid "Do you want to remove the missing repository '$1'?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryOpen.tle"
+msgctxt "dlgSgRepositoryOpen.tle:"
 msgid "Repository Opening"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveFailed1.fur"
+msgctxt "dlgSgRepositoryRemoveFailed1.fur:"
 msgid "This could happen if the repository is open in another window or currently commands are executed."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveFailed1.hdl"
+msgctxt "dlgSgRepositoryRemoveFailed1.hdl:"
 msgid "The repository '$1' could not be removed."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveFailed1.tle"
+msgctxt "dlgSgRepositoryRemoveFailed1.tle:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl:"
 msgid "Do you want to remove $1 groups?"
 msgstr ""
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "Репозитории на диске останутся, но SmartGit забудет о них."
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl:"
 msgid "Do you want to remove $1 repositories?"
 msgstr "Вы хотите удалить $1 репозитория\\(ев\\)?"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "Репозитории на диске останутся, но SmartGit забудет о них. Репозитории удаляемых групп будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl:"
 msgid "Do you want to remove $1 repositories and $2 groups?"
 msgstr "Вы хотите удалить $1 репозитория\\(ев\\) и $2 групп\\(ы\\)?"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "Репозитории останутся на диске, но SmartGit забудет о них. Репозитории удаляемой группы будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl:"
 msgid "Do you want to remove $1 repositories and the group \"$2\"?"
 msgstr "Вы хотите удалить $1 репозитория\\(ев\\) и группу \"$2\"?"
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "Репозитории удаляемой группы будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl:"
 msgid "Do you want to remove the group \"$1\"?"
 msgstr "Вы хотите удалить группу \"$1\"?"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "Репозиторий на диске останется, но SmartGit забудет о нем."
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl:"
 msgid "Do you want to remove the repository \"$1\"?"
 msgstr "Вы хотите удалить репозиторий \"$1\"?"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "Репозиторий на диске останется, но SmartGit забудет о нем. Репозитории удаляемых групп будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl:"
 msgid "Do you want to remove the repository \"$1\" and $2 groups?"
 msgstr "Вы хотите удалить репозиторий \"$1\" и $2 групп\\(ы\\)?"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "Репозиторий на диске останется, но SmartGit забудет о нем. Репозитории удаляемой группы будут перемещены в корень."
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl:"
 msgid "Do you want to remove the repository \"$1\" and the group \"$2\"?"
 msgstr "Вы хотите удалить репозиторий \"$1\" и группу \"$2\"?"
 
@@ -9073,11 +9073,11 @@ msgctxt "dlgSgRepositorySettings.err:"
 msgid "Please enter a valid, comma-separated list of regular expressions."
 msgstr ""
 
-msgctxt "dlgSgRepositorySettings.hdl"
+msgctxt "dlgSgRepositorySettings.hdl:"
 msgid "Edit the repository settings"
 msgstr "Изменение настроек репозитория"
 
-msgctxt "dlgSgRepositorySettings.inf"
+msgctxt "dlgSgRepositorySettings.inf:"
 msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
 msgstr "Здесь вы можете изменить настройки Git для репозитория. Параметры по умолчанию можно найти в меню Параметры"
 
@@ -9113,7 +9113,7 @@ msgctxt "dlgSgRepositorySettings.tab:"
 msgid "User"
 msgstr "Пользователь"
 
-msgctxt "dlgSgRepositorySettings.tle"
+msgctxt "dlgSgRepositorySettings.tle:"
 msgid "Repository Settings"
 msgstr "Настройки репозитория"
 
@@ -9157,7 +9157,7 @@ msgctxt "dlgSgResetAdv.chk:"
 msgid "Thoroughly fix line-endings according to .gitattributes"
 msgstr "Исправить окончания строк в соответствии с .gitattributes"
 
-msgctxt "dlgSgResetAdv.hdl"
+msgctxt "dlgSgResetAdv.hdl:"
 msgid "Reset to commit $1"
 msgstr "Сброс состояния к коммиту $1"
 
@@ -9205,7 +9205,7 @@ msgctxt "dlgSgResetAdv.rbt:"
 msgid "Reset the Index but not the working tree - 'mixed'"
 msgstr "Сбросить индекс, но не трогать рабочий каталог - 'смешанный'"
 
-msgctxt "dlgSgResetAdv.tle"
+msgctxt "dlgSgResetAdv.tle:"
 msgid "Reset"
 msgstr "Сброс изменений"
 
@@ -9213,15 +9213,15 @@ msgctxt "dlgSgResetConfirm.btn:"
 msgid "Reset"
 msgstr "Сбросить"
 
-msgctxt "dlgSgResetConfirm.fur"
+msgctxt "dlgSgResetConfirm.fur:"
 msgid "Current staged and local changes will be lost!"
 msgstr "Все внесенные изменения будут утеряны!"
 
-msgctxt "dlgSgResetConfirm.hdl"
+msgctxt "dlgSgResetConfirm.hdl:"
 msgid "Do you want to reset the HEAD to commit $1?"
 msgstr "Вы хотите сбросить состояние к коммиту $1?"
 
-msgctxt "dlgSgResetConfirm.tle"
+msgctxt "dlgSgResetConfirm.tle:"
 msgid "Reset"
 msgstr "Сброс изменений"
 
@@ -9237,11 +9237,11 @@ msgctxt "dlgSgResolve.edt:"
 msgid "Content"
 msgstr ""
 
-msgctxt "dlgSgResolve.hdl"
+msgctxt "dlgSgResolve.hdl:"
 msgid "Resolve Conflict"
 msgstr ""
 
-msgctxt "dlgSgResolve.inf"
+msgctxt "dlgSgResolve.inf:"
 msgid "Select which content to use for the resolved file\\(s\\)."
 msgstr ""
 
@@ -9253,23 +9253,23 @@ msgctxt "dlgSgResolve.rbt:"
 msgid "Open Conflict Solver"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
 msgid "Set to $1 \\(\"ours\", $2\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
 msgid "Set to $1 \\(\"theirs\", $2\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
 msgid "Set to rebase target \\(\"theirs\", $1\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
 msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.tle"
+msgctxt "dlgSgResolve.tle:"
 msgid "Resolve"
 msgstr ""
 
@@ -9277,15 +9277,15 @@ msgctxt "dlgSgResolveManuallyModifiedSingle.btn:"
 msgid "Overwrite"
 msgstr ""
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.fur"
+msgctxt "dlgSgResolveManuallyModifiedSingle.fur:"
 msgid "$1 seems to contain manual conflict resolutions. They will be lost when continuing."
 msgstr ""
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.hdl"
+msgctxt "dlgSgResolveManuallyModifiedSingle.hdl:"
 msgid "Do you want to overwrite your manual conflict resolution?"
 msgstr ""
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.tle"
+msgctxt "dlgSgResolveManuallyModifiedSingle.tle:"
 msgid "Resolve"
 msgstr ""
 
@@ -9293,11 +9293,11 @@ msgctxt "dlgSgResolveSubmodule.btn:"
 msgid "Resolve"
 msgstr ""
 
-msgctxt "dlgSgResolveSubmodule.hdl"
+msgctxt "dlgSgResolveSubmodule.hdl:"
 msgid "Resolve Conflict"
 msgstr ""
 
-msgctxt "dlgSgResolveSubmodule.inf"
+msgctxt "dlgSgResolveSubmodule.inf:"
 msgid "Select to which submodule commit you want to resolve."
 msgstr ""
 
@@ -9309,7 +9309,7 @@ msgctxt "dlgSgResolveSubmodule.rbt:"
 msgid "Leave submodule pointer as is"
 msgstr ""
 
-msgctxt "dlgSgResolveSubmodule.tle"
+msgctxt "dlgSgResolveSubmodule.tle:"
 msgid "Resolve"
 msgstr ""
 
@@ -9321,15 +9321,15 @@ msgctxt "dlgSgRevealCommitLocalOrTracked.btn:"
 msgid "Reveal Tracked"
 msgstr "Перейти к отслеживаемой"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.chk"
+msgctxt "dlgSgRevealCommitLocalOrTracked.chk:"
 msgid "Always reveal local branch"
 msgstr "Всегда переходить к локальной ветке"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.fur"
+msgctxt "dlgSgRevealCommitLocalOrTracked.fur:"
 msgid "Select whether to reveal '$1' or '$2'."
 msgstr "Выберите к какой перейти '$1' или '$2'."
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.hdl"
+msgctxt "dlgSgRevealCommitLocalOrTracked.hdl:"
 msgid "Do you want to reveal the local or the tracked branch?"
 msgstr "Хотите ли вы перейти к локальной или отслеживаемой ветке?"
 
@@ -9349,15 +9349,15 @@ msgctxt "dlgSgRevertAndCommitConfirmSingle.btn:"
 msgid "Revert"
 msgstr "Откатить"
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.fur"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.fur:"
 msgid "This will undo the changes introduced with the selected commit."
 msgstr "Эта операция отменяет изменения выбранного коммита."
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.hdl"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.hdl:"
 msgid "Do you want to revert the selected commit?"
 msgstr "Вы хотите отменить выбранный коммит?"
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.tle"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.tle:"
 msgid "Revert"
 msgstr "Откат изменений"
 
@@ -9365,7 +9365,7 @@ msgctxt "dlgSgRevertConfigurationFile.btn:"
 msgid "Revert"
 msgstr "Откатить"
 
-msgctxt "dlgSgRevertConfigurationFile.fur"
+msgctxt "dlgSgRevertConfigurationFile.fur:"
 msgid "Only changes of these files will be reverted \\(without committing\\)."
 msgstr "Только изменения в этих файлах будут обращены \\(без фиксации\\)."
 
@@ -9373,35 +9373,35 @@ msgctxt "dlgSgRevertConfigurationFile.hdl:"
 msgid "Do you want to revert changes of '$1'?"
 msgstr "Вы хотите откатить изменения '$1'?"
 
-msgctxt "dlgSgRevertConfigurationFile.tle"
+msgctxt "dlgSgRevertConfigurationFile.tle:"
 msgid "Revert"
 msgstr "Откат изменений"
 
-msgctxt "dlgSgRevertInProgress.fur"
+msgctxt "dlgSgRevertInProgress.fur:"
 msgid "You have to finish the Revert before you can continue. To finish the Revert use Commit, to abort use Discard."
 msgstr ""
 
-msgctxt "dlgSgRevertInProgress.hdl"
+msgctxt "dlgSgRevertInProgress.hdl:"
 msgid "There is currently a Revert in progress."
 msgstr ""
 
-msgctxt "dlgSgRevertInProgress.tle"
+msgctxt "dlgSgRevertInProgress.tle:"
 msgid "Revert"
 msgstr ""
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.chk"
+msgctxt "dlgSgRevertNotAllConflictsResolved.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.fur"
+msgctxt "dlgSgRevertNotAllConflictsResolved.fur:"
 msgid "You may need to resolve the conflicts before proceeding."
 msgstr ""
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.hdl"
+msgctxt "dlgSgRevertNotAllConflictsResolved.hdl:"
 msgid "Reverting failed because of conflicts."
 msgstr ""
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.tle"
+msgctxt "dlgSgRevertNotAllConflictsResolved.tle:"
 msgid "Revert"
 msgstr ""
 
@@ -9409,11 +9409,11 @@ msgctxt "dlgSgReviewCommentAdd.btn:"
 msgid "Add"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentAdd.hdl"
+msgctxt "dlgSgReviewCommentAdd.hdl:"
 msgid "Add comment"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentAdd.tle"
+msgctxt "dlgSgReviewCommentAdd.tle:"
 msgid "Add Comment"
 msgstr ""
 
@@ -9421,11 +9421,11 @@ msgctxt "dlgSgReviewCommentEdit.btn:"
 msgid "Edit"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentEdit.hdl"
+msgctxt "dlgSgReviewCommentEdit.hdl:"
 msgid "Edit comment"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentEdit.tle"
+msgctxt "dlgSgReviewCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr ""
 
@@ -9433,11 +9433,11 @@ msgctxt "dlgSgReviewCommentReply.btn:"
 msgid "Reply"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentReply.hdl"
+msgctxt "dlgSgReviewCommentReply.hdl:"
 msgid "Reply to selected comment"
 msgstr ""
 
-msgctxt "dlgSgReviewCommentReply.tle"
+msgctxt "dlgSgReviewCommentReply.tle:"
 msgid "Reply To Comment"
 msgstr ""
 
@@ -9445,7 +9445,7 @@ msgctxt "dlgSgReviewComment(Add|Edit|Reply).edt:"
 msgid "Text"
 msgstr ""
 
-msgctxt "dlgSgReviewComment(Add|Edit|Reply).inf"
+msgctxt "dlgSgReviewComment(Add|Edit|Reply).inf:"
 msgid "Enter the text of the comment."
 msgstr ""
 
@@ -9453,15 +9453,15 @@ msgctxt "dlgSgReviewConfigureDisposeDatabase.btn:"
 msgid "Dispose"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.fur"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.fur:"
 msgid "This will disable the Reviewing system and unpushed local data will be lost."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.hdl"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.hdl:"
 msgid "Do you really want to dispose all local review data?"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.tle"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.tle:"
 msgid "Dispose Database"
 msgstr ""
 
@@ -9469,15 +9469,15 @@ msgctxt "dlgSgReviewConfigureForGitHub.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureForGitHub.fur"
+msgctxt "dlgSgReviewConfigureForGitHub.fur:"
 msgid "This repository is connected to a GitHub server. GitHub comes with its own reviewing concepts, like commit comments and pull requests. Hence, you probably do not want to have SmartGit's review database in addition to GitHub's existing capabilities."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureForGitHub.hdl"
+msgctxt "dlgSgReviewConfigureForGitHub.hdl:"
 msgid "Do you really want to configure SmartGit's review database for your GitHub repository?"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureForGitHub.tle"
+msgctxt "dlgSgReviewConfigureForGitHub.tle:"
 msgid "Configure Review System"
 msgstr ""
 
@@ -9485,15 +9485,15 @@ msgctxt "dlgSgReviewConfigureIntializeNew.btn:"
 msgid "Initialize"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureIntializeNew.fur"
+msgctxt "dlgSgReviewConfigureIntializeNew.fur:"
 msgid "This will create a new Review database in the current repository which may be pushed to other remotes later."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureIntializeNew.hdl"
+msgctxt "dlgSgReviewConfigureIntializeNew.hdl:"
 msgid "Do you want to initialize a new Review database?"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureIntializeNew.tle"
+msgctxt "dlgSgReviewConfigureIntializeNew.tle:"
 msgid "Configure Review System"
 msgstr ""
 
@@ -9509,15 +9509,15 @@ msgctxt "dlgSgReviewConfigureWhat.btn:"
 msgid "Initialize a Remote"
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureWhat.fur"
+msgctxt "dlgSgReviewConfigureWhat.fur:"
 msgid "The user database allows to define aliases \\(e.g. @mike\\) that make addressing teammates easier in review comments."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureWhat.hdl"
+msgctxt "dlgSgReviewConfigureWhat.hdl:"
 msgid "Select what you want to configure."
 msgstr ""
 
-msgctxt "dlgSgReviewConfigureWhat.tle"
+msgctxt "dlgSgReviewConfigureWhat.tle:"
 msgid "Configure Review Database"
 msgstr ""
 
@@ -9525,15 +9525,15 @@ msgctxt "dlgSgReviewPullRequestClose.edt:"
 msgid "Comment"
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestClose.hdl"
+msgctxt "dlgSgReviewPullRequestClose.hdl:"
 msgid "Close Pull Request"
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestClose.inf"
+msgctxt "dlgSgReviewPullRequestClose.inf:"
 msgid "Enter the comment which will be logged when closing the pull request."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestClose.tle"
+msgctxt "dlgSgReviewPullRequestClose.tle:"
 msgid "Close Pull Request"
 msgstr ""
 
@@ -9553,11 +9553,11 @@ msgctxt "dlgSgReviewPullRequestCreate.err:"
 msgid "Unknown user '$1'."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestCreate.hdl"
+msgctxt "dlgSgReviewPullRequestCreate.hdl:"
 msgid "Create a Pull Request"
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestCreate.inf"
+msgctxt "dlgSgReviewPullRequestCreate.inf:"
 msgid "A Pull Request suggests the integration of one branch into another."
 msgstr ""
 
@@ -9569,7 +9569,7 @@ msgctxt "dlgSgReviewPullRequestCreate.lbl:"
 msgid "The pull request will be highlighted to those users which are listed as assignees."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestCreate.tle"
+msgctxt "dlgSgReviewPullRequestCreate.tle:"
 msgid "Create Pull Request"
 msgstr ""
 
@@ -9589,15 +9589,15 @@ msgctxt "dlgSgReviewPullRequestState.err:"
 msgid "Unknown user '$1'."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestState.hdl"
+msgctxt "dlgSgReviewPullRequestState.hdl:"
 msgid "Assign Pull Request"
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestState.inf"
+msgctxt "dlgSgReviewPullRequestState.inf:"
 msgid "Enter the user\\(s\\) to which the Pull Request should be assigned to."
 msgstr ""
 
-msgctxt "dlgSgReviewPullRequestState.tle"
+msgctxt "dlgSgReviewPullRequestState.tle:"
 msgid "Assign"
 msgstr ""
 
@@ -9633,7 +9633,7 @@ msgctxt "dlgSgReviewUserAddEdit.hdl:"
 msgid "Edit User"
 msgstr ""
 
-msgctxt "dlgSgReviewUserAddEdit.inf"
+msgctxt "dlgSgReviewUserAddEdit.inf:"
 msgid "Enter the user's name and email address \\(as used for Git\\), one or more space- or comma-separated aliases and optional contact details."
 msgstr ""
 
@@ -9689,7 +9689,7 @@ msgctxt "dlgSgReviewUsersEdit.hdl:"
 msgid "Edit review database users"
 msgstr ""
 
-msgctxt "dlgSgReviewUsersEdit.inf"
+msgctxt "dlgSgReviewUsersEdit.inf:"
 msgid "Users can have aliases which are used in comment texts and they have optional contact details."
 msgstr ""
 
@@ -9709,15 +9709,15 @@ msgctxt "dlgSgRollbackToCommit.btn:"
 msgid "Rollback"
 msgstr "Откатить"
 
-msgctxt "dlgSgRollbackToCommit.fur"
+msgctxt "dlgSgRollbackToCommit.fur:"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr "Все различия между HEAD и выбранным коммитом будут сохранены в рабочем каталоге."
 
-msgctxt "dlgSgRollbackToCommit.hdl"
+msgctxt "dlgSgRollbackToCommit.hdl:"
 msgid "Do you want to rollback the Index to the state of commit $1?"
 msgstr "Вы хотите откатить изменения инндекса к состоянию коммита $1?"
 
-msgctxt "dlgSgRollbackToCommit.tle"
+msgctxt "dlgSgRollbackToCommit.tle:"
 msgid "Rollback To"
 msgstr "Откат изменений"
 
@@ -9729,7 +9729,7 @@ msgctxt "dlgSgRollbackToFiles.btn:"
 msgid "Rollback"
 msgstr "Откатить"
 
-msgctxt "dlgSgRollbackToFiles.fur"
+msgctxt "dlgSgRollbackToFiles.fur:"
 msgid "All differences of the selected files between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr "Все изменения между выбранных файлов между HEAD и выбранным коммитом будут помещены в рабочий каталог и, опционально, проиндексированы."
 
@@ -9737,7 +9737,7 @@ msgctxt "dlgSgRollbackToFiles.hdl:"
 msgid "Do you want to rollback the selected files to the state of commit $1?"
 msgstr "Вы хотите откатить выбранные файлы к состоянию коммита $1?"
 
-msgctxt "dlgSgRollbackToFiles.tle"
+msgctxt "dlgSgRollbackToFiles.tle:"
 msgid "Rollback To"
 msgstr "Откат изменений"
 
@@ -9761,7 +9761,7 @@ msgctxt "dlgSgSelectBranch.inf:"
 msgid "Select which auxiliary branch should be shown in addition to the current branch."
 msgstr ""
 
-msgctxt "dlgSgSelectBranch.tle"
+msgctxt "dlgSgSelectBranch.tle:"
 msgid "Set Tracked Branch"
 msgstr "Выбор ветки для отслеживания"
 
@@ -9957,15 +9957,15 @@ msgctxt "dlgSgSetupStdWnd.btn:"
 msgid "Use Standard Window"
 msgstr ""
 
-msgctxt "dlgSgSetupStdWnd.fur"
+msgctxt "dlgSgSetupStdWnd.fur:"
 msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 msgstr ""
 
-msgctxt "dlgSgSetupStdWnd.hdl"
+msgctxt "dlgSgSetupStdWnd.hdl:"
 msgid "Do you want to use the Standard Window?"
 msgstr ""
 
-msgctxt "dlgSgSetupStdWnd.tle"
+msgctxt "dlgSgSetupStdWnd.tle:"
 msgid "Setup SmartGit $1"
 msgstr ""
 
@@ -9973,11 +9973,11 @@ msgctxt "dlgSgShowLocalChanges.btn:"
 msgid "Compare"
 msgstr ""
 
-msgctxt "dlgSgShowLocalChanges.hdl"
+msgctxt "dlgSgShowLocalChanges.hdl:"
 msgid "File $1 modified in Index and working tree"
 msgstr ""
 
-msgctxt "dlgSgShowLocalChanges.inf"
+msgctxt "dlgSgShowLocalChanges.inf:"
 msgid "Select the file states to compare."
 msgstr ""
 
@@ -9993,7 +9993,7 @@ msgctxt "dlgSgShowLocalChanges.rbt:"
 msgid "Index vs. Working Tree"
 msgstr "Индекс vs. рабочий каталог"
 
-msgctxt "dlgSgShowLocalChanges.tle"
+msgctxt "dlgSgShowLocalChanges.tle:"
 msgid "Show Changes"
 msgstr ""
 
@@ -10017,27 +10017,27 @@ msgctxt "dlgSgSplitOffFiles.edt:"
 msgid "Commit Message"
 msgstr ""
 
-msgctxt "dlgSgSplitOffFiles.hdl"
+msgctxt "dlgSgSplitOffFiles.hdl:"
 msgid "Move files to a second commit"
 msgstr ""
 
-msgctxt "dlgSgSplitOffFiles.inf"
+msgctxt "dlgSgSplitOffFiles.inf:"
 msgid "Provide the message for the second commit that should contain the changes from the selected files."
 msgstr ""
 
-msgctxt "dlgSgSplitOffFiles.tle"
+msgctxt "dlgSgSplitOffFiles.tle:"
 msgid "Split Off Files"
 msgstr ""
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.fur"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.fur:"
 msgid "By splitting off all files, the resulting commit would become empty."
 msgstr ""
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.hdl"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.hdl:"
 msgid "You can't split off all files from a commit"
 msgstr ""
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.tle"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -10069,11 +10069,11 @@ msgctxt "dlgSgSshCredentials.edt:"
 msgid "Private Key File"
 msgstr ""
 
-msgctxt "dlgSgSshCredentials.hdl"
+msgctxt "dlgSgSshCredentials.hdl:"
 msgid "SSH Credentials"
 msgstr ""
 
-msgctxt "dlgSgSshCredentials.inf"
+msgctxt "dlgSgSshCredentials.inf:"
 msgid "Provide the credentials for authenticating to the SSH server '$1' as user '$2'."
 msgstr ""
 
@@ -10089,7 +10089,7 @@ msgctxt "dlgSgSshCredentials.rbt:"
 msgid "Private Key"
 msgstr ""
 
-msgctxt "dlgSgSshCredentials.tle"
+msgctxt "dlgSgSshCredentials.tle:"
 msgid "SSH Authentication"
 msgstr ""
 
@@ -10101,27 +10101,27 @@ msgctxt "dlgSgStageConflict.btn:"
 msgid "Stage Anyway"
 msgstr "Индексировать все равно"
 
-msgctxt "dlgSgStageConflict.fur"
+msgctxt "dlgSgStageConflict.fur:"
 msgid "The file contains conflict markers which indicate that you have not resolved all conflicts."
 msgstr "Файл содержит отметки, указывающие на то, что конфликты не были разрешены."
 
-msgctxt "dlgSgStageConflict.hdl"
+msgctxt "dlgSgStageConflict.hdl:"
 msgid "Should $1 really be staged?"
 msgstr "Проиндексировать файл $1?"
 
-msgctxt "dlgSgStageConflict.tle"
+msgctxt "dlgSgStageConflict.tle:"
 msgid "Stage"
 msgstr "Решение"
 
-msgctxt "dlgSgStageNoFilesFound.fur"
+msgctxt "dlgSgStageNoFilesFound.fur:"
 msgid "Could not find files with modified working tree, untracked or missing files."
 msgstr "Нет модифицированных файлов в рабочем каталоге, которые можно было бы проиндексировать."
 
-msgctxt "dlgSgStageNoFilesFound.hdl"
+msgctxt "dlgSgStageNoFilesFound.hdl:"
 msgid "No files found that could be staged."
 msgstr "Нет файлов для индексирования."
 
-msgctxt "dlgSgStageNoFilesFound.tle"
+msgctxt "dlgSgStageNoFilesFound.tle:"
 msgid "Stage"
 msgstr "Индексирование"
 
@@ -10141,15 +10141,15 @@ msgctxt "dlgSgStartupExpired.btn:"
 msgid "Exit"
 msgstr ""
 
-msgctxt "dlgSgStartupExpired.fur"
+msgctxt "dlgSgStartupExpired.fur:"
 msgid "Please download and install a new one or a release version."
 msgstr ""
 
-msgctxt "dlgSgStartupExpired.hdl"
+msgctxt "dlgSgStartupExpired.hdl:"
 msgid "This beta version expired."
 msgstr ""
 
-msgctxt "dlgSgStartupExpired.tle"
+msgctxt "dlgSgStartupExpired.tle:"
 msgid "Beta Version Expired"
 msgstr ""
 
@@ -10173,15 +10173,15 @@ msgctxt "dlgSgStashAll.edt:"
 msgid "Message"
 msgstr "Пояснение"
 
-msgctxt "dlgSgStashAll.hdl"
+msgctxt "dlgSgStashAll.hdl:"
 msgid "Stash Index and Working Tree changes"
 msgstr "Скрыть изменения индекса и рабочего каталога"
 
-msgctxt "dlgSgStashAll.inf"
+msgctxt "dlgSgStashAll.inf:"
 msgid "The saved stash can be applied later. By default, Index and Working Tree are cleaned, but you may keep the Index or both."
 msgstr "Спрятанные изменения могут применены позднее. По умолчанию, индекс и рабочий каталог очищаются, но вы можете оставить индекс или оба."
 
-msgctxt "dlgSgStashAll.tle"
+msgctxt "dlgSgStashAll.tle:"
 msgid "Save Stash"
 msgstr "Скрытие изменений"
 
@@ -10205,11 +10205,11 @@ msgctxt "dlgSgStashApply.hdl:"
 msgid "Apply the latest saved stash"
 msgstr "Применение последних спрятанных изменений"
 
-msgctxt "dlgSgStashApply.inf"
+msgctxt "dlgSgStashApply.inf:"
 msgid "Decide how to apply the stash to the Index or working tree."
 msgstr "Решите, как применить спрятанные изменения: к индексу или рабочему каталогу."
 
-msgctxt "dlgSgStashApply.tle"
+msgctxt "dlgSgStashApply.tle:"
 msgid "Apply Stash"
 msgstr "Применение спрятанного"
 
@@ -10217,15 +10217,15 @@ msgctxt "dlgSgStashApplyWithoutRestoringIndex.btn:"
 msgid "Try Without Restoring Index"
 msgstr ""
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.fur"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.fur:"
 msgid "Restoring the index failed while applying the patch."
 msgstr ""
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.hdl"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.hdl:"
 msgid "Should the stash been applied without restoring the index?"
 msgstr ""
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.tle"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.tle:"
 msgid "Apply Stash"
 msgstr ""
 
@@ -10237,7 +10237,7 @@ msgctxt "dlgSgStashOnDemandConfirmation.btn:"
 msgid "Save Stash"
 msgstr "Спрятать"
 
-msgctxt "dlgSgStashOnDemandConfirmation.chk"
+msgctxt "dlgSgStashOnDemandConfirmation.chk:"
 msgid "Automatically save stash"
 msgstr ""
 
@@ -10309,7 +10309,7 @@ msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "What to do with the working tree or Index changes?"
 msgstr "Что делать с изменениями в рабочем каталоге или индексе?"
 
-msgctxt "dlgSgStashOnDemandConfirmation.tle"
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Reset"
 msgstr "Сброс изменений"
 
@@ -10321,15 +10321,15 @@ msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
 msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl:"
 msgid "Your local changes have been stashed away, but could not be reapplied."
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.tle"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.tle:"
 msgid "Pull"
 msgstr ""
 
@@ -10337,15 +10337,15 @@ msgctxt "dlgSgStashOnDemandProceedWithoutStashing.btn:"
 msgid "Proceed"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.fur"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.fur:"
 msgid "Auto-stashing changes is not possible due to technical reasons. Changes will be discarded!"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.hdl"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.hdl:"
 msgid "Do you want to proceed without stashing changes?"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.tle"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.tle:"
 msgid "Reset"
 msgstr ""
 
@@ -10357,15 +10357,15 @@ msgctxt "dlgSgStashRename.edt:"
 msgid "Message"
 msgstr ""
 
-msgctxt "dlgSgStashRename.hdl"
+msgctxt "dlgSgStashRename.hdl:"
 msgid "Rename Stash"
 msgstr ""
 
-msgctxt "dlgSgStashRename.inf"
+msgctxt "dlgSgStashRename.inf:"
 msgid "Enter the new message for the stash"
 msgstr ""
 
-msgctxt "dlgSgStashRename.tle"
+msgctxt "dlgSgStashRename.tle:"
 msgid "Rename"
 msgstr ""
 
@@ -10377,15 +10377,15 @@ msgctxt "dlgSgStashesDropConfirm.btn:"
 msgid "Drop Stashes"
 msgstr ""
 
-msgctxt "dlgSgStashesDropConfirm.fur"
+msgctxt "dlgSgStashesDropConfirm.fur:"
 msgid "The stashed changes will be lost."
 msgstr ""
 
-msgctxt "dlgSgStashesDropConfirm.hdl"
+msgctxt "dlgSgStashesDropConfirm.hdl:"
 msgid "Do you want to drop the selected stash?"
 msgstr ""
 
-msgctxt "dlgSgStashesDropConfirm.tle"
+msgctxt "dlgSgStashesDropConfirm.tle:"
 msgid "Drop Stash"
 msgstr ""
 
@@ -10477,7 +10477,7 @@ msgctxt "dlgSgSubmoduleAdd.rbt:"
 msgid "Remote repository"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleAdd.tle"
+msgctxt "dlgSgSubmoduleAdd.tle:"
 msgid "Add Submodule"
 msgstr "Добавление субмодуля"
 
@@ -10485,19 +10485,19 @@ msgctxt "dlgSgSubmoduleDeinitConfirm.btn:"
 msgid "Deinit"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.chk"
+msgctxt "dlgSgSubmoduleDeinitConfirm.chk:"
 msgid "Force \\(for modified submodules\\)"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.fur"
+msgctxt "dlgSgSubmoduleDeinitConfirm.fur:"
 msgid "The submodule will be skipped from the working tree. To get rid from the \\(remote\\) repository, you have to use Unregister instead."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.hdl"
+msgctxt "dlgSgSubmoduleDeinitConfirm.hdl:"
 msgid "Do you want to deinit submodule '$1'?"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.tle"
+msgctxt "dlgSgSubmoduleDeinitConfirm.tle:"
 msgid "Deinit Submodule"
 msgstr ""
 
@@ -10509,15 +10509,15 @@ msgctxt "dlgSgSubmoduleInitAll.chk:"
 msgid "Pull submodule repositories"
 msgstr "Получить изменения из репозиториев субмодулей"
 
-msgctxt "dlgSgSubmoduleInitAll.hdl"
+msgctxt "dlgSgSubmoduleInitAll.hdl:"
 msgid "Initialize all submodules"
 msgstr "Инициализация всех субмодулей"
 
-msgctxt "dlgSgSubmoduleInitAll.inf"
+msgctxt "dlgSgSubmoduleInitAll.inf:"
 msgid "Submodule entries will be added to .git/config. You may customize the URLs afterwards or pull immediately."
 msgstr "Записи о субмодулях будут добавлены в .git/config. Вы можете настроить URL адрес позже или выполнить получение немедленно"
 
-msgctxt "dlgSgSubmoduleInitAll.tle"
+msgctxt "dlgSgSubmoduleInitAll.tle:"
 msgid "Initialize Submodule"
 msgstr "Инициализация субмодулей"
 
@@ -10533,15 +10533,15 @@ msgctxt "dlgSgSubmoduleInitGit.edt:"
 msgid "URL"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitGit.hdl"
+msgctxt "dlgSgSubmoduleInitGit.hdl:"
 msgid "Set submodule URL"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitGit.inf"
+msgctxt "dlgSgSubmoduleInitGit.inf:"
 msgid "You can customize the submodule's clone URL used in .git/config for your local setup."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitGit.tle"
+msgctxt "dlgSgSubmoduleInitGit.tle:"
 msgid "Initialize Submodule"
 msgstr ""
 
@@ -10549,15 +10549,15 @@ msgctxt "dlgSgSubmoduleRegister.edt:"
 msgid "URL"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleRegister.hdl"
+msgctxt "dlgSgSubmoduleRegister.hdl:"
 msgid "Register nested root as submodule"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleRegister.inf"
+msgctxt "dlgSgSubmoduleRegister.inf:"
 msgid "Select the URL for the submodule to register."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleRegister.tle"
+msgctxt "dlgSgSubmoduleRegister.tle:"
 msgid "Register Submodule"
 msgstr ""
 
@@ -10565,15 +10565,15 @@ msgctxt "dlgSgSubmoduleResetConfirm.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetConfirm.fur"
+msgctxt "dlgSgSubmoduleResetConfirm.fur:"
 msgid "The corresponding commit will be checked out, so the submodule content will match the content of the registered commit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetConfirm.hdl"
+msgctxt "dlgSgSubmoduleResetConfirm.hdl:"
 msgid "Do you want to reset submodule '$1' to the commit registered in the repository?"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetConfirm.tle"
+msgctxt "dlgSgSubmoduleResetConfirm.tle:"
 msgid "Reset Submodule"
 msgstr ""
 
@@ -10581,15 +10581,15 @@ msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.fur"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.fur:"
 msgid "The submodule HEAD is not reachable from any ref. After resetting, it will be hard to access this commit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.hdl"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.hdl:"
 msgid "Do you want to perform the reset even though you will loose access to the current HEAD commit?"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.tle"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.tle:"
 msgid "Reset Submodule"
 msgstr ""
 
@@ -10605,27 +10605,27 @@ msgctxt "dlgSgSubmoduleSync.chk:"
 msgid "Pull submodule repository"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSync.hdl"
+msgctxt "dlgSgSubmoduleSync.hdl:"
 msgid "Synchronize all submodules"
 msgstr "Синхронизация всех субмодулей"
 
-msgctxt "dlgSgSubmoduleSync.inf"
+msgctxt "dlgSgSubmoduleSync.inf:"
 msgid "Submodule entries will be updated in .git/config. You may customize the URLs afterwards or pull immediately."
 msgstr "Записи о субмодулях будут обновлены в .git/config. Вы можете настроить URL адрес позже или выполнить получение немедленно"
 
-msgctxt "dlgSgSubmoduleSync.tle"
+msgctxt "dlgSgSubmoduleSync.tle:"
 msgid "Synchronize Submodules"
 msgstr "Синхронизация субмодулей"
 
-msgctxt "dlgSgSubmoduleSyncConfigured.fur"
+msgctxt "dlgSgSubmoduleSyncConfigured.fur:"
 msgid "You may now pull individual submodules or on the root directory to clone the configured repositories."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSyncConfigured.hdl"
+msgctxt "dlgSgSubmoduleSyncConfigured.hdl:"
 msgid "Submodules have been configured."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSyncConfigured.tle"
+msgctxt "dlgSgSubmoduleSyncConfigured.tle:"
 msgid "Synchronize Submodules"
 msgstr ""
 
@@ -10633,11 +10633,11 @@ msgctxt "dlgSgSubmoduleUnregisterConfirm.btn:"
 msgid "Unregister"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleUnregisterConfirm.fur"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.fur:"
 msgid "All relevant files will be adjusted. Afterwards you will only need to perform a commit to finish the operation. To just skip the submodule from the working tree, use Deinit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleUnregisterConfirm.tle"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.tle:"
 msgid "Unregister Submodule"
 msgstr ""
 
@@ -10693,7 +10693,7 @@ msgctxt "dlgSgSubtreeAdd.rbt:"
 msgid "Remote repository"
 msgstr ""
 
-msgctxt "dlgSgSubtreeAdd.tle"
+msgctxt "dlgSgSubtreeAdd.tle:"
 msgid "Add Subtree"
 msgstr ""
 
@@ -10713,19 +10713,19 @@ msgctxt "dlgSgSvnClientCertificate.edt:"
 msgid "Passphrase"
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.hdl"
+msgctxt "dlgSgSvnClientCertificate.hdl:"
 msgid "Client Certificate"
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.inf"
+msgctxt "dlgSgSvnClientCertificate.inf:"
 msgid "Provide the client certificate for authentication to the SVN repository '$1'."
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.tle"
+msgctxt "dlgSgSvnClientCertificate.tle:"
 msgid "SVN Authentication"
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\""
+msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
 msgid "Authentication to the SVN repository '$1' failed with error: $2'"
 msgstr ""
 
@@ -10757,7 +10757,7 @@ msgctxt "dlgSgSvnSslFingerprintChanged.lbl:"
 msgid "This might indicate a security problem! When in doubt, contact your server administrator."
 msgstr ""
 
-msgctxt "dlgSgSvnSslFingerprintChanged.tle"
+msgctxt "dlgSgSvnSslFingerprintChanged.tle:"
 msgid "SVN Authentication"
 msgstr ""
 
@@ -10765,19 +10765,19 @@ msgctxt "dlgSgSyncConfirm.btn:"
 msgid "Synchronize"
 msgstr "Синхронизировать"
 
-msgctxt "dlgSgSyncConfirm.chk"
+msgctxt "dlgSgSyncConfirm.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlgSgSyncConfirm.fur"
+msgctxt "dlgSgSyncConfirm.fur:"
 msgid "First, local changes will be pushed, then possible remote changes pulled. The advantage over a normal push is that if it fails because of remote changes, they will be pulled automatically."
 msgstr "Сначала будут отправлены локальные изменения, затем получены внешние, если они есть. В отличии от обычной отправки, если отправка изменений не возможна из-за наличия внешних, они будут автоматически получены и применены."
 
-msgctxt "dlgSgSyncConfirm.hdl"
+msgctxt "dlgSgSyncConfirm.hdl:"
 msgid "Do you want to proceed with sync?"
 msgstr "Хотите запустить синхронизацию?"
 
-msgctxt "dlgSgSyncConfirm.tle"
+msgctxt "dlgSgSyncConfirm.tle:"
 msgid "Synchronize"
 msgstr "Синхронизация"
 
@@ -10805,15 +10805,15 @@ msgctxt "dlgSgTagAdd.err:"
 msgid "The name must not end with a slash or dot."
 msgstr "Имя не может заканчиваться на слеш или точку."
 
-msgctxt "dlgSgTagAdd.hdl"
+msgctxt "dlgSgTagAdd.hdl:"
 msgid "Add tag to selected commit"
 msgstr "Добавление метки к выбранному коммиту"
 
-msgctxt "dlgSgTagAdd.inf"
+msgctxt "dlgSgTagAdd.inf:"
 msgid "Enter the name of the tag to create. If entering a message, an annotated tag is created."
 msgstr "Введите имя метки для создания. Если введете описание, то будет создана аннотированная метка."
 
-msgctxt "dlgSgTagAdd.tle"
+msgctxt "dlgSgTagAdd.tle:"
 msgid "Add Tag"
 msgstr "Создание метки"
 
@@ -10821,15 +10821,15 @@ msgctxt "dlgSgTagAddOverwrite.btn:"
 msgid "Overwrite"
 msgstr "Перезаписать"
 
-msgctxt "dlgSgTagAddOverwrite.fur"
+msgctxt "dlgSgTagAddOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different tag name."
 msgstr "Нажмите 'Отмена' для ввода другого имени."
 
-msgctxt "dlgSgTagAddOverwrite.hdl"
+msgctxt "dlgSgTagAddOverwrite.hdl:"
 msgid "The tag '$1' already exists. Do you want to overwrite it?"
 msgstr "Метка '$1' уже существует. Переписать ее?"
 
-msgctxt "dlgSgTagAddOverwrite.tle"
+msgctxt "dlgSgTagAddOverwrite.tle:"
 msgid "Add Tag"
 msgstr "Создание метки"
 
@@ -10837,23 +10837,23 @@ msgctxt "dlgSgTagDeleteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "Удалить"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk:"
 msgid "Delete from all remotes"
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
 msgstr "Удалить во внешнем '$1'"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.fur"
+msgctxt "dlgSgTagDeleteConfirmSingle.fur:"
 msgid "You will not be able to restore it."
 msgstr "Вы не сможете ее восстановить после удаления."
 
-msgctxt "dlgSgTagDeleteConfirmSingle.hdl"
+msgctxt "dlgSgTagDeleteConfirmSingle.hdl:"
 msgid "Do you want to delete the tag '$1'?"
 msgstr "Вы хотите удалить метку '$1'?"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.tle"
+msgctxt "dlgSgTagDeleteConfirmSingle.tle:"
 msgid "Delete"
 msgstr "Удаление"
 
@@ -10877,11 +10877,11 @@ msgctxt "dlgSgToolAdd.err:"
 msgid "The options 'Can be used by the Open command' and 'Show output and wait until finished' cannot both be set."
 msgstr ""
 
-msgctxt "dlgSgToolAdd.hdl"
+msgctxt "dlgSgToolAdd.hdl:"
 msgid "Add external tool"
 msgstr "Добавить внешний инструмент"
 
-msgctxt "dlgSgToolAdd.tle"
+msgctxt "dlgSgToolAdd.tle:"
 msgid "Add"
 msgstr "Добавление"
 
@@ -10893,11 +10893,11 @@ msgctxt "dlgSgToolEdit.err:"
 msgid "Please enter the name for this command."
 msgstr ""
 
-msgctxt "dlgSgToolEdit.hdl"
+msgctxt "dlgSgToolEdit.hdl:"
 msgid "Edit external tool"
 msgstr "Редактирование внешнего инструмента"
 
-msgctxt "dlgSgToolEdit.tle"
+msgctxt "dlgSgToolEdit.tle:"
 msgid "Edit"
 msgstr "Редактирование"
 
@@ -10941,7 +10941,7 @@ msgctxt "dlgSgTool(Add|Edit).edt:"
 msgid "Menu Item Name"
 msgstr "Имя пункта меню"
 
-msgctxt "dlgSgTool(Add|Edit).inf"
+msgctxt "dlgSgTool(Add|Edit).inf:"
 msgid "Define the name of the tool menu item, the command which should be executed and configure its arguments. The used variables define on what selection the tool may be used."
 msgstr "Определение имени пункта меню, команды и аргументов ее выполнения. Используемые переменные определяют вариант применения приложения."
 
@@ -11045,23 +11045,23 @@ msgctxt "dlgSgUndoLastCommitConfirm.fur:"
 msgid "Undoing an already pushed commit might cause serious problems!\\n\\nMessage: $1"
 msgstr "Отмена ранее отправленного коммита может вызывать серьезные проблемы!\\n\\nСообщение коммита: $1"
 
-msgctxt "dlgSgUndoLastCommitConfirm.hdl"
+msgctxt "dlgSgUndoLastCommitConfirm.hdl:"
 msgid "Do you want to undo the last local commit?"
 msgstr "Вы хотите отменить последний коммит в локальном репозитории?"
 
-msgctxt "dlgSgUndoLastCommitConfirm.tle"
+msgctxt "dlgSgUndoLastCommitConfirm.tle:"
 msgid "Undo Last Commit"
 msgstr "Отмена последнего коммита"
 
-msgctxt "dlgSgUnstageNoFilesFound.fur"
+msgctxt "dlgSgUnstageNoFilesFound.fur:"
 msgid "Could not find files with staged changes."
 msgstr ""
 
-msgctxt "dlgSgUnstageNoFilesFound.hdl"
+msgctxt "dlgSgUnstageNoFilesFound.hdl:"
 msgid "No files found that could be unstaged."
 msgstr ""
 
-msgctxt "dlgSgUnstageNoFilesFound.tle"
+msgctxt "dlgSgUnstageNoFilesFound.tle:"
 msgid "Unstage"
 msgstr ""
 
@@ -11069,11 +11069,11 @@ msgctxt "dlgSgWelcome.chk:"
 msgid "Show this dialog if no repository was opened"
 msgstr "Показывать этот диалог если нет открытого репозитория"
 
-msgctxt "dlgSgWelcome.hdl"
+msgctxt "dlgSgWelcome.hdl:"
 msgid "What do you want to do?"
 msgstr "Что хочешь сделать?"
 
-msgctxt "dlgSgWelcome.inf"
+msgctxt "dlgSgWelcome.inf:"
 msgid "Select whether to open a new, local repository, clone a \\(remote\\) repository or open an existing repository."
 msgstr "Выберите, нужно ли открыть новый локальный репозиторий, склонировать внешний или открыть существующий."
 
@@ -11089,7 +11089,7 @@ msgctxt "dlgSgWelcome.rbt:"
 msgid "Reopen previously used repository:"
 msgstr "Открыть ранее использованный репозиторий:"
 
-msgctxt "dlgSgWelcome.tle"
+msgctxt "dlgSgWelcome.tle:"
 msgid "Welcome to SmartGit"
 msgstr "Добро пожаловать в SmartGit"
 
@@ -11101,39 +11101,39 @@ msgctxt "dlgSgWorktreeAdd.edt:"
 msgid "Directory"
 msgstr "Каталог"
 
-msgctxt "dlgSgWorktreeAdd.hdl"
+msgctxt "dlgSgWorktreeAdd.hdl:"
 msgid "Create another worktree from this repository"
 msgstr "Создание другого рабочего каталога в этом репозитории"
 
-msgctxt "dlgSgWorktreeAdd.inf"
+msgctxt "dlgSgWorktreeAdd.inf:"
 msgid "Select the branch and directory to use for the new worktree."
 msgstr "Выберите ветку и каталог, которые будут использоваться для нового рабочего каталога."
 
-msgctxt "dlgSgWorktreeAdd.tle"
+msgctxt "dlgSgWorktreeAdd.tle:"
 msgid "Add Worktree"
 msgstr "Добавить рабочий каталог"
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.fur"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.fur:"
 msgid "You only can create worktrees for existing local branches that don't yet have an associated worktree."
 msgstr ""
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.hdl"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.hdl:"
 msgid "No \\(more\\) local branches available."
 msgstr ""
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.tle"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.tle:"
 msgid "Add Worktree"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneNoWorktree.fur"
+msgctxt "dlgSgWorktreePruneNoWorktree.fur:"
 msgid "All your worktrees are still available."
 msgstr "Все рабочие каталоги актуальны."
 
-msgctxt "dlgSgWorktreePruneNoWorktree.hdl"
+msgctxt "dlgSgWorktreePruneNoWorktree.hdl:"
 msgid "No worktree to prune."
 msgstr "Нет рабочих каталогов для удаления"
 
-msgctxt "dlgSgWorktreePruneNoWorktree.tle"
+msgctxt "dlgSgWorktreePruneNoWorktree.tle:"
 msgid "Prune Obsolete Worktrees"
 msgstr "Удаление устаревших рабочих каталогов"
 
@@ -11141,15 +11141,15 @@ msgctxt "dlgSgWorktreePruneWorktrees.btn:"
 msgid "Prune Worktrees"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneWorktrees.fur"
+msgctxt "dlgSgWorktreePruneWorktrees.fur:"
 msgid "Git reported following worktrees as obsolete:"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneWorktrees.hdl"
+msgctxt "dlgSgWorktreePruneWorktrees.hdl:"
 msgid "Do you want to prune following worktrees?"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneWorktrees.tle"
+msgctxt "dlgSgWorktreePruneWorktrees.tle:"
 msgid "Prune Obsolete Worktrees"
 msgstr ""
 
@@ -11169,15 +11169,15 @@ msgctxt "dlgShPushTrackingLocalSvnBranches.btn:"
 msgid "Push onto Existing"
 msgstr ""
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.fur"
+msgctxt "dlgShPushTrackingLocalSvnBranches.fur:"
 msgid "You are going to push local branches back to the SVN repository. These branches may either be pushed as new branches or onto their existing SVN counterparts \\(recommended in most cases\\)."
 msgstr ""
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.hdl"
+msgctxt "dlgShPushTrackingLocalSvnBranches.hdl:"
 msgid "Do you want to push local branches as new SVN branches?"
 msgstr ""
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.tle"
+msgctxt "dlgShPushTrackingLocalSvnBranches.tle:"
 msgid "Push"
 msgstr ""
 
@@ -11189,15 +11189,15 @@ msgctxt "dlgTxtEditor.fileModified.btn:"
 msgid "Reload"
 msgstr ""
 
-msgctxt "dlgTxtEditor.fileModified.fur"
+msgctxt "dlgTxtEditor.fileModified.fur:"
 msgid "Unless you want to see the old file state, it is recommended to reload."
 msgstr ""
 
-msgctxt "dlgTxtEditor.fileModified.hdl"
+msgctxt "dlgTxtEditor.fileModified.hdl:"
 msgid "The file config was changed. Reload it?"
 msgstr ""
 
-msgctxt "dlgTxtEditor.fileModified.tle"
+msgctxt "dlgTxtEditor.fileModified.tle:"
 msgid "Editor"
 msgstr ""
 
@@ -11261,11 +11261,11 @@ msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).btn:"
 msgid "Move to Trash"
 msgstr "Удалить в корзину"
 
-msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).fur"
+msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).fur:"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr "После нажатия кнопки Удалить восстановить файл можно будет только специальными инструментами!"
 
-msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).tle"
+msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).tle:"
 msgid "Delete"
 msgstr "Удаление"
 
@@ -11273,11 +11273,11 @@ msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgReposito
 msgid "Remove"
 msgstr "Удалить"
 
-msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).chk"
+msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
-msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).tle"
+msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).tle:"
 msgid "Remove"
 msgstr "Удаление"
 
@@ -11657,7 +11657,7 @@ msgctxt "ttpBranches:"
 msgid "<b>Incoming</b> from repository <b>$1</b> branch <b>$2</b> to branch <b>$3</b>"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\""
+msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
 msgid "<b>Last Updated By: </b>$1"
 msgstr ""
 
@@ -11665,11 +11665,11 @@ msgctxt "ttpBranches:"
 msgid "<b>Local Branch:\\t</b>$1"
 msgstr "<b>Локальная ветка:\\t</b>$1"
 
-msgctxt "ttpBranches\"<b>On:\\t</b>$1\""
+msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
 msgid "<b>On: </b>$1"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\""
+msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
 msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
 msgstr ""
 
@@ -11961,83 +11961,83 @@ msgctxt "wndAnnotate.mni:"
 msgid "Show Changes"
 msgstr "Показать изменения"
 
-msgctxt "wndAnnotate.mniCommit-first"
+msgctxt "wndAnnotate.mniCommit-first:"
 msgid "Go to First Commit"
 msgstr "Перейти к первому коммиту"
 
-msgctxt "wndAnnotate.mniCommit-last"
+msgctxt "wndAnnotate.mniCommit-last:"
 msgid "Go to Last Commit"
 msgstr "Перейти к последнему коммиту"
 
-msgctxt "wndAnnotate.mniCommit-next"
+msgctxt "wndAnnotate.mniCommit-next:"
 msgid "Go to Next Commit"
 msgstr "Перейти к следующему коммиту"
 
-msgctxt "wndAnnotate.mniCommit-preceding-line"
+msgctxt "wndAnnotate.mniCommit-preceding-line:"
 msgid "Go to Preceding Commit"
 msgstr "Перейти к предшествующему коммиту"
 
-msgctxt "wndAnnotate.mniCommit-previous"
+msgctxt "wndAnnotate.mniCommit-previous:"
 msgid "Go to Previous Commit"
 msgstr "Перейти к предыдущему коммиту"
 
-msgctxt "wndAnnotate.mniCompare"
+msgctxt "wndAnnotate.mniCompare:"
 msgid "Show Changes"
 msgstr ""
 
-msgctxt "wndAnnotate.mniCustomize"
+msgctxt "wndAnnotate.mniCustomize:"
 msgid "Customize"
 msgstr ""
 
-msgctxt "wndAnnotate.mniEdit-copy"
+msgctxt "wndAnnotate.mniEdit-copy:"
 msgid "Copy"
 msgstr "Копировать"
 
-msgctxt "wndAnnotate.mniFile-close"
+msgctxt "wndAnnotate.mniFile-close:"
 msgid "Close"
 msgstr "Закрыть"
 
-msgctxt "wndAnnotate.mniGoto-line"
+msgctxt "wndAnnotate.mniGoto-line:"
 msgid "Go to Line"
 msgstr "Перейти к строке"
 
-msgctxt "wndAnnotate.mniLog"
+msgctxt "wndAnnotate.mniLog:"
 msgid "Log"
 msgstr "История"
 
-msgctxt "wndAnnotate.mniSearch-find"
+msgctxt "wndAnnotate.mniSearch-find:"
 msgid "Find"
 msgstr "Найти"
 
-msgctxt "wndAnnotate.mniSearch-next"
+msgctxt "wndAnnotate.mniSearch-next:"
 msgid "Find Next"
 msgstr "Найти следующий"
 
-msgctxt "wndAnnotate.mniSearch-previous"
+msgctxt "wndAnnotate.mniSearch-previous:"
 msgid "Find Previous"
 msgstr "Найти предыдущий"
 
-msgctxt "wndAnnotate.mniSet-syntax"
+msgctxt "wndAnnotate.mniSet-syntax:"
 msgid "Syntax Language"
 msgstr "Язык синтаксиса"
 
-msgctxt "wndAnnotate.mniShowChanges"
+msgctxt "wndAnnotate.mniShowChanges:"
 msgid "Show Changes"
 msgstr "Показать изменения"
 
-msgctxt "wndAnnotate.mniUndo-goto"
+msgctxt "wndAnnotate.mniUndo-goto:"
 msgid "Undo Go To"
 msgstr "Вернуться"
 
-msgctxt "wndAnnotate.mniView-settings"
+msgctxt "wndAnnotate.mniView-settings:"
 msgid "Settings"
 msgstr "Настройки"
 
-msgctxt "wndAnnotate.mniWindowHideView"
+msgctxt "wndAnnotate.mniWindowHideView:"
 msgid "Hide View"
 msgstr "Скрыть панель"
 
-msgctxt "wndAnnotate.mniWindowLineHistory"
+msgctxt "wndAnnotate.mniWindowLineHistory:"
 msgid "Line History"
 msgstr "Линейная история"
 
@@ -12113,43 +12113,43 @@ msgctxt "wndCompare.mni:"
 msgid "Apply Selection to Right"
 msgstr ""
 
-msgctxt "wndCompare.mniRefresh"
+msgctxt "wndCompare.mniRefresh:"
 msgid "Reload"
 msgstr "Перезагрузить"
 
-msgctxt "wndCompare.mniView-ignore-whitespaces"
+msgctxt "wndCompare.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr "Игнорировать пробелы"
 
-msgctxt "wndCompare.mniView-layout-left-beside-right"
+msgctxt "wndCompare.mniView-layout-left-beside-right:"
 msgid "Left Beside Right"
 msgstr "Левый рядом с правым"
 
-msgctxt "wndCompare.mniView-layout-left-over-right"
+msgctxt "wndCompare.mniView-layout-left-over-right:"
 msgid "Left Above Right"
 msgstr "Левый над правым"
 
-msgctxt "wndCompare.tbtEdit-take-left"
+msgctxt "wndCompare.tbtEdit-take-left:"
 msgid "Take the left block to the right. Depending on the left block, this will insert, replace or delete at the right."
 msgstr ""
 
-msgctxt "wndCompare.tbtEdit-take-right"
+msgctxt "wndCompare.tbtEdit-take-right:"
 msgid "Take the right block to the left. Depending on the right block, this will insert, replace or delete at the left."
 msgstr ""
 
-msgctxt "wndCompare.tbtFile-save"
+msgctxt "wndCompare.tbtFile-save:"
 msgid "Save file modifications."
 msgstr ""
 
-msgctxt "wndCompare.tbtGoto-next-diff"
+msgctxt "wndCompare.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "Следующее изменение."
 
-msgctxt "wndCompare.tbtGoto-previous-diff"
+msgctxt "wndCompare.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "Предыдущее изменение."
 
-msgctxt "wndCompare.tbtRefresh"
+msgctxt "wndCompare.tbtRefresh:"
 msgid "Reload content from file system and recompare."
 msgstr ""
 
@@ -12169,23 +12169,23 @@ msgctxt "wndConflictSolver.mni:"
 msgid "Apply Selection to Working Tree"
 msgstr "Применить выбранное к рабочему каталогу"
 
-msgctxt "wndConflictSolver.mniView-ignore-whitespaces"
+msgctxt "wndConflictSolver.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr "Игнорировать пробелы"
 
-msgctxt "wndConflictSolver.mniView-layout-all"
+msgctxt "wndConflictSolver.mniView-layout-all:"
 msgid "All"
 msgstr "Все"
 
-msgctxt "wndConflictSolver.mniView-layout-left-merge"
+msgctxt "wndConflictSolver.mniView-layout-left-merge:"
 msgid "Left and Merge"
 msgstr "Левое и объединение"
 
-msgctxt "wndConflictSolver.mniView-layout-left-right-above-merge"
+msgctxt "wndConflictSolver.mniView-layout-left-right-above-merge:"
 msgid "Left and Right Above Merge"
 msgstr "Левое и правое над объединением"
 
-msgctxt "wndConflictSolver.mniView-layout-right-merge"
+msgctxt "wndConflictSolver.mniView-layout-right-merge:"
 msgid "Merge and Right"
 msgstr "Объединение и правое"
 
@@ -12237,59 +12237,59 @@ msgctxt "wndConflictSolver.tbr:"
 msgid "Take Right, Left"
 msgstr "Взять право, лево"
 
-msgctxt "wndConflictSolver.tbtEdit-take-left"
+msgctxt "wndConflictSolver.tbtEdit-take-left:"
 msgid "Take the left block to the merge result. Depending on the left block, this will insert, replace or delete at the merge result."
 msgstr "Взять левый блок в результат объединения. В зависимости от левого блока, это приведет либо к вставке, либо к удалению в результате объединения."
 
-msgctxt "wndConflictSolver.tbtEdit-take-left-right"
+msgctxt "wndConflictSolver.tbtEdit-take-left-right:"
 msgid "Take the left block, then the right one."
 msgstr "Взять блок слева, затем справа."
 
-msgctxt "wndConflictSolver.tbtEdit-take-right"
+msgctxt "wndConflictSolver.tbtEdit-take-right:"
 msgid "Take the right block to the merge result. Depending on the right block, this will insert, replace or delete at the merge result."
 msgstr "Взять правый блок в результат объединения. В зависимости от правого блока, это приведет либо к вставке, либо к удалению в результате объединения."
 
-msgctxt "wndConflictSolver.tbtEdit-take-right-left"
+msgctxt "wndConflictSolver.tbtEdit-take-right-left:"
 msgid "Take the right block, then the left one."
 msgstr "Взять блок справа, затем слева."
 
-msgctxt "wndConflictSolver.tbtFile-open-base"
+msgctxt "wndConflictSolver.tbtFile-open-base:"
 msgid "Open the left and right changes from the common base file."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtFile-save"
+msgctxt "wndConflictSolver.tbtFile-save:"
 msgid "Save file modifications."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtGoto-next-conflict"
+msgctxt "wndConflictSolver.tbtGoto-next-conflict:"
 msgid "Go to next conflict."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtGoto-next-diff"
+msgctxt "wndConflictSolver.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "Следующее изменение."
 
-msgctxt "wndConflictSolver.tbtGoto-previous-conflict"
+msgctxt "wndConflictSolver.tbtGoto-previous-conflict:"
 msgid "Go to previous conflict."
 msgstr ""
 
-msgctxt "wndConflictSolver.tbtGoto-previous-diff"
+msgctxt "wndConflictSolver.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "Предыдущее изменение."
 
-msgctxt "wndConflictSolver.tbtView-layout-all"
+msgctxt "wndConflictSolver.tbtView-layout-all:"
 msgid "Show the left, merge and right file."
 msgstr "Показать левый файл, объединенный и правый."
 
-msgctxt "wndConflictSolver.tbtView-layout-left-merge"
+msgctxt "wndConflictSolver.tbtView-layout-left-merge:"
 msgid "Show the left and merge file."
 msgstr "Показать левый файл и объединенный."
 
-msgctxt "wndConflictSolver.tbtView-layout-left-right-above-merge"
+msgctxt "wndConflictSolver.tbtView-layout-left-right-above-merge:"
 msgid "Show the left and right files above the merge file."
 msgstr "Показать левый и правый файлы над объединенным."
 
-msgctxt "wndConflictSolver.tbtView-layout-right-merge"
+msgctxt "wndConflictSolver.tbtView-layout-right-merge:"
 msgid "Show the merge and right file."
 msgstr "Показать объединенный файл и правый."
 
@@ -12565,167 +12565,167 @@ msgctxt "wndDeepgit.mni:"
 msgid "Open Repository Log"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDbBack"
+msgctxt "wndDeepgit.mniDbBack:"
 msgid "Go Back"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgAbout"
+msgctxt "wndDeepgit.mniDgAbout:"
 msgid "About DeepGit"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgBack"
+msgctxt "wndDeepgit.mniDgBack:"
 msgid "Go Back"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgConfigureRefGroups"
+msgctxt "wndDeepgit.mniDgConfigureRefGroups:"
 msgid "Tag-Grouping"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgExtendLineToBlock"
+msgctxt "wndDeepgit.mniDgExtendLineToBlock:"
 msgid "Extend Lines to Blocks"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgFilterAddSelection"
+msgctxt "wndDeepgit.mniDgFilterAddSelection:"
 msgid "Add Selection to Filter"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgFilterReset"
+msgctxt "wndDeepgit.mniDgFilterReset:"
 msgid "Reset Filter"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgFilterSetSelection"
+msgctxt "wndDeepgit.mniDgFilterSetSelection:"
 msgid "Set Selection as Filter"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgFollowRenames"
+msgctxt "wndDeepgit.mniDgFollowRenames:"
 msgid "Follow Renames"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgForward"
+msgctxt "wndDeepgit.mniDgForward:"
 msgid "Go Forward"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgHighlightBlameChanges"
+msgctxt "wndDeepgit.mniDgHighlightBlameChanges:"
 msgid "Highlight Changes of Current Blame Commit"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgHighlightOriginChanges"
+msgctxt "wndDeepgit.mniDgHighlightOriginChanges:"
 msgid "Highlight Changes of Current Origin Commit"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgIgnoreWhitespaceOnlyChanges"
+msgctxt "wndDeepgit.mniDgIgnoreWhitespaceOnlyChanges:"
 msgid "Ignore Whitespace Changes"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgLicenseAgreement"
+msgctxt "wndDeepgit.mniDgLicenseAgreement:"
 msgid "License Agreement"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgOptimizeCreationOrigins"
+msgctxt "wndDeepgit.mniDgOptimizeCreationOrigins:"
 msgid "Optimize 'Appeared Here' Origins"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.mniDgPerspectiveBlameOrigin:"
 msgid "Blame+Origins Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveBlameSimple"
+msgctxt "wndDeepgit.mniDgPerspectiveBlameSimple:"
 msgid "Blame Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveCommit"
+msgctxt "wndDeepgit.mniDgPerspectiveCommit:"
 msgid "Log Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveHistory"
+msgctxt "wndDeepgit.mniDgPerspectiveHistory:"
 msgid "Diff Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgPerspectiveOrigins"
+msgctxt "wndDeepgit.mniDgPerspectiveOrigins:"
 msgid "Origins Perspective"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgResetInlineHelp"
+msgctxt "wndDeepgit.mniDgResetInlineHelp:"
 msgid "Reshow All Inline Help"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgSetEncoding"
+msgctxt "wndDeepgit.mniDgSetEncoding:"
 msgid "Encoding"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgShowAtRefs"
+msgctxt "wndDeepgit.mniDgShowAtRefs:"
 msgid "Show At Refs"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgShowLinePrefixes"
+msgctxt "wndDeepgit.mniDgShowLinePrefixes:"
 msgid "Show Line Prefixes"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgShowOnRefs"
+msgctxt "wndDeepgit.mniDgShowOnRefs:"
 msgid "Show On Refs"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgToggleLineHistory"
+msgctxt "wndDeepgit.mniDgToggleLineHistory:"
 msgid "Line History"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgViewToolbar"
+msgctxt "wndDeepgit.mniDgViewToolbar:"
 msgid "Show Toolbar"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgWindowHorizontalLayout"
+msgctxt "wndDeepgit.mniDgWindowHorizontalLayout:"
 msgid "Horizontal Blame + Origins Layout"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgWindowVerticalLayout"
+msgctxt "wndDeepgit.mniDgWindowVerticalLayout:"
 msgid "Vertical Blame + Origins Layout"
 msgstr ""
 
-msgctxt "wndDeepgit.mniEdit-copy"
+msgctxt "wndDeepgit.mniEdit-copy:"
 msgid "Copy"
 msgstr ""
 
-msgctxt "wndDeepgit.mniFile-close"
+msgctxt "wndDeepgit.mniFile-close:"
 msgid "Close"
 msgstr ""
 
-msgctxt "wndDeepgit.mniGoto-line"
+msgctxt "wndDeepgit.mniGoto-line:"
 msgid "Go to Line"
 msgstr ""
 
-msgctxt "wndDeepgit.mniGoto-next-diff"
+msgctxt "wndDeepgit.mniGoto-next-diff:"
 msgid "Next Change"
 msgstr ""
 
-msgctxt "wndDeepgit.mniGoto-previous-diff"
+msgctxt "wndDeepgit.mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr ""
 
-msgctxt "wndDeepgit.mniNextChange"
+msgctxt "wndDeepgit.mniNextChange:"
 msgid "Next Change"
 msgstr ""
 
-msgctxt "wndDeepgit.mniOpenFileLog"
+msgctxt "wndDeepgit.mniOpenFileLog:"
 msgid "Open File Log"
 msgstr ""
 
-msgctxt "wndDeepgit.mniOpenRepositoryLog"
+msgctxt "wndDeepgit.mniOpenRepositoryLog:"
 msgid "Open Repository Log"
 msgstr ""
 
-msgctxt "wndDeepgit.mniPreviousChange"
+msgctxt "wndDeepgit.mniPreviousChange:"
 msgid "Previous Change"
 msgstr ""
 
-msgctxt "wndDeepgit.mniSearch-find"
+msgctxt "wndDeepgit.mniSearch-find:"
 msgid "Find"
 msgstr ""
 
-msgctxt "wndDeepgit.mniSearch-next"
+msgctxt "wndDeepgit.mniSearch-next:"
 msgid "Find Next"
 msgstr ""
 
-msgctxt "wndDeepgit.mniSearch-previous"
+msgctxt "wndDeepgit.mniSearch-previous:"
 msgid "Find Previous"
 msgstr ""
 
@@ -12817,59 +12817,59 @@ msgctxt "wndDeepgit.tbt:"
 msgid "Go to previous change."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtBack"
+msgctxt "wndDeepgit.tbtBack:"
 msgid "Go back to previous blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDbBack"
+msgctxt "wndDeepgit.tbtDbBack:"
 msgid "Go back to previous blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgForward"
+msgctxt "wndDeepgit.tbtDgForward:"
 msgid "Go forward to next blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.tbtDgPerspectiveBlameOrigin:"
 msgid "Find where the line originates from in cases where you need to choose from one of possible Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveBlameSimple"
+msgctxt "wndDeepgit.tbtDgPerspectiveBlameSimple:"
 msgid "Find where the line originates from in simple cases when there are no alternative Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveCommit"
+msgctxt "wndDeepgit.tbtDgPerspectiveCommit:"
 msgid "Investigate Log."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveHistory"
+msgctxt "wndDeepgit.tbtDgPerspectiveHistory:"
 msgid "Investigate Diff between file's revisions."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveOrigins"
+msgctxt "wndDeepgit.tbtDgPerspectiveOrigins:"
 msgid "Find out what else happened where the line originates from.\\n\\nIn order to inspect available Origins, they have to be evaluated first. First, select the file you want to investigate using File\\|Open and select a line in it. Then wait until the calculation of possible Origins has finished."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtForward"
+msgctxt "wndDeepgit.tbtForward:"
 msgid "Go forward to next blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.tbtPerspectiveBlameOrigin:"
 msgid "Find where the line originates from in cases where you need to choose from one of possible Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveBlameSimple"
+msgctxt "wndDeepgit.tbtPerspectiveBlameSimple:"
 msgid "Find where the line originates from in simple cases when there are no alternative Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveCommit"
+msgctxt "wndDeepgit.tbtPerspectiveCommit:"
 msgid "Investigate Log."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveHistory"
+msgctxt "wndDeepgit.tbtPerspectiveHistory:"
 msgid "Investigate Diff between file's revisions."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtPerspectiveOrigins"
+msgctxt "wndDeepgit.tbtPerspectiveOrigins:"
 msgid "Find out what else happened where the line originates from.\\n\\nIn order to inspect available Origins, they have to be evaluated first. First, select the file you want to investigate using File\\|Open and select a line in it. Then wait until the calculation of possible Origins has finished."
 msgstr ""
 
@@ -12893,31 +12893,31 @@ msgctxt "wndEditor.mni:"
 msgid "LF \\(Unix, macOS\\)"
 msgstr ""
 
-msgctxt "wndEditor.mniEdit-undo"
+msgctxt "wndEditor.mniEdit-undo:"
 msgid "Undo"
 msgstr ""
 
-msgctxt "wndEditor.mniEofEnforceLineEnding"
+msgctxt "wndEditor.mniEofEnforceLineEnding:"
 msgid "Enforce Line Ending on End of File"
 msgstr ""
 
-msgctxt "wndEditor.mniReplaceTabsWithSpaces"
+msgctxt "wndEditor.mniReplaceTabsWithSpaces:"
 msgid "Replace Tabs With Spaces"
 msgstr ""
 
-msgctxt "wndEditor.mniSaveAuto"
+msgctxt "wndEditor.mniSaveAuto:"
 msgid "Auto-Save"
 msgstr ""
 
-msgctxt "wndEditor.mniView-remember-as-default"
+msgctxt "wndEditor.mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr ""
 
-msgctxt "wndEditor.mniView-settings"
+msgctxt "wndEditor.mniView-settings:"
 msgid "Settings"
 msgstr ""
 
-msgctxt "wndEditor.tbtFile-save"
+msgctxt "wndEditor.tbtFile-save:"
 msgid "Save file modifications."
 msgstr ""
 
@@ -12961,59 +12961,59 @@ msgctxt "wndGit.indexEditor.mni:"
 msgid "Unstage Selection"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-ignore-whitespaces"
+msgctxt "wndGit.indexEditor.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-all"
+msgctxt "wndGit.indexEditor.mniView-layout-all:"
 msgid "All"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-index"
+msgctxt "wndGit.indexEditor.mniView-layout-head-index:"
 msgid "HEAD and Index"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-index-wt"
+msgctxt "wndGit.indexEditor.mniView-layout-head-index-wt:"
 msgid "All"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-wt-above-index"
+msgctxt "wndGit.indexEditor.mniView-layout-head-wt-above-index:"
 msgid "HEAD and Working Tree Above Index"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-index-wt"
+msgctxt "wndGit.indexEditor.mniView-layout-index-wt:"
 msgid "Index and Working Tree"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-left-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-left-merge:"
 msgid "HEAD and Index"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-left-right-above-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-left-right-above-merge:"
 msgid "HEAD and Working Tree Above Index"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-right-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-right-merge:"
 msgid "Index and Working Tree"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.tbtEdit-take-left"
+msgctxt "wndGit.indexEditor.tbtEdit-take-left:"
 msgid "Take the left block to the merge result. Depending on the left block, this will insert, replace or delete at the merge result."
 msgstr ""
 
-msgctxt "wndGit.indexEditor.tbtEdit-take-right"
+msgctxt "wndGit.indexEditor.tbtEdit-take-right:"
 msgid "Take the right block to the merge result. Depending on the right block, this will insert, replace or delete at the merge result."
 msgstr ""
 
-msgctxt "wndGit.indexEditor.tbtFile-save"
+msgctxt "wndGit.indexEditor.tbtFile-save:"
 msgid "Save file modifications."
 msgstr "Сохранить изменения."
 
-msgctxt "wndGit.indexEditor.tbtGoto-next-diff"
+msgctxt "wndGit.indexEditor.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "Следующее изменение."
 
-msgctxt "wndGit.indexEditor.tbtGoto-previous-diff"
+msgctxt "wndGit.indexEditor.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "Предыдущее изменение."
 
@@ -13025,7 +13025,7 @@ msgctxt "wndLog.hnt:"
 msgid "No graph roots selected."
 msgstr ""
 
-msgctxt "wndLog.mniFixCaseChange"
+msgctxt "wndLog.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr "Исправить изменение регистра"
 
@@ -13177,31 +13177,31 @@ msgctxt "wndStd.mni:"
 msgid "Sort by Path"
 msgstr ""
 
-msgctxt "wndStd.mniBisectTryCommit"
+msgctxt "wndStd.mniBisectTryCommit:"
 msgid "Try Commit"
 msgstr ""
 
-msgctxt "wndStd.mniFixCaseChange"
+msgctxt "wndStd.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr ""
 
-msgctxt "wndStd.mniIntegrateMain"
+msgctxt "wndStd.mniIntegrateMain:"
 msgid "Integrate Main"
 msgstr ""
 
-msgctxt "wndStd.mniStdOpenSubmodule"
+msgctxt "wndStd.mniStdOpenSubmodule:"
 msgid "Open a Submodule"
 msgstr ""
 
-msgctxt "wndStd.mniStdOpenSubmoduleFromFile"
+msgctxt "wndStd.mniStdOpenSubmoduleFromFile:"
 msgid "Open this Submodule"
 msgstr ""
 
-msgctxt "wndStd.mniStdSetModeHistory"
+msgctxt "wndStd.mniStdSetModeHistory:"
 msgid "Show History"
 msgstr ""
 
-msgctxt "wndStd.mniStdSetModeWt"
+msgctxt "wndStd.mniStdSetModeWt:"
 msgid "Show Local Changes"
 msgstr ""
 
@@ -13213,7 +13213,7 @@ msgctxt "wndStd.tbr:"
 msgid "Submodule"
 msgstr ""
 
-msgctxt "wndStd.tbtFlowFeatureStart"
+msgctxt "wndStd.tbtFlowFeatureStart:"
 msgid "Start a new feature branch."
 msgstr ""
 
@@ -13221,19 +13221,19 @@ msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|
 msgid "Ready"
 msgstr "Готов"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
 msgid "Full Screen"
 msgstr "Полный экран"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
 msgid "Maximize"
 msgstr "Развернуть"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore:"
 msgid "Restore"
 msgstr "Восстановить"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-minimize"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-minimize:"
 msgid "Minimize"
 msgstr "Свернуть"
 
@@ -13253,83 +13253,83 @@ msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|
 msgid "Window"
 msgstr "Окно"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left:"
 msgid "Take Left Block"
 msgstr "Взять блок слева"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left-right"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left-right:"
 msgid "Take Left, then Right Block"
 msgstr "Взять левый блок, затем правый"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right:"
 msgid "Take Right Block"
 msgstr "Взять блок справа"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right-left"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right-left:"
 msgid "Take Right, then Left Block"
 msgstr "Взять правый блок, затем левый"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-undo"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-undo:"
 msgid "Undo"
 msgstr "Отменить"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-export-html"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-export-html:"
 msgid "Export as HTML-File"
 msgstr "Выгрузить как HTML-файл"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-open-base"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-open-base:"
 msgid "Open Base File Changes"
 msgstr "Открыть изменения к общей базе"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-conflict"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-conflict:"
 msgid "Next Conflict"
 msgstr "Следующий конфликт"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-diff"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-diff:"
 msgid "Next Change"
 msgstr "Следующее изменение"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-conflict"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-conflict:"
 msgid "Previous Conflict"
 msgstr "Предыдущий конфлик"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-diff"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr "Предыдущее изменение"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniShow-line-numbers"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniShow-line-numbers:"
 msgid "Show Line Numbers"
 msgstr "Показывать номер строк"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-all"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-all:"
 msgid "Ignore All Whitespaces for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-leading-trailing"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-leading-trailing:"
 msgid "Ignore Leading/Trailing Whitespaces for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-none"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-none:"
 msgid "Ignore No Whitespace for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-refresh"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-refresh:"
 msgid "Reload"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-remember-as-default"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr "Запомнить по умолчанию"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-settings"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-settings:"
 msgid "Settings"
 msgstr "Настройки"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-show-current-line-control"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-show-current-line-control:"
 msgid "Show Long Current Lines"
 msgstr "Показывать длинные строки"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-synchronize-scrolling"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-synchronize-scrolling:"
 msgid "Synchronize Scrolling"
 msgstr "Синхронная прокрутка"
 
@@ -13357,59 +13357,59 @@ msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mni:"
 msgid "Copy Selection"
 msgstr "Скопировать выделенное"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniCustomize"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniCustomize:"
 msgid "Customize"
 msgstr ""
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-copy"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-copy:"
 msgid "Copy"
 msgstr "Копировать"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-cut"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-cut:"
 msgid "Cut"
 msgstr "Вырезать"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-ignore-case-changes"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-ignore-case-changes:"
 msgid "Ignore Case Change for Line Comparison"
 msgstr "Игнорировать различия регистров в строке сравнения"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-paste"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-paste:"
 msgid "Paste"
 msgstr "Вставить"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-redo"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-redo:"
 msgid "Redo"
 msgstr "Повторить"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-close"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-close:"
 msgid "Close"
 msgstr "Закрыть"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-save"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-save:"
 msgid "Save"
 msgstr "Сохранить"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniGoto-line"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniGoto-line:"
 msgid "Go to Line"
 msgstr "Перейти к строке"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-find"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-find:"
 msgid "Find"
 msgstr "Найти"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-next"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-next:"
 msgid "Find Next"
 msgstr "Найти след."
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-previous"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-previous:"
 msgid "Find Previous"
 msgstr "Найти пред."
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-replace"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-replace:"
 msgid "Find and Replace"
 msgstr "Найти и заменить"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSet-syntax"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSet-syntax:"
 msgid "Syntax Language"
 msgstr "Язык синтаксиса"
 
@@ -13433,11 +13433,11 @@ msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).tbr:"
 msgid "Save"
 msgstr "Сохранить"
 
-msgctxt "wnd(Log|Project|).tbtFlowFeatureFinish"
+msgctxt "wnd(Log|Project|).tbtFlowFeatureFinish:"
 msgid "Finish a Git-Flow feature."
 msgstr ""
 
-msgctxt "wnd(Log|Project|).tbtFlowFeatureStart"
+msgctxt "wnd(Log|Project|).tbtFlowFeatureStart:"
 msgid "Start a new Git-Flow feature."
 msgstr ""
 
@@ -13737,7 +13737,7 @@ msgctxt "wnd(Log|Project|Std|).lbl:"
 msgid "Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\""
+msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
 msgid "Show Rewritten Behind Commits"
 msgstr ""
 
@@ -14501,307 +14501,307 @@ msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Varying Coloring"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniAbout"
+msgctxt "wnd(Log|Project|Std|).mniAbout:"
 msgid "About SmartGit"
 msgstr "О SmartGit"
 
-msgctxt "wnd(Log|Project|Std|).mniAdd"
+msgctxt "wnd(Log|Project|Std|).mniAdd:"
 msgid "Add"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniAnnotate"
+msgctxt "wnd(Log|Project|Std|).mniAnnotate:"
 msgid "Blame"
 msgstr "Авторство"
 
-msgctxt "wnd(Log|Project|Std|).mniAssume-unchanged-toggle"
+msgctxt "wnd(Log|Project|Std|).mniAssume-unchanged-toggle:"
 msgid "Toggle 'Assume Unchanged'"
 msgstr "Переключить 'Считать неизмененным'"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectBad"
+msgctxt "wnd(Log|Project|Std|).mniBisectBad:"
 msgid "Mark HEAD as Bad"
 msgstr "Поместить HEAD плохим"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectExit"
+msgctxt "wnd(Log|Project|Std|).mniBisectExit:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBisectGood"
+msgctxt "wnd(Log|Project|Std|).mniBisectGood:"
 msgid "Mark HEAD as Good"
 msgstr "Пометить HEAD хорошим"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectStart"
+msgctxt "wnd(Log|Project|Std|).mniBisectStart:"
 msgid "Start"
 msgstr "Начать"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAbort"
+msgctxt "wnd(Log|Project|Std|).mniBranchAbort:"
 msgid "Abort"
 msgstr "Прервать"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAdd"
+msgctxt "wnd(Log|Project|Std|).mniBranchAdd:"
 msgid "Add Branch"
 msgstr "Создать ветку"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAddTag"
+msgctxt "wnd(Log|Project|Std|).mniBranchAddTag:"
 msgid "Add Tag"
 msgstr "Создать метку"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchClose"
+msgctxt "wnd(Log|Project|Std|).mniBranchClose:"
 msgid "Close"
 msgstr "Закрыть"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchContinue"
+msgctxt "wnd(Log|Project|Std|).mniBranchContinue:"
 msgid "Continue"
 msgstr "Продолжить"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchDelete"
+msgctxt "wnd(Log|Project|Std|).mniBranchDelete:"
 msgid "Delete"
 msgstr "Удалить"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchRename"
+msgctxt "wnd(Log|Project|Std|).mniBranchRename:"
 msgid "Rename"
 msgstr "Переименовать"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchResetTracking"
+msgctxt "wnd(Log|Project|Std|).mniBranchResetTracking:"
 msgid "Stop Tracking"
 msgstr "Прекратить отслеживание"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSetTracking"
+msgctxt "wnd(Log|Project|Std|).mniBranchSetTracking:"
 msgid "Set Tracked Branch"
 msgstr "Указать ветку отслеживания"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSplit"
+msgctxt "wnd(Log|Project|Std|).mniBranchSplit:"
 msgid "Modify or Split Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSplitFiles"
+msgctxt "wnd(Log|Project|Std|).mniBranchSplitFiles:"
 msgid "Split Off Files"
 msgstr "Разделить файлы"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowRemoteOnly"
+msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowRemoteOnly:"
 msgid "Show remote branches in their Git-Flow sections"
 msgstr "Показывать внешние ветки в разделах Git-Flow"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowTracked"
+msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowTracked:"
 msgid "Show remote, tracked branches"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionize"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionize:"
 msgid "Group tags and branches by path-like name \\(foo/bar\\)"
 msgstr "Группировать ветки и метки в виде структуры каталогов \\(группа/имя\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeAfterLastSlash"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeAfterLastSlash:"
 msgid "After last slash"
 msgstr "После последнего слеша"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeCompact"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeCompact:"
 msgid "Except for single refs"
 msgstr "Исключать для одиночных ссылок"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionsBeforeRefs"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionsBeforeRefs:"
 msgid "Show groups first"
 msgstr "Группы первыми"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSelectObsolete"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSelectObsolete:"
 msgid "Select Obsolete Local Branches"
 msgstr "Выбрать устаревшие локальные ветки"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByName"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByName:"
 msgid "Sort Refs by Name"
 msgstr "Сортировка по имени"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByNameReversed"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByNameReversed:"
 msgid "Sort Refs by Name \\(Numbers Reversed\\)"
 msgstr "Сортировка по имени \\(числа в обратном порядке\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByTime"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByTime:"
 msgid "Sort Refs by Commit Time"
 msgstr "Сортировка по времени коммита"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.compact"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.compact:"
 msgid "Compact"
 msgstr "Компактно"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.ignoreLineSeparators"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.ignoreLineSeparators:"
 msgid "Ignore Line-Ending Changes"
 msgstr "Игнорировать различия окончаний строк"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.sideBySide"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.sideBySide:"
 msgid "Side by Side"
 msgstr "Рядом"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.unified"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.unified:"
 msgid "Unified"
 msgstr "Единый"
 
-msgctxt "wnd(Log|Project|Std|).mniCheckForLatestBuild"
+msgctxt "wnd(Log|Project|Std|).mniCheckForLatestBuild:"
 msgid "Check for Latest Build"
 msgstr "Проверить наличие свежей сборки"
 
-msgctxt "wnd(Log|Project|Std|).mniCheckForNewVersion"
+msgctxt "wnd(Log|Project|Std|).mniCheckForNewVersion:"
 msgid "Check for New Version"
 msgstr "Проверить наличие новой версии"
 
-msgctxt "wnd(Log|Project|Std|).mniCheckout"
+msgctxt "wnd(Log|Project|Std|).mniCheckout:"
 msgid "Check Out"
 msgstr "Переключиться"
 
-msgctxt "wnd(Log|Project|Std|).mniCherryPick"
+msgctxt "wnd(Log|Project|Std|).mniCherryPick:"
 msgid "Cherry-Pick"
 msgstr "Забрать \\(cherry-pick\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniClean"
+msgctxt "wnd(Log|Project|Std|).mniClean:"
 msgid "Clean Working Tree"
 msgstr "Очистить рабочий каталог"
 
-msgctxt "wnd(Log|Project|Std|).mniClearOutput"
+msgctxt "wnd(Log|Project|Std|).mniClearOutput:"
 msgid "Clear Output"
 msgstr "Очистить вывод"
 
-msgctxt "wnd(Log|Project|Std|).mniCommit"
+msgctxt "wnd(Log|Project|Std|).mniCommit:"
 msgid "Commit"
 msgstr "Зафиксировать"
 
-msgctxt "wnd(Log|Project|Std|).mniCompact-display"
+msgctxt "wnd(Log|Project|Std|).mniCompact-display:"
 msgid "Compact Change Display"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniCompareWithWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniCompareWithWorkingTree:"
 msgid "Compare with Working Tree"
 msgstr "Сравнить в рабочем каталоге"
 
-msgctxt "wnd(Log|Project|Std|).mniConfigureTagGrouping"
+msgctxt "wnd(Log|Project|Std|).mniConfigureTagGrouping:"
 msgid "Tag-Grouping"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniConfigureToolbar"
+msgctxt "wnd(Log|Project|Std|).mniConfigureToolbar:"
 msgid "Configure Toolbar"
 msgstr "Настроить панель инструментов"
 
-msgctxt "wnd(Log|Project|Std|).mniConflictSolver"
+msgctxt "wnd(Log|Project|Std|).mniConflictSolver:"
 msgid "Conflict Solver"
 msgstr "Решение конфликтов"
 
-msgctxt "wnd(Log|Project|Std|).mniContactSupport"
+msgctxt "wnd(Log|Project|Std|).mniContactSupport:"
 msgid "Contact Support"
 msgstr "Написать в поддержку"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyCommitId"
+msgctxt "wnd(Log|Project|Std|).mniCopyCommitId:"
 msgid "Copy ID"
 msgstr "Копировать ID"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyCommitMessage"
+msgctxt "wnd(Log|Project|Std|).mniCopyCommitMessage:"
 msgid "Copy Message"
 msgstr "Копировать сообщение"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyName"
+msgctxt "wnd(Log|Project|Std|).mniCopyName:"
 msgid "Copy Name"
 msgstr "Копировать имя"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyPath"
+msgctxt "wnd(Log|Project|Std|).mniCopyPath:"
 msgid "Copy Path"
 msgstr "Копировать путь"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyRelativePath"
+msgctxt "wnd(Log|Project|Std|).mniCopyRelativePath:"
 msgid "Copy Relative Path"
 msgstr "Копировать относительный путь"
 
-msgctxt "wnd(Log|Project|Std|).mniCustomize"
+msgctxt "wnd(Log|Project|Std|).mniCustomize:"
 msgid "Customize"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugCreateHeapDump"
+msgctxt "wnd(Log|Project|Std|).mniDebugCreateHeapDump:"
 msgid "Create Heap Dump"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugCreateThreadDumps"
+msgctxt "wnd(Log|Project|Std|).mniDebugCreateThreadDumps:"
 msgid "Create Periodical Thread Dumps"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugEnableRefreshTraceLogging"
+msgctxt "wnd(Log|Project|Std|).mniDebugEnableRefreshTraceLogging:"
 msgid "Starting Tracing Refreshing"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorEvents"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorEvents:"
 msgid "Log File Monitor Events"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorState"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorState:"
 msgid "Log File Monitor State"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogOpenRepositories"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogOpenRepositories:"
 msgid "Log Open Repositories"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugRestart"
+msgctxt "wnd(Log|Project|Std|).mniDebugRestart:"
 msgid "Restart"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDebugRunGc"
+msgctxt "wnd(Log|Project|Std|).mniDebugRunGc:"
 msgid "Run GC"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniDelete"
+msgctxt "wnd(Log|Project|Std|).mniDelete:"
 msgid "Delete"
 msgstr "Удалить"
 
-msgctxt "wnd(Log|Project|Std|).mniDiscard"
+msgctxt "wnd(Log|Project|Std|).mniDiscard:"
 msgid "Discard"
 msgstr "Отменить изменения"
 
-msgctxt "wnd(Log|Project|Std|).mniEdit-ignore-case-changes"
+msgctxt "wnd(Log|Project|Std|).mniEdit-ignore-case-changes:"
 msgid "Ignore Case Change for Line Comparison"
 msgstr "Игнорировать различия регистров в строке сравнения"
 
-msgctxt "wnd(Log|Project|Std|).mniEditCommitAuthor"
+msgctxt "wnd(Log|Project|Std|).mniEditCommitAuthor:"
 msgid "Edit Author"
 msgstr "Изменить автора"
 
-msgctxt "wnd(Log|Project|Std|).mniEditCommitMessage"
+msgctxt "wnd(Log|Project|Std|).mniEditCommitMessage:"
 msgid "Edit Message"
 msgstr "Изменить сообщение"
 
-msgctxt "wnd(Log|Project|Std|).mniEditFile"
+msgctxt "wnd(Log|Project|Std|).mniEditFile:"
 msgid "Edit File"
 msgstr "Изменить файл"
 
-msgctxt "wnd(Log|Project|Std|).mniExit"
+msgctxt "wnd(Log|Project|Std|).mniExit:"
 msgid "Exit"
 msgstr "Выйти"
 
-msgctxt "wnd(Log|Project|Std|).mniFastForward"
+msgctxt "wnd(Log|Project|Std|).mniFastForward:"
 msgid "Fast-Forward Merge"
 msgstr "Быстрое слияние"
 
-msgctxt "wnd(Log|Project|Std|).mniFetch"
+msgctxt "wnd(Log|Project|Std|).mniFetch:"
 msgid "Pull"
 msgstr "Получить"
 
-msgctxt "wnd(Log|Project|Std|).mniFile-close"
+msgctxt "wnd(Log|Project|Std|).mniFile-close:"
 msgid "Close"
 msgstr "Закрыть"
 
-msgctxt "wnd(Log|Project|Std|).mniFilterCommits"
+msgctxt "wnd(Log|Project|Std|).mniFilterCommits:"
 msgid "Filter Commits"
 msgstr "Фильтр коммитов"
 
-msgctxt "wnd(Log|Project|Std|).mniFilterFiles"
+msgctxt "wnd(Log|Project|Std|).mniFilterFiles:"
 msgid "Filter Files"
 msgstr "Фильтр файлов"
 
-msgctxt "wnd(Log|Project|Std|).mniFindAction"
+msgctxt "wnd(Log|Project|Std|).mniFindAction:"
 msgid "Find Command"
 msgstr "Найти команду"
 
-msgctxt "wnd(Log|Project|Std|).mniFindObject"
+msgctxt "wnd(Log|Project|Std|).mniFindObject:"
 msgid "Find Object"
 msgstr "Найти объект"
 
-msgctxt "wnd(Log|Project|Std|).mniFixup"
+msgctxt "wnd(Log|Project|Std|).mniFixup:"
 msgid "Use Message for Commit"
 msgstr "Использовать сообщение для коммита"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowConfigure"
+msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure"
 msgstr "Настроить"
 
@@ -14813,183 +14813,183 @@ msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniFlowContext"
+msgctxt "wnd(Log|Project|Std|).mniFlowContext:"
 msgid "Git-Flow"
 msgstr "Git-Flow"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowFeatureFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowFeatureFinish:"
 msgid "Finish Feature"
 msgstr "Завершить задачу"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowFeatureStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowFeatureStart:"
 msgid "Start Feature"
 msgstr "Начать задачу"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowHotfixFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowHotfixFinish:"
 msgid "Finish Hotfix"
 msgstr "Выпустить хотфикс"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowHotfixStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowHotfixStart:"
 msgid "Start Hotfix"
 msgstr "Начать хотфикс"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowIntegrateDevelop"
+msgctxt "wnd(Log|Project|Std|).mniFlowIntegrateDevelop:"
 msgid "Integrate Develop"
 msgstr "Включить develop"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowReleaseFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowReleaseFinish:"
 msgid "Finish Release"
 msgstr "Выпустить релиз"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowReleaseStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowReleaseStart:"
 msgid "Start Release"
 msgstr "Начать релиз"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowSupportStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowSupportStart:"
 msgid "Start Support Branch"
 msgstr "Создать сервисную ветку"
 
-msgctxt "wnd(Log|Project|Std|).mniForgetCommit"
+msgctxt "wnd(Log|Project|Std|).mniForgetCommit:"
 msgid "Forget Commit"
 msgstr "Забыть коммит"
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-line"
+msgctxt "wnd(Log|Project|Std|).mniGoto-line:"
 msgid "Go to Line"
 msgstr "Перейти к строке"
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-next-diff"
+msgctxt "wnd(Log|Project|Std|).mniGoto-next-diff:"
 msgid "Next Change"
 msgstr "Следующее изменение"
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-previous-diff"
+msgctxt "wnd(Log|Project|Std|).mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr "Предыдущее изменение"
 
-msgctxt "wnd(Log|Project|Std|).mniGotoChildrenCommit"
+msgctxt "wnd(Log|Project|Std|).mniGotoChildrenCommit:"
 msgid "Select Child Commit"
 msgstr "Выбрать дочерний коммит"
 
-msgctxt "wnd(Log|Project|Std|).mniGotoParentsCommit"
+msgctxt "wnd(Log|Project|Std|).mniGotoParentsCommit:"
 msgid "Select Parent Commit"
 msgstr "Выбрать родительский коммит"
 
-msgctxt "wnd(Log|Project|Std|).mniIgnore"
+msgctxt "wnd(Log|Project|Std|).mniIgnore:"
 msgid "Ignore"
 msgstr "Игнорировать"
 
-msgctxt "wnd(Log|Project|Std|).mniIgnore-line-separators"
+msgctxt "wnd(Log|Project|Std|).mniIgnore-line-separators:"
 msgid "Ignore Line-Ending Changes"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniIgnoreReveal"
+msgctxt "wnd(Log|Project|Std|).mniIgnoreReveal:"
 msgid "Edit Ignore File"
 msgstr "Изменить файл игнора"
 
-msgctxt "wnd(Log|Project|Std|).mniIncludeTrackedRemoteBranches"
+msgctxt "wnd(Log|Project|Std|).mniIncludeTrackedRemoteBranches:"
 msgid "Include Tracked Remote Branches"
 msgstr "Включать отслеживаемые внешние ветки"
 
-msgctxt "wnd(Log|Project|Std|).mniIndexEditor"
+msgctxt "wnd(Log|Project|Std|).mniIndexEditor:"
 msgid "Index Editor"
 msgstr "Редактор изменений"
 
-msgctxt "wnd(Log|Project|Std|).mniInvestigate"
+msgctxt "wnd(Log|Project|Std|).mniInvestigate:"
 msgid "Investigate"
 msgstr "Исследовать"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsInstall"
+msgctxt "wnd(Log|Project|Std|).mniLfsInstall:"
 msgid "Install"
 msgstr "Установить"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsLock"
+msgctxt "wnd(Log|Project|Std|).mniLfsLock:"
 msgid "Lock"
 msgstr "Заблокировать"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsPrune"
+msgctxt "wnd(Log|Project|Std|).mniLfsPrune:"
 msgid "Prune"
 msgstr "Удалить устаревшее"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsTrack"
+msgctxt "wnd(Log|Project|Std|).mniLfsTrack:"
 msgid "Track"
 msgstr "Отслеживать"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsUnlock"
+msgctxt "wnd(Log|Project|Std|).mniLfsUnlock:"
 msgid "Unlock"
 msgstr "Разблокировать"
 
-msgctxt "wnd(Log|Project|Std|).mniLicenseAgreement"
+msgctxt "wnd(Log|Project|Std|).mniLicenseAgreement:"
 msgid "License Agreement"
 msgstr "Лицензионное соглашение"
 
-msgctxt "wnd(Log|Project|Std|).mniLocalGc"
+msgctxt "wnd(Log|Project|Std|).mniLocalGc:"
 msgid "Run Garbage Collector"
 msgstr "Запустить сборщик мусора"
 
-msgctxt "wnd(Log|Project|Std|).mniLog"
+msgctxt "wnd(Log|Project|Std|).mniLog:"
 msgid "Log"
 msgstr "История"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringBranch"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringBranch:"
 msgid "Branch Coloring"
 msgstr "Выделение коммитов ветки"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringDefault"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringDefault:"
 msgid "Default Coloring"
 msgstr "Оформление по умолчанию"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringLegacy"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringLegacy:"
 msgid "Varying Coloring"
 msgstr "Многоцветное оформление"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringMerge"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringMerge:"
 msgid "Mergeable Coloring"
 msgstr "Раскраска объединяемых"
 
-msgctxt "wnd(Log|Project|Std|).mniLogRepository"
+msgctxt "wnd(Log|Project|Std|).mniLogRepository:"
 msgid "Show Log Window"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogShowAllParents"
+msgctxt "wnd(Log|Project|Std|).mniLogShowAllParents:"
 msgid "Follow All Parents"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogShowOnlyFirstParents"
+msgctxt "wnd(Log|Project|Std|).mniLogShowOnlyFirstParents:"
 msgid "Follow Only First Parent"
 msgstr "Показывать только первого родителя"
 
-msgctxt "wnd(Log|Project|Std|).mniLogTopoFiltering"
+msgctxt "wnd(Log|Project|Std|).mniLogTopoFiltering:"
 msgid "Show Graph While Filtering"
 msgstr "Показывать граф при фильтрации"
 
-msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexOnDemand"
+msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexOnDemand:"
 msgid "Show Working Tree  Index On Demand"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexPermanent"
+msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexPermanent:"
 msgid "Show Working Tree Permanently"
 msgstr "Всегда показывать рабочий каталог"
 
-msgctxt "wnd(Log|Project|Std|).mniMailingList"
+msgctxt "wnd(Log|Project|Std|).mniMailingList:"
 msgid "SmartGit Website"
 msgstr "Сайт SmartGit"
 
-msgctxt "wnd(Log|Project|Std|).mniMerge"
+msgctxt "wnd(Log|Project|Std|).mniMerge:"
 msgid "Merge"
 msgstr "Объединить"
 
-msgctxt "wnd(Log|Project|Std|).mniModifyCommit"
+msgctxt "wnd(Log|Project|Std|).mniModifyCommit:"
 msgid "Modify"
 msgstr "Изменить коммит"
 
-msgctxt "wnd(Log|Project|Std|).mniNewStandardWindow"
+msgctxt "wnd(Log|Project|Std|).mniNewStandardWindow:"
 msgid "Show Standard Window"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniNewWindow"
+msgctxt "wnd(Log|Project|Std|).mniNewWindow:"
 msgid "New Window"
 msgstr "Новое окно"
 
-msgctxt "wnd(Log|Project|Std|).mniOpen"
+msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open from Working Tree"
 msgstr "Открыть в рабочем каталоге"
 
@@ -15001,99 +15001,99 @@ msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniOpenDocumentation"
+msgctxt "wnd(Log|Project|Std|).mniOpenDocumentation:"
 msgid "Online Documentation"
 msgstr "Онлайн документация"
 
-msgctxt "wnd(Log|Project|Std|).mniOpenRootLog"
+msgctxt "wnd(Log|Project|Std|).mniOpenRootLog:"
 msgid "Open Root Log"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniOpenUserEcho"
+msgctxt "wnd(Log|Project|Std|).mniOpenUserEcho:"
 msgid "Feature Requests"
 msgstr "Предложить идею"
 
-msgctxt "wnd(Log|Project|Std|).mniOpenWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniOpenWorkingTree:"
 msgid "Open Working Tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreferences"
+msgctxt "wnd(Log|Project|Std|).mniPreferences:"
 msgid "Preferences"
 msgstr "Параметры"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCommentNext"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCommentNext:"
 msgid "Next Comment"
 msgstr "Следующий комментарий"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCommentPrevious"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCommentPrevious:"
 msgid "Previous Comment"
 msgstr "Предыдущий комментарий"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareAutomatic"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareAutomatic:"
 msgid "Automatic"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareHeadVsIndex"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareHeadVsIndex:"
 msgid "HEAD vs. Index"
 msgstr "HEAD vs. индекс"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareIndexVsWT"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareIndexVsWT:"
 msgid "Index vs. Working Tree"
 msgstr "Индекс vs. рабочий каталог"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewRefresh"
+msgctxt "wnd(Log|Project|Std|).mniPreviewRefresh:"
 msgid "Reload"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewShowCurrentLines"
+msgctxt "wnd(Log|Project|Std|).mniPreviewShowCurrentLines:"
 msgid "Show Long Current Lines"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewUndo"
+msgctxt "wnd(Log|Project|Std|).mniPreviewUndo:"
 msgid "Undo"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniPush"
+msgctxt "wnd(Log|Project|Std|).mniPush:"
 msgid "Push"
 msgstr "Отправить"
 
-msgctxt "wnd(Log|Project|Std|).mniPushCommits"
+msgctxt "wnd(Log|Project|Std|).mniPushCommits:"
 msgid "Push Up To"
 msgstr "Отправить коммит в"
 
-msgctxt "wnd(Log|Project|Std|).mniPushTo"
+msgctxt "wnd(Log|Project|Std|).mniPushTo:"
 msgid "Push To"
 msgstr "Отправить в"
 
-msgctxt "wnd(Log|Project|Std|).mniPushToGerrit"
+msgctxt "wnd(Log|Project|Std|).mniPushToGerrit:"
 msgid "Push to Gerrit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseAbort"
+msgctxt "wnd(Log|Project|Std|).mniRebaseAbort:"
 msgid "Abort"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseContinue"
+msgctxt "wnd(Log|Project|Std|).mniRebaseContinue:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseHeadTo"
+msgctxt "wnd(Log|Project|Std|).mniRebaseHeadTo:"
 msgid "Rebase"
 msgstr "Переместить"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseInteractive"
+msgctxt "wnd(Log|Project|Std|).mniRebaseInteractive:"
 msgid "Rebase Interactive From"
 msgstr "Интерактивно переместить поверх"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseSkip"
+msgctxt "wnd(Log|Project|Std|).mniRebaseSkip:"
 msgid "Skip"
 msgstr "Пропустить"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseStep"
+msgctxt "wnd(Log|Project|Std|).mniRebaseStep:"
 msgid "Step"
 msgstr "Далее"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseToHead"
+msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD"
 msgstr ""
 
@@ -15105,75 +15105,75 @@ msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRefresh"
+msgctxt "wnd(Log|Project|Std|).mniRefresh:"
 msgid "Refresh"
 msgstr "Обновить"
 
-msgctxt "wnd(Log|Project|Std|).mniRegister"
+msgctxt "wnd(Log|Project|Std|).mniRegister:"
 msgid "Register"
 msgstr "Зарегистрировать"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteAdd"
+msgctxt "wnd(Log|Project|Std|).mniRemoteAdd:"
 msgid "Add"
 msgstr "Добавить"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteCopyUrl"
+msgctxt "wnd(Log|Project|Std|).mniRemoteCopyUrl:"
 msgid "Copy URL"
 msgstr "Копировать ссылку"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteDelete"
+msgctxt "wnd(Log|Project|Std|).mniRemoteDelete:"
 msgid "Delete"
 msgstr "Удалить"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetch"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetch:"
 msgid "Fetch"
 msgstr "Забрать"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetchAll"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetchAll:"
 msgid "Fetch All"
 msgstr "Забрать все"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetchMore"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetchMore:"
 msgid "Fetch More"
 msgstr "Забрать недостающие"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteProperties"
+msgctxt "wnd(Log|Project|Std|).mniRemoteProperties:"
 msgid "Properties"
 msgstr "Параметры"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteRename"
+msgctxt "wnd(Log|Project|Std|).mniRemoteRename:"
 msgid "Rename"
 msgstr "Переименовать"
 
-msgctxt "wnd(Log|Project|Std|).mniRemove"
+msgctxt "wnd(Log|Project|Std|).mniRemove:"
 msgid "Remove"
 msgstr "Убрать"
 
-msgctxt "wnd(Log|Project|Std|).mniRename"
+msgctxt "wnd(Log|Project|Std|).mniRename:"
 msgid "Move or Rename"
 msgstr "Переместить/переименовать"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryAdd"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryAdd:"
 msgid "Add or Create"
 msgstr "Добавить или создать"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryAddGroup"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryAddGroup:"
 msgid "Add Group"
 msgstr "Создать группу"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryClone"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryClone:"
 msgid "Clone"
 msgstr "Склонировать"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryClose"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryClose:"
 msgid "Close Repository"
 msgstr "Закрыть репозиторий"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfig"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfig:"
 msgid "Repository"
 msgstr "Репозитория"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfigUser"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfigUser:"
 msgid "User"
 msgstr "Пользователя"
 
@@ -15189,95 +15189,95 @@ msgctxt "wnd(Log|Project|Std|).mniRepositoryFavorite:"
 msgid "Unmark as Favorite"
 msgstr "Из избранного"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryOpen"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryOpen:"
 msgid "Open Repository"
 msgstr "Открыть репозиторий"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryOpenInNewWindow"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryOpenInNewWindow:"
 msgid "Open Repository in New Window"
 msgstr "Открыть репозиторий в новом окне"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryRemove"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryRemove:"
 msgid "Remove"
 msgstr "Удалить"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryRename"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryRename:"
 msgid "Rename"
 msgstr "Переименовать"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySearch"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySearch:"
 msgid "Search for Repositories"
 msgstr "Найти репозиторий"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySelectObsolete"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySelectObsolete:"
 msgid "Select Obsolete Repositories"
 msgstr "Выбрать устаревшие репозитории"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySettings"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySettings:"
 msgid "Settings"
 msgstr "Настройки"
 
-msgctxt "wnd(Log|Project|Std|).mniReset"
+msgctxt "wnd(Log|Project|Std|).mniReset:"
 msgid "Reset"
 msgstr "Сбросить быстро"
 
-msgctxt "wnd(Log|Project|Std|).mniResetAdvanced"
+msgctxt "wnd(Log|Project|Std|).mniResetAdvanced:"
 msgid "Reset Advanced"
 msgstr "Сбросить"
 
-msgctxt "wnd(Log|Project|Std|).mniResolve"
+msgctxt "wnd(Log|Project|Std|).mniResolve:"
 msgid "Resolve"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniResolveOurs"
+msgctxt "wnd(Log|Project|Std|).mniResolveOurs:"
 msgid "Take Ours"
 msgstr "Взять наше"
 
-msgctxt "wnd(Log|Project|Std|).mniResolveRecreateConflict"
+msgctxt "wnd(Log|Project|Std|).mniResolveRecreateConflict:"
 msgid "Recreate Conflict"
 msgstr "Восстановить конфликт"
 
-msgctxt "wnd(Log|Project|Std|).mniResolveTheirs"
+msgctxt "wnd(Log|Project|Std|).mniResolveTheirs:"
 msgid "Take Theirs"
 msgstr "Взять их"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommit"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommit:"
 msgid "Reveal Commit"
 msgstr "Перейти к коммиту"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommitExtend"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommitExtend:"
 msgid "Compare with Selected Commit"
 msgstr "Сравнить с выбранным коммитом"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommitWithHead"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommitWithHead:"
 msgid "Compare with HEAD"
 msgstr "Сравнить c HEAD"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealPrevCommit"
+msgctxt "wnd(Log|Project|Std|).mniRevealPrevCommit:"
 msgid "Reveal Previous Commit"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRevealWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniRevealWorkingTree:"
 msgid "Reveal Working Tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniRevert"
+msgctxt "wnd(Log|Project|Std|).mniRevert:"
 msgid "Revert"
 msgstr "Откатить"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewCommentCreate"
+msgctxt "wnd(Log|Project|Std|).mniReviewCommentCreate:"
 msgid "Add Comment"
 msgstr "Добавить комментарий"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewConfigure"
+msgctxt "wnd(Log|Project|Std|).mniReviewConfigure:"
 msgid "Configure"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase"
+msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase:"
 msgid "Dump Database"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate"
+msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Pull Request"
 msgstr "Создать PR"
 
@@ -15289,335 +15289,335 @@ msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Pull Request"
 msgstr "Создать PR"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewShowClosedPullRequests"
+msgctxt "wnd(Log|Project|Std|).mniReviewShowClosedPullRequests:"
 msgid "Show Closed Pull Requests"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniReviewSync"
+msgctxt "wnd(Log|Project|Std|).mniReviewSync:"
 msgid "Sync"
 msgstr "Синхронизировать"
 
-msgctxt "wnd(Log|Project|Std|).mniRewriteTextFile"
+msgctxt "wnd(Log|Project|Std|).mniRewriteTextFile:"
 msgid "Fix Line-Endings"
 msgstr "Исправить окончания строк"
 
-msgctxt "wnd(Log|Project|Std|).mniRollbackTo"
+msgctxt "wnd(Log|Project|Std|).mniRollbackTo:"
 msgid "Rollback To"
 msgstr "Откатить к"
 
-msgctxt "wnd(Log|Project|Std|).mniSaveAs"
+msgctxt "wnd(Log|Project|Std|).mniSaveAs:"
 msgid "Save As"
 msgstr "Сохранить как"
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-find"
+msgctxt "wnd(Log|Project|Std|).mniSearch-find:"
 msgid "Find"
 msgstr "Найти"
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-next"
+msgctxt "wnd(Log|Project|Std|).mniSearch-next:"
 msgid "Find Next"
 msgstr "Найти следующий"
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-previous"
+msgctxt "wnd(Log|Project|Std|).mniSearch-previous:"
 msgid "Find Previous"
 msgstr "Найти предыдущий"
 
-msgctxt "wnd(Log|Project|Std|).mniSelectCommittableFiles"
+msgctxt "wnd(Log|Project|Std|).mniSelectCommittableFiles:"
 msgid "Select Committable Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSelectDirectory"
+msgctxt "wnd(Log|Project|Std|).mniSelectDirectory:"
 msgid "Select Directory"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSelectRoot"
+msgctxt "wnd(Log|Project|Std|).mniSelectRoot:"
 msgid "Select Repository Root"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSet-syntax"
+msgctxt "wnd(Log|Project|Std|).mniSet-syntax:"
 msgid "Syntax Language"
 msgstr "Язык синтаксиса"
 
-msgctxt "wnd(Log|Project|Std|).mniSetDepth"
+msgctxt "wnd(Log|Project|Std|).mniSetDepth:"
 msgid "Set Depth"
 msgstr "Установить глубину"
 
-msgctxt "wnd(Log|Project|Std|).mniShow-line-numbers"
+msgctxt "wnd(Log|Project|Std|).mniShow-line-numbers:"
 msgid "Show Line Numbers"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniShowChanges"
+msgctxt "wnd(Log|Project|Std|).mniShowChanges:"
 msgid "Show Changes"
 msgstr "Изменения"
 
-msgctxt "wnd(Log|Project|Std|).mniSkipWorkTree"
+msgctxt "wnd(Log|Project|Std|).mniSkipWorkTree:"
 msgid "Toggle 'Skip Worktree'"
 msgstr "Переключить 'Пропускать рабочий каталог'"
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsAsIs"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsAsIs:"
 msgid "Sort By Time"
 msgstr "Упорядочить по времени"
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsFirstParentsBeforeMergeParents"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsFirstParentsBeforeMergeParents:"
 msgid "Sort First Parents before Merge Parents"
 msgstr "Упорядочить: сначала родитель, потом объединение"
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsMergeParentsBeforeFirstParents"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsMergeParentsBeforeFirstParents:"
 msgid "Sort Merge Parents before First Parents"
 msgstr "Упорядочить: сначала объединение, потом родитель"
 
-msgctxt "wnd(Log|Project|Std|).mniSplitCommit"
+msgctxt "wnd(Log|Project|Std|).mniSplitCommit:"
 msgid "Split"
 msgstr "Разделить"
 
-msgctxt "wnd(Log|Project|Std|).mniSquashCommits"
+msgctxt "wnd(Log|Project|Std|).mniSquashCommits:"
 msgid "Squash"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniStage"
+msgctxt "wnd(Log|Project|Std|).mniStage:"
 msgid "Stage"
 msgstr "Проиндексировать"
 
-msgctxt "wnd(Log|Project|Std|).mniStashApply"
+msgctxt "wnd(Log|Project|Std|).mniStashApply:"
 msgid "Apply Stash"
 msgstr "Применить спрятанное"
 
-msgctxt "wnd(Log|Project|Std|).mniStashDrop"
+msgctxt "wnd(Log|Project|Std|).mniStashDrop:"
 msgid "Drop Stash"
 msgstr "Удалить спрятанное"
 
-msgctxt "wnd(Log|Project|Std|).mniStashRename"
+msgctxt "wnd(Log|Project|Std|).mniStashRename:"
 msgid "Rename Stash"
 msgstr "Переименовать спрятанное"
 
-msgctxt "wnd(Log|Project|Std|).mniStashSave"
+msgctxt "wnd(Log|Project|Std|).mniStashSave:"
 msgid "Stash All"
 msgstr "Спрятать все"
 
-msgctxt "wnd(Log|Project|Std|).mniStashSaveSelection"
+msgctxt "wnd(Log|Project|Std|).mniStashSaveSelection:"
 msgid "Stash Selection"
 msgstr "Спрятать выбранное"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeactivate"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeactivate:"
 msgid "Deactivate"
 msgstr "Деактивировать"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeinit"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeinit:"
 msgid "Deinit"
 msgstr "Отменить инициализацию"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleInit"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleInit:"
 msgid "Initialize"
 msgstr "Инициализировать"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleRegister"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleRegister:"
 msgid "Add"
 msgstr "Добавить"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleReset"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleReset:"
 msgid "Reset"
 msgstr "Сбросить"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleSync"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleSync:"
 msgid "Synchronize"
 msgstr "Синхронизировать"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleUnregister"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleUnregister:"
 msgid "Unregister"
 msgstr "Отменить регистрацию"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeAdd"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeAdd:"
 msgid "Add"
 msgstr "Добавить"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeMerge"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeMerge:"
 msgid "Merge"
 msgstr "Объединить"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreePush"
+msgctxt "wnd(Log|Project|Std|).mniSubtreePush:"
 msgid "Push"
 msgstr "Отправить"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeReset"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeReset:"
 msgid "Reset"
 msgstr "Сбросить"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeSplit"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeSplit:"
 msgid "Split"
 msgstr "Разделить"
 
-msgctxt "wnd(Log|Project|Std|).mniSync"
+msgctxt "wnd(Log|Project|Std|).mniSync:"
 msgid "Synchronize"
 msgstr "Синхронизировать"
 
-msgctxt "wnd(Log|Project|Std|).mniUndoLastCommit"
+msgctxt "wnd(Log|Project|Std|).mniUndoLastCommit:"
 msgid "Undo Last Commit"
 msgstr "Отменить последний коммит"
 
-msgctxt "wnd(Log|Project|Std|).mniUnstage"
+msgctxt "wnd(Log|Project|Std|).mniUnstage:"
 msgid "Unstage"
 msgstr "Убрать из индекса"
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr "Игнорировать пробелы"
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-all"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-all:"
 msgid "Ignore All Whitespaces for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-leading-trailing"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-leading-trailing:"
 msgid "Ignore Leading/Trailing Whitespaces for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-none"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-none:"
 msgid "Ignore No Whitespace for Line Comparison"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-remember-as-default"
+msgctxt "wnd(Log|Project|Std|).mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr "Запомнить по умолчанию"
 
-msgctxt "wnd(Log|Project|Std|).mniView-settings"
+msgctxt "wnd(Log|Project|Std|).mniView-settings:"
 msgid "Settings"
 msgstr "Настройки"
 
-msgctxt "wnd(Log|Project|Std|).mniView-show-current-line-control"
+msgctxt "wnd(Log|Project|Std|).mniView-show-current-line-control:"
 msgid "Show Long Current Lines"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewFromSubmodules"
+msgctxt "wnd(Log|Project|Std|).mniViewFromSubmodules:"
 msgid "Show Files From Submodules"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewIgnored"
+msgctxt "wnd(Log|Project|Std|).mniViewIgnored:"
 msgid "Show Ignored Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewRecursive"
+msgctxt "wnd(Log|Project|Std|).mniViewRecursive:"
 msgid "Files from Subdirectories"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewRenameSource"
+msgctxt "wnd(Log|Project|Std|).mniViewRenameSource:"
 msgid "Show Rename Source Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewSeparateWtAndIndex"
+msgctxt "wnd(Log|Project|Std|).mniViewSeparateWtAndIndex:"
 msgid "Separate Working Tree and Index"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewSetAnchorCommit"
+msgctxt "wnd(Log|Project|Std|).mniViewSetAnchorCommit:"
 msgid "Set Anchor Commit"
 msgstr "Установить привязку коммита"
 
-msgctxt "wnd(Log|Project|Std|).mniViewSkipped"
+msgctxt "wnd(Log|Project|Std|).mniViewSkipped:"
 msgid "Show Skipped Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewStaged"
+msgctxt "wnd(Log|Project|Std|).mniViewStaged:"
 msgid "Show Staged Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleIndex"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleIndex:"
 msgid "Only Index"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleMixed"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleMixed:"
 msgid "Mixed"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleWorkingTree:"
 msgid "Only Working Tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewToolBar"
+msgctxt "wnd(Log|Project|Std|).mniViewToolBar:"
 msgid "Show Toolbar"
 msgstr "Показать панель инструментов"
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnchanged"
+msgctxt "wnd(Log|Project|Std|).mniViewUnchanged:"
 msgid "Show Unchanged Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnchangedAssumed"
+msgctxt "wnd(Log|Project|Std|).mniViewUnchangedAssumed:"
 msgid "Show Assume-Unchanged Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnversioned"
+msgctxt "wnd(Log|Project|Std|).mniViewUnversioned:"
 msgid "Show Unversioned Files"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowBranches"
+msgctxt "wnd(Log|Project|Std|).mniWindowBranches:"
 msgid "Branches"
 msgstr "Ветки"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowChanges"
+msgctxt "wnd(Log|Project|Std|).mniWindowChanges:"
 msgid "Changes"
 msgstr "Изменения"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowClose"
+msgctxt "wnd(Log|Project|Std|).mniWindowClose:"
 msgid "Close"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowComments"
+msgctxt "wnd(Log|Project|Std|).mniWindowComments:"
 msgid "Comments"
 msgstr "Комментарии"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowCommit"
+msgctxt "wnd(Log|Project|Std|).mniWindowCommit:"
 msgid "Commit"
 msgstr "Коммит"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowDebugLog"
+msgctxt "wnd(Log|Project|Std|).mniWindowDebugLog:"
 msgid "Debug Log"
 msgstr "Отладочные сообщения"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowDirectories"
+msgctxt "wnd(Log|Project|Std|).mniWindowDirectories:"
 msgid "Repositories"
 msgstr "Репозитории"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowFiles"
+msgctxt "wnd(Log|Project|Std|).mniWindowFiles:"
 msgid "Files"
 msgstr "Файлы"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowGraph"
+msgctxt "wnd(Log|Project|Std|).mniWindowGraph:"
 msgid "Graph"
 msgstr "Граф"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowHideView"
+msgctxt "wnd(Log|Project|Std|).mniWindowHideView:"
 msgid "Hide View"
 msgstr "Скрыть панель"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowJournal"
+msgctxt "wnd(Log|Project|Std|).mniWindowJournal:"
 msgid "Journal"
 msgstr "Журнал"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutReset"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutReset:"
 msgid "Reset Perspective"
 msgstr "Сбросить расположение панелей"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetMain"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetMain:"
 msgid "Main Perspective"
 msgstr "Основное расположение"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetReview"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetReview:"
 msgid "Review Perspective"
 msgstr "Расположение для ревью"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowOutput"
+msgctxt "wnd(Log|Project|Std|).mniWindowOutput:"
 msgid "Output"
 msgstr "Вывод"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniWindowWorkingTree:"
 msgid "Show Working Tree Window"
 msgstr "Показать окно рабочего каталога"
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreeAdd"
+msgctxt "wnd(Log|Project|Std|).mniWorktreeAdd:"
 msgid "Add Worktree"
 msgstr "Добавить рабочий каталог"
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreePrune"
+msgctxt "wnd(Log|Project|Std|).mniWorktreePrune:"
 msgid "Prune Obsolete Worktrees"
 msgstr "Удалить устаревшие рабочие каталоги"
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreeRemove"
+msgctxt "wnd(Log|Project|Std|).mniWorktreeRemove:"
 msgid "Remove Worktree"
 msgstr "Удалить рабочий каталог"
 
@@ -15813,7 +15813,7 @@ msgctxt "wnd(Log|Project|Std|).tab:"
 msgid "Repositories"
 msgstr "Репозитории"
 
-msgctxt "wnd(Log|Project|Std|).tbr\"  History  \""
+msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
 msgid "History"
 msgstr "История"
 
@@ -16077,119 +16077,119 @@ msgctxt "wnd(Log|Project|Std|).tbt:"
 msgid "Show directories tree"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtAnnotate"
+msgctxt "wnd(Log|Project|Std|).tbtAnnotate:"
 msgid "Show a blame \\(annotated\\) view of the selected file."
 msgstr "Показать построчное авторство для выбранного файла."
 
-msgctxt "wnd(Log|Project|Std|).tbtBranchAdd"
+msgctxt "wnd(Log|Project|Std|).tbtBranchAdd:"
 msgid "Add a new branch for the current commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtBranchAddTag"
+msgctxt "wnd(Log|Project|Std|).tbtBranchAddTag:"
 msgid "Add a new tag for the current commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtCheckout"
+msgctxt "wnd(Log|Project|Std|).tbtCheckout:"
 msgid "Check out an existing commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtCherryPick"
+msgctxt "wnd(Log|Project|Std|).tbtCherryPick:"
 msgid "Cherry-pick commits from other branches."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtClearOutput"
+msgctxt "wnd(Log|Project|Std|).tbtClearOutput:"
 msgid "Clear output pane."
 msgstr "Очистить."
 
-msgctxt "wnd(Log|Project|Std|).tbtCommit"
+msgctxt "wnd(Log|Project|Std|).tbtCommit:"
 msgid "Commit local changes."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtConflictSolver"
+msgctxt "wnd(Log|Project|Std|).tbtConflictSolver:"
 msgid "Open the Conflict Solver \\(or configured external merge tool\\) to resolve conflicts."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtDelete"
+msgctxt "wnd(Log|Project|Std|).tbtDelete:"
 msgid "Delete the selected local files or directory."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtDiscard"
+msgctxt "wnd(Log|Project|Std|).tbtDiscard:"
 msgid "Discard local changes."
 msgstr "Отменяет локальные изменения."
 
-msgctxt "wnd(Log|Project|Std|).tbtFetch"
+msgctxt "wnd(Log|Project|Std|).tbtFetch:"
 msgid "Fetch commits from a remote repository and \\(optionally\\) integrate them with possible local commits."
 msgstr "Получение изменений с внешнего репозитория и \\(опционно\\) применение их в локальном репозитории."
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowContext"
+msgctxt "wnd(Log|Project|Std|).tbtFlowContext:"
 msgid "Finish a Git-Flow feature."
 msgstr "Завершить задачу по Git-Flow"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixFinish"
+msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixFinish:"
 msgid "Finish a Git-Flow hotfix."
 msgstr "Выпустить хотфикс по Git-Flow"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixStart"
+msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixStart:"
 msgid "Start a new Git-Flow hotfix."
 msgstr "Начать хотфикс по Git-Flow"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowIntegrateDevelop"
+msgctxt "wnd(Log|Project|Std|).tbtFlowIntegrateDevelop:"
 msgid "Integrate new base commits into a Git-Flow feature."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtGoto-next-diff"
+msgctxt "wnd(Log|Project|Std|).tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "Следующее изменение."
 
-msgctxt "wnd(Log|Project|Std|).tbtGoto-previous-diff"
+msgctxt "wnd(Log|Project|Std|).tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "Предыдущее изменение."
 
-msgctxt "wnd(Log|Project|Std|).tbtIgnore"
+msgctxt "wnd(Log|Project|Std|).tbtIgnore:"
 msgid "Mark unversioned local files/directories to be ignored."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtIndexEditor"
+msgctxt "wnd(Log|Project|Std|).tbtIndexEditor:"
 msgid "Edit the Index state of the selected file, e.g. to decide which lines should be staged."
 msgstr "Изменить состояние индекса для выбранного файла, например выбрать, какие строки следует проиндексировать."
 
-msgctxt "wnd(Log|Project|Std|).tbtInvestigate"
+msgctxt "wnd(Log|Project|Std|).tbtInvestigate:"
 msgid "Investigate history line-wise with DeepGit."
 msgstr "Исследовать построчно историю файла с помощью DeepGit."
 
-msgctxt "wnd(Log|Project|Std|).tbtLog"
+msgctxt "wnd(Log|Project|Std|).tbtLog:"
 msgid "Show the history for selected file or directory."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtLogRepository"
+msgctxt "wnd(Log|Project|Std|).tbtLogRepository:"
 msgid "Show the history for the whole repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtMerge"
+msgctxt "wnd(Log|Project|Std|).tbtMerge:"
 msgid "Merge changes from other branches."
 msgstr "Объединить с изменениями другой ветки."
 
-msgctxt "wnd(Log|Project|Std|).tbtPreviewRefresh"
+msgctxt "wnd(Log|Project|Std|).tbtPreviewRefresh:"
 msgid "Reload the previewed file contents."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtPush"
+msgctxt "wnd(Log|Project|Std|).tbtPush:"
 msgid "Push local commits to the remote origin repository."
 msgstr "Отправка локальных изменений во внешний репозиторий."
 
-msgctxt "wnd(Log|Project|Std|).tbtPushTo"
+msgctxt "wnd(Log|Project|Std|).tbtPushTo:"
 msgid "Push local commits to a remote repository, allowing to choose the target repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRebaseHeadTo"
+msgctxt "wnd(Log|Project|Std|).tbtRebaseHeadTo:"
 msgid "Apply commits from your current branch to the selected commit."
 msgstr "Применение коммитов текущей ветки поверх выбранного коммита."
 
-msgctxt "wnd(Log|Project|Std|).tbtRefresh"
+msgctxt "wnd(Log|Project|Std|).tbtRefresh:"
 msgid "Refresh the log view."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch"
+msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from current remote repository."
 msgstr ""
 
@@ -16201,123 +16201,123 @@ msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from current remote repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRemove"
+msgctxt "wnd(Log|Project|Std|).tbtRemove:"
 msgid "Remove selected files or directories from repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositoryAdd"
+msgctxt "wnd(Log|Project|Std|).tbtRepositoryAdd:"
 msgid "Add or create a new repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositoryClone"
+msgctxt "wnd(Log|Project|Std|).tbtRepositoryClone:"
 msgid "Clone a new repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositorySearch"
+msgctxt "wnd(Log|Project|Std|).tbtRepositorySearch:"
 msgid "Search for existing repositories."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtReset"
+msgctxt "wnd(Log|Project|Std|).tbtReset:"
 msgid "Reset current HEAD to another commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtResetAdvanced"
+msgctxt "wnd(Log|Project|Std|).tbtResetAdvanced:"
 msgid "Reset current HEAD to another commit and keep the difference in Index or Working Tree."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealHomeCommit"
+msgctxt "wnd(Log|Project|Std|).tbtRevealHomeCommit:"
 msgid "Reveal HEAD/working tree in graph."
 msgstr "Перейти к состоянию рабочего каталога в графе."
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealPrevCommit"
+msgctxt "wnd(Log|Project|Std|).tbtRevealPrevCommit:"
 msgid "Reveal selected commits before invoking Reveal Working Tree."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealWorkingTree"
+msgctxt "wnd(Log|Project|Std|).tbtRevealWorkingTree:"
 msgid "Reveal working tree node in graph."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRevert"
+msgctxt "wnd(Log|Project|Std|).tbtRevert:"
 msgid "Undo the changes of an existing commit by \"reverse\" merging it."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtShowChanges"
+msgctxt "wnd(Log|Project|Std|).tbtShowChanges:"
 msgid "Open the file compare for the selected file."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStage"
+msgctxt "wnd(Log|Project|Std|).tbtStage:"
 msgid "Store working tree files in the index to prepare the next commit."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStashApply"
+msgctxt "wnd(Log|Project|Std|).tbtStashApply:"
 msgid "Reapply local changes from a stash."
 msgstr "Применение спрятанных ранее локальных изменений."
 
-msgctxt "wnd(Log|Project|Std|).tbtStashDrop"
+msgctxt "wnd(Log|Project|Std|).tbtStashDrop:"
 msgid "Drop one or more stashes from the repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStashSave"
+msgctxt "wnd(Log|Project|Std|).tbtStashSave:"
 msgid "Stash current local changes."
 msgstr "Прячет текущие локальные изменения."
 
-msgctxt "wnd(Log|Project|Std|).tbtStdSetModeHistory"
+msgctxt "wnd(Log|Project|Std|).tbtStdSetModeHistory:"
 msgid "Show the history view."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtStdSetModeWt"
+msgctxt "wnd(Log|Project|Std|).tbtStdSetModeWt:"
 msgid "Show the local files of the repository \\(Working Tree\\)."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtSync"
+msgctxt "wnd(Log|Project|Std|).tbtSync:"
 msgid "Push local commits of the current branch and pull remote changes."
 msgstr "Отправка локальных изменений текущей ветки и получение внешних."
 
-msgctxt "wnd(Log|Project|Std|).tbtUnstage"
+msgctxt "wnd(Log|Project|Std|).tbtUnstage:"
 msgid "Remove staged changes from index."
 msgstr "Убирает изменения из индекса"
 
-msgctxt "wnd(Log|Project|Std|).tbtView-ignore-whitespaces"
+msgctxt "wnd(Log|Project|Std|).tbtView-ignore-whitespaces:"
 msgid "Ignore irrelevant whitespace"
 msgstr "Пропускать незначащие пробелы"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewFromSubmodules"
+msgctxt "wnd(Log|Project|Std|).tbtViewFromSubmodules:"
 msgid "If selected, files from submodules will be shown."
 msgstr "Показывать файлы субмодулей"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewIgnored"
+msgctxt "wnd(Log|Project|Std|).tbtViewIgnored:"
 msgid "If selected, ignored files will be shown."
 msgstr "Показывать игноририемые файлы"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewRenameSource"
+msgctxt "wnd(Log|Project|Std|).tbtViewRenameSource:"
 msgid "If selected, removed/missing source files of detected renames will be shown."
 msgstr "Показывать удаленные/отсутствующие исходные файлы с обнаруженными переименованиями"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewSkipped"
+msgctxt "wnd(Log|Project|Std|).tbtViewSkipped:"
 msgid "If selected, skipped files will be shown."
 msgstr "Показывать пропускаемые файлы"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewStaged"
+msgctxt "wnd(Log|Project|Std|).tbtViewStaged:"
 msgid "If selected, files with staged \\(Index\\) changes and without working tree changes will be shown."
 msgstr "Показывать файлы в индексе и файлы без изменений в рабочем каталоге."
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnchanged"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnchanged:"
 msgid "If selected, unchanged files will be shown."
 msgstr "Показывать неизмененные файлы"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnchangedAssumed"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnchangedAssumed:"
 msgid "If selected, files having the 'assume-unchanged' flag will be shown."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnversioned"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnversioned:"
 msgid "If selected, not yet version controlled files will be shown."
 msgstr "Показывать файлы вне контроля версий"
 
-msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetMain"
+msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetMain:"
 msgid "Switch to the Main perspective."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetReview"
+msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetReview:"
 msgid "Switch to the Review perspective."
 msgstr ""
 

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -6761,6 +6761,11 @@ msgctxt "dlgSgOutput.chk:"
 msgid "Show automatically for failed command"
 msgstr ""
 
+# $1: Command name, $2: Return code
+msgctxt "dlgSgOutput.lbl:"
+msgid "$1 failed \\(return code $2\\)"
+msgstr ""
+
 msgctxt "dlgSgOutput.lbl:"
 msgid "Authentication using OAuth failed \\(see details below\\)"
 msgstr ""
@@ -7003,10 +7008,6 @@ msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
-msgstr ""
-
-msgctxt "dlgSgOutput.lbl:"
-msgid "stash failed \\(return code $1\\)"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -13132,14 +13133,9 @@ msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
 msgstr ""
 
-# TODO: Check if the variable range is correct.
-#| msgid "SmartGit 25.1.093 needs to be restarted now for the changes to take effect."
+# $1: Software name and version
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
 msgid "$1 needs to be restarted now for the changes to take effect."
-msgstr ""
-
-msgctxt "ntmUpdateCheckFetchVersionSuccess:"
-msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
 msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
@@ -13280,10 +13276,6 @@ msgstr ""
 
 msgctxt "nttSupportExpired:"
 msgid "Your support period has expired on $1."
-msgstr ""
-
-msgctxt "nttUpdateCheck:"
-msgid "Quick Poll: $1"
 msgstr ""
 
 msgctxt "nttUpdateCheck:"
@@ -18516,6 +18508,10 @@ msgstr ""
 #~ msgid "Set or select the options according to your account."
 #~ msgstr ""
 
+#~ msgctxt "dlgSgOutput.lbl:"
+#~ msgid "stash failed \\(return code $1\\)"
+#~ msgstr ""
+
 #~ msgctxt "dlgSgProviderGenerateToken.hdl"
 #~ msgid "Generate a new API token for $1"
 #~ msgstr ""
@@ -18562,6 +18558,14 @@ msgstr ""
 
 #~ msgctxt "dlgTxtEditor.fileModified.hdl:"
 #~ msgid "The file config was changed. Reload it?"
+#~ msgstr ""
+
+#~ msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+#~ msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
+#~ msgstr ""
+
+#~ msgctxt "nttUpdateCheck:"
+#~ msgid "Quick Poll: $1"
 #~ msgstr ""
 
 #~ msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -18476,117 +18476,17 @@ msgstr ""
 #~ msgid "Please wait"
 #~ msgstr "Пожалуйста, подождите..."
 
-#~ msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
-#~ msgid "\\[$1\\] - $2"
-#~ msgstr ""
-
 #~ msgctxt "dlgSgAbortRebasingConfirm.fur:"
 #~ msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 #~ msgstr "Рабочий каталог находится в состоянии 'перемещения'. Вы можете прервать перемещение. Если хотите просто пропустить текущий патч, используйте Ветки\\|Переместить\\|Пропустить.\\n\\nПри отмене будут удалены любые локальные изменения \\(путем вызова 'git rebase --abort'\\)!"
-
-#~ msgctxt "dlgSgAbortRevertingConfirm.hdl"
-#~ msgid "Do you want to abort the current revert?"
-#~ msgstr ""
 
 #~ msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
 #~ msgid "Skip large files \\(\"partial clone\"\\)"
 #~ msgstr "Пропустить большие файлы \\(\"частичное клонирование\"\\)"
 
-#~ msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
-#~ msgid "Simple commit \\(one parent, \"squash\"\\)"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
-#~ msgid "\\[$1\\] - \\[$2\\] - $3"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgErrorUtilsClientException.fur:"
-#~ msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgHostingProviderAdd.inf"
-#~ msgid "Set or select the options according to your account."
-#~ msgstr ""
-
-#~ msgctxt "dlgSgOutput.lbl:"
-#~ msgid "stash failed \\(return code $1\\)"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgProviderGenerateToken.hdl"
-#~ msgid "Generate a new API token for $1"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgPushForced.hdl:"
-#~ msgid "Do you want to force-push \\(replace\\) the remote branch?"
-#~ msgstr ""
-
 #~ msgctxt "dlgSgRepositorySettings.inf:"
 #~ msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
 #~ msgstr "Здесь вы можете изменить настройки Git для репозитория. Параметры по умолчанию можно найти в меню Параметры"
-
-#~ msgctxt "dlgSgResetAdv.inf"
-#~ msgid "Reset the current branch (HEAD) to the selected commit and optionally update Index and working tree."
-#~ msgstr ""
-
-#~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
-#~ msgid "Set to $1 \\(\"ours\", $2\\)"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
-#~ msgid "Set to $1 \\(\"theirs\", $2\\)"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
-#~ msgid "Set to rebase target \\(\"theirs\", $1\\)"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
-#~ msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgSetupStdWnd.fur:"
-#~ msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
-#~ msgstr ""
-
-#~ msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
-#~ msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
-#~ msgstr ""
-
-#~ msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
-#~ msgid "Authentication to the SVN repository '$1' failed with error: $2'"
-#~ msgstr ""
-
-#~ msgctxt "dlgTxtEditor.fileModified.hdl:"
-#~ msgid "The file config was changed. Reload it?"
-#~ msgstr ""
-
-#~ msgctxt "ntmUpdateCheckFetchVersionSuccess:"
-#~ msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
-#~ msgstr ""
-
-#~ msgctxt "nttUpdateCheck:"
-#~ msgid "Quick Poll: $1"
-#~ msgstr ""
-
-#~ msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
-#~ msgid "<b>Last Updated By: </b>$1"
-#~ msgstr ""
-
-#~ msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
-#~ msgid "<b>On: </b>$1"
-#~ msgstr ""
-
-#~ msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
-#~ msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
-#~ msgstr ""
-
-#~ msgctxt "wndStd.mni:"
-#~ msgid "On master: SmartGit: automatic stash on Pull."
-#~ msgstr ""
-
-#~ msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
-#~ msgid "Show Rewritten Behind Commits"
-#~ msgstr ""
 
 #~ msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
 #~ msgid "History"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -37,6 +37,10 @@ msgctxt "*.btn:"
 msgid "OK"
 msgstr "OK"
 
+msgctxt "*.chk:"
+msgid "Don't show again"
+msgstr ""
+
 msgctxt "*.hnt:"
 msgid "Filter"
 msgstr "Фильтр"
@@ -161,6 +165,18 @@ msgctxt "dlgCommitInvisibleIndex.tle:"
 msgid "Commit"
 msgstr ""
 
+msgctxt "dlgCommitNoEmailConfigured.fur:"
+msgid "Before committing you will have to configure your name and email, e.g. in the SmartGit Preferences."
+msgstr ""
+
+msgctxt "dlgCommitNoEmailConfigured.hdl:"
+msgid "Please configure the email for commit."
+msgstr ""
+
+msgctxt "dlgCommitNoEmailConfigured.tle:"
+msgid "Commit"
+msgstr ""
+
 msgctxt "dlgCommitView.hiddenOptions.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
@@ -269,6 +285,18 @@ msgctxt "dlgDgSetPerspectiveCantSwitch.tle:"
 msgid "Origins Perspective"
 msgstr ""
 
+msgctxt "dlgHostingProvider.canBeConfigured.btn:"
+msgid "Configure Hosting Provider"
+msgstr ""
+
+msgctxt "dlgHostingProvider.canBeConfigured.fur:"
+msgid "The easiest way to access the repository at $1 is through a hosting provider."
+msgstr ""
+
+msgctxt "dlgHostingProvider.canBeConfigured.hdl:"
+msgid "Do you want to configure a GitLab hosting provider?"
+msgstr ""
+
 msgctxt "dlgInfo.tle:"
 msgid "Discard"
 msgstr ""
@@ -279,6 +307,11 @@ msgstr "Прервать"
 
 msgctxt "dlgProgress.lbl:"
 msgid "Please wait ..."
+msgstr "Пожалуйста, подождите..."
+
+# [decode] msgid "Please wait …"
+msgctxt "dlgProgress.lbl:"
+msgid "Please wait \\u2026"
 msgstr "Пожалуйста, подождите..."
 
 msgctxt "dlgProgress.tle:"
@@ -730,6 +763,10 @@ msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr ""
 
 msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
+msgid "\\[$1\\] - $2"
+msgstr ""
+
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
@@ -1033,8 +1070,16 @@ msgctxt "dlgScDialogAssertionHandlerLinkageError.btn:"
 msgid "Force Exit"
 msgstr ""
 
+msgctxt "dlgScDialogAssertionHandlerLinkageError.btn:"
+msgid "Just Exit"
+msgstr ""
+
 msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
 msgid "SmartGit has detected inconsistencies within its installation files \\(JAR files\\), what has most likely been caused by a faulty installation.\\n\\nPlease uninstall SmartGit completely, make sure there are no more installation files left \\(especially JAR files\\), then reinstall.\\n\\nIf the problem persists, send following log file as an attachment to smartgit@syntevo.com."
+msgstr ""
+
+msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
+msgid "Your SmartGit-installation seems to be damaged."
 msgstr ""
 
 msgctxt "dlgScDialogAssertionHandlerLinkageError.tle:"
@@ -1073,7 +1118,43 @@ msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr ""
 
+msgctxt "dlgScEvaluationReminderContinue.hdl:"
+msgid "Your SmartGit evaluation ends today."
+msgstr ""
+
 msgctxt "dlgScEvaluationReminderContinue.tle:"
+msgid "Evaluation"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "&Continue \\($1\\)"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "&Continue"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Continue \\($1\\)"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Exit"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Register"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.fur:"
+msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.hdl:"
+msgid "Your evaluation has already expired."
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.tle:"
 msgid "Evaluation"
 msgstr ""
 
@@ -1083,6 +1164,30 @@ msgstr ""
 
 msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle:"
 msgid "\\[$1\\] - Conflict Solver"
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterCommandNoFile.fur:"
+msgid "Be sure to add arguments to the appropriate input field."
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterCommandNoFile.hdl:"
+msgid "The specified command is no file."
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterCommandNoFile.tle:"
+msgid "Input Validation"
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterEmptyCommand.fur:"
+msgid "Select the command which should be invoked."
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterEmptyCommand.hdl:"
+msgid "The Command input field must not be empty!"
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterEmptyCommand.tle:"
+msgid "Input Validation"
 msgstr ""
 
 msgctxt "dlgScFileComparatorAdd.hdl:"
@@ -1473,6 +1578,10 @@ msgctxt "dlgScMasterPasswordEnter.inf:"
 msgid "A stored password or passphrase has been requested from the password store."
 msgstr ""
 
+msgctxt "dlgScMasterPasswordEnter.lbl:"
+msgid "Forgot it? Reset it in the preferences, 'Authentication' page."
+msgstr ""
+
 msgctxt "dlgScMasterPasswordEnter.tle:"
 msgid "Passwords"
 msgstr ""
@@ -1566,6 +1675,10 @@ msgid "Free Updates Until"
 msgstr ""
 
 msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
+msgid "License ID"
+msgstr ""
+
+msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "Name"
 msgstr ""
 
@@ -1609,6 +1722,34 @@ msgctxt "dlgScRegisterRequestRejected.tle:"
 msgid "SmartGit License"
 msgstr ""
 
+msgctxt "dlgScSecretToken.btn:"
+msgid "Connect"
+msgstr ""
+
+msgctxt "dlgScSecretToken.edt:"
+msgid "API Key"
+msgstr ""
+
+msgctxt "dlgScSecretToken.hdl:"
+msgid "Provide API key for '$1'"
+msgstr ""
+
+msgctxt "dlgScSecretToken.inf:"
+msgid "An API key is required to access the AI at '$1'. It will be stored in SmartGit's password store."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://console.anthropic.com/settings/keys Anthropic account\\]."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://console.mistral.ai/api-keys Mistral account\\]."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://platform.openai.com/settings/organization/api-keys OpenAI account\\]."
+msgstr ""
+
 msgctxt "dlgScSetupLicense.btn:"
 msgid "Configure Proxy"
 msgstr "Настроить прокси"
@@ -1644,6 +1785,26 @@ msgstr "Укажите путь к файлу с лицензией, котор�
 msgctxt "dlgScSetupLicense.tle:"
 msgid "SmartGit License"
 msgstr "Лицензия SmartGit"
+
+msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
+msgid "Exit Later"
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
+msgid "Restart Now"
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.fur:"
+msgid "You can do that now or manually later."
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.hdl:"
+msgid "SmartGit has to be restarted for the license change to take effect."
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.tle:"
+msgid "SmartGit License"
+msgstr ""
 
 msgctxt "dlgScSpellCheckDictionaryAdd.err:"
 msgid "Please enter a name."
@@ -2002,8 +2163,8 @@ msgid "Abort Rebase"
 msgstr "Прервать перемещение"
 
 msgctxt "dlgSgAbortRebasingConfirm.fur:"
-msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
-msgstr "Рабочий каталог находится в состоянии 'перемещения'. Вы можете прервать перемещение. Если хотите просто пропустить текущий патч, используйте Ветки\\|Переместить\\|Пропустить.\\n\\nПри отмене будут удалены любые локальные изменения \\(путем вызова 'git rebase --abort'\\)!"
+msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use $1 instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
+msgstr ""
 
 msgctxt "dlgSgAbortRebasingConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
@@ -2034,6 +2195,10 @@ msgid "Discard"
 msgstr ""
 
 msgctxt "dlgSgAbout.btn:"
+msgid "Copy Evaluation-ID"
+msgstr ""
+
+msgctxt "dlgSgAbout.btn:"
 msgid "Register"
 msgstr "Зарегистрировать"
 
@@ -2048,6 +2213,10 @@ msgstr "Адрес"
 msgctxt "dlgSgAbout.edt:"
 msgid "Build Date"
 msgstr "Дата сборки"
+
+msgctxt "dlgSgAbout.edt:"
+msgid "Demo Until"
+msgstr ""
 
 msgctxt "dlgSgAbout.edt:"
 msgid "Email"
@@ -2086,6 +2255,10 @@ msgid "User Count"
 msgstr "Количество пользователей"
 
 msgctxt "dlgSgAbout.edt:"
+msgid "Valid Until"
+msgstr ""
+
+msgctxt "dlgSgAbout.edt:"
 msgid "Version"
 msgstr "Версия"
 
@@ -2104,6 +2277,376 @@ msgstr "Лицензиат"
 msgctxt "dlgSgAbout.tle:"
 msgid "About SmartGit"
 msgstr "О SmartGit"
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.btn:"
+msgid "Drop"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.fur:"
+msgid "This will remove all AI-related Git notes from the repository."
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.hdl:"
+msgid "Do you want to drop all AI-related Git notes?"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.tle:"
+msgid "Drop AI Notes"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.btn:"
+msgid "Swap"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.edt:"
+msgid "New \\(To\\)"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.edt:"
+msgid "Old \\(From\\)"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.hdl:"
+msgid "Choose the diff direction"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.inf:"
+msgid "The two commits have diverged, so they can be compared in either direction. The diff represents the changes from Old to New."
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.tle:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
+msgid "Allow"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
+msgid "Deny"
+msgstr ""
+
+# $1: rootFile , $2: typeName , $3: details
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.fur:"
+msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to $2 are allowed. $3\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.hdl:"
+msgid "Do you allow SmartGit to upload repository data to $1?"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.tle:"
+msgid "AI Upload Consent"
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorError.hdl:"
+msgid "Failed to annotate selected commits."
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorError.tle:"
+msgid "Annotate Commits"
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorOutput.tle:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.fur:"
+msgid "Click the AI button again to generate your first commit message."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.hdl:"
+msgid "GitHub models are now configured."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.tle:"
+msgid "AI Commit Message Compose"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.fur:"
+msgid "No modifications found."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.hdl:"
+msgid "AI generation of the commit message failed."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.tle:"
+msgid "AI Commit Message Compose"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageNoModifications.fur:"
+msgid "There are no uncommitted changes in your working tree, so an AI commit message cannot be generated."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageNoModifications.hdl:"
+msgid "No local changes detected."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.btn:"
+msgid "Reword"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.fur:"
+msgid "SmartGit has detected a commit message containing an AI-generation marker. If the commit has not yet been pushed, it can be automatically reworded in the background.\\n\\nYou can enable or disable this option from the AI popup menu."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.hdl:"
+msgid "Do you want to reword marked commits in the background?"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.tle:"
+msgid "Commit Message Rewording"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.fur:"
+msgid "Your settings exclude untracked files from commits, so they will not be used to generate the AI commit message.\\n\\nTo include untracked files in commits, update the setting in Preferences."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.hdl:"
+msgid "Untracked files are excluded."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.tle:"
+msgid "AI Commit Message"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.hdl:"
+msgid "Configure AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.inf:"
+msgid "SmartGit supports AI-generated commit messages, with more AI features coming. GitHub models can be used out-of-the-box."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Configure manually \\(view documentation\\)"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Disable AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Use GitHub models for this repository"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Use GitHub models globally"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.tle:"
+msgid "AI Integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.btn:"
+msgid "Confirm"
+msgstr ""
+
+# [decode] msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data – either from the working tree or selected commits – to GitHub's servers.\n\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \(see the drop-down menu for configuration\)."
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.fur:"
+msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data \\u2013 either from the working tree or selected commits \\u2013 to GitHub's servers.\\n\\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \\(see the drop-down menu for configuration\\)."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.hdl:"
+msgid "Git diffs will be sent to GitHub for AI processing."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.tle:"
+msgid "Confirm GitHub AI Usage"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.btn:"
+msgid "Go Back"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable automatic stash messages"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable commit explanation"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable commit rewording"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Only for current repository"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "API URL"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "Model"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "URL Query"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Commit Rewording"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Explain Commits"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Please wait"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Stash Messages"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Welcome"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can automatically generate stash messages."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can explain individual commits or commit ranges in the background. Results are stored in Git notes."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can reword commit messages in the background when using special markers."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit offers AI-powered features to enhance productivity, simplify workflows, and assist you with your repositories."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "Verifying connectivity..."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "Verifying connectivity\\u2026"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Leave the stash message blank to enable auto-generation.\\n- SmartGit will generate a message and safely update the stash in the background.\\n- You can always enable or disable AI stash rewording in the Save Stash dialog.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Select one or more commits to generate a natural language explanation.\\n- For multiple commits, explanations are generated in the background and saved in Git Notes.\\n- Select two different branches to generate an explanation of their differences.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Use '@ai' to reword the entire commit message.\\n- 'WIP' will describe Work in Progress with an AI generated commit message.\\n- You can always enable or disable AI commit rewording features from the hamburger menu.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Optional parameters"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Please wait ..."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Please wait \\u2026"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Select your AI provider. This is the service SmartGit will use to generate AI-powered content."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "SmartGit won't ask about AI features again."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Steps"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Your GitHub credentials from the Hosting Provider configuration will be used. There is nothing more to set up here."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.rbt:"
+msgid "Disable AI integration globally"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.rbt:"
+msgid "Enable AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.tle:"
+msgid "AI Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.fur:"
+msgid "The configuration has been saved to '$1', which is included by '$2'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.hdl:"
+msgid "The AI integration has been configured successfully."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.tle:"
+msgid "AI Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupConnectivityFailed.fur:"
+msgid "Object '$1' not found."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConnectivityFailed.hdl:"
+msgid "Connection to '$1' failed."
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Back to Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Enable and Exit"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Exit without Enabling"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.fur:"
+msgid "You have selected some AI features. Do you want to enable them now, or exit the setup without enabling them?"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.hdl:"
+msgid "Enable already selected AI features?"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.tle:"
+msgid "AI Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.fur:"
+msgid "API URL missing."
+msgstr ""
+
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.hdl:"
+msgid "Configuration is invalid."
+msgstr ""
 
 msgctxt "dlgSgApplicationAlreadyRunning.fur:"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
@@ -2477,6 +3020,22 @@ msgctxt "dlgSgBranchTrackingSetConfirm.tle:"
 msgid "Set Tracked Branch"
 msgstr ""
 
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.btn:"
+msgid "Open"
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.fur:"
+msgid "You can see a detailed list of pull requests in the Log's Branches view and review changes in the Graph."
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.hdl:"
+msgid "Do you want to review pull requests in the Log?"
+msgstr ""
+
 msgctxt "dlgSgBugReportSettings.btn:"
 msgid "Exit"
 msgstr ""
@@ -2573,6 +3132,34 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.tle:"
 msgid "Check Out"
 msgstr "Переключение"
 
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.btn:"
+msgid "Checkout"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.fur:"
+msgid "The target branch has a different submodules configuration \\(.gitmodules\\). If you were expecting this change, you can proceed as usual.\\n\\nOtherwise, be aware that significant changes to your submodule configuration can lead to complex working tree states. In some cases, it might be simpler to perform a fresh clone of the target branch."
+msgstr ""
+
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.hdl:"
+msgid "Do you want to check out branch '$1'?"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.btn:"
+msgid "Switch"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.fur:"
+msgid "A worktree repository already exists for the selected branch. Therefore, you can't check out this branch directly, but you can switch to this worktree."
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.hdl:"
+msgid "Do you want to switch to worktree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.tle:"
+msgid "Check Out"
+msgstr ""
+
 msgctxt "dlgSgCheckoutTarget.btn:"
 msgid "Checkout"
 msgstr "Переключиться"
@@ -2584,6 +3171,10 @@ msgstr ""
 msgctxt "dlgSgCheckoutTarget.chk:"
 msgid "Track remote branch"
 msgstr "Отслеживать внешнюю ветку"
+
+msgctxt "dlgSgCheckoutTarget.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
 
 msgctxt "dlgSgCheckoutTarget.hdl:"
 msgid "Check out commit"
@@ -2696,6 +3287,10 @@ msgstr "Добавить идентификатор исходного комм�
 msgctxt "dlgSgCherryPickConfirmation.fur:"
 msgid "This will cherry-pick the selected commit into the Working Tree."
 msgstr "При выполнении этой операции, изменения выбранного коммита будут перенесены в рабочий каталог."
+
+msgctxt "dlgSgCherryPickConfirmation.fur:"
+msgid "This will cherry-pick the selected commits into the Working Tree."
+msgstr ""
 
 msgctxt "dlgSgCherryPickConfirmation.hdl:"
 msgid "Do you want to cherry-pick?"
@@ -2817,6 +3412,18 @@ msgctxt "dlgSgClone.btn:"
 msgid "Configure"
 msgstr "Настроить"
 
+msgctxt "dlgSgClone.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgClone.btn:"
+msgid "Go Back"
+msgstr ""
+
+msgctxt "dlgSgClone.chk:"
+msgid "Configure newly cloned repository to use SmartGit as credential helper"
+msgstr ""
+
 msgctxt "dlgSgClone.chk:"
 msgid "Create upstream remote"
 msgstr ""
@@ -2841,9 +3448,9 @@ msgctxt "dlgSgClone.chk:"
 msgid "Map SVN trunk, tags and branches to Git"
 msgstr ""
 
-msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
+msgctxt "dlgSgClone.chk:"
 msgid "Skip large files \\(\"partial clone\"\\)"
-msgstr "Пропустить большие файлы \\(\"частичное клонирование\"\\)"
+msgstr ""
 
 msgctxt "dlgSgClone.edt:"
 msgid "Check Out Branch"
@@ -2929,6 +3536,11 @@ msgctxt "dlgSgClone.hnt:"
 msgid "Searching ..."
 msgstr ""
 
+# [decode] msgid "Searching …"
+msgctxt "dlgSgClone.hnt:"
+msgid "Searching \\u2026"
+msgstr ""
+
 msgctxt "dlgSgClone.inf:"
 msgid "Customize how and what to clone."
 msgstr "Настройка что и как клонировать"
@@ -2963,6 +3575,18 @@ msgstr "например https://user@server:port/path/to/repository"
 
 msgctxt "dlgSgClone.mni:"
 msgid "Add Hosting Provider"
+msgstr ""
+
+msgctxt "dlgSgClone.mni:"
+msgid "Own Repositories"
+msgstr ""
+
+msgctxt "dlgSgClone.mni:"
+msgid "Starred Repositories"
+msgstr ""
+
+msgctxt "dlgSgClone.mni:"
+msgid "Top Repositories"
 msgstr ""
 
 msgctxt "dlgSgClone.rbt:"
@@ -3177,7 +3801,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Merge commit \\(multiple parents\\)"
 msgstr ""
 
-msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
+msgctxt "dlgSgCommit.rbt:"
 msgid "Simple commit \\(one parent, \"squash\"\\)"
 msgstr ""
 
@@ -3350,6 +3974,10 @@ msgid "Select a commit"
 msgstr "Выберите коммит"
 
 msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
+msgid "No graph roots selected."
+msgstr ""
+
+msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
 msgid "No repository selected."
 msgstr ""
 
@@ -3479,6 +4107,10 @@ msgstr ""
 
 msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl:"
 msgid "The right file is not editable because of mixed line-endings."
+msgstr ""
+
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle:"
+msgid "\\[$1\\] - \\[$2\\] - $3"
 msgstr ""
 
 msgctxt "dlgSgConflictResolverExternalStarted.btn:"
@@ -3754,11 +4386,11 @@ msgid "GIT_DIR for repository at '$1' does not exist."
 msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
-msgid "Repository '$1' is not valid."
+msgid "No valid worktree state of the repository."
 msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
-msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
+msgid "Repository '$1' is not valid."
 msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
@@ -3832,6 +4464,22 @@ msgstr "Открыть сравнение файла без отображени
 msgctxt "dlgSgFileCompareNoChanges.tle:"
 msgid "File Compare"
 msgstr "Сравнение файлов"
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.btn:"
+msgid "Rerun"
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.fur:"
+msgid "For the initial commit\\(s\\) where the file was added, SmartGit will try to find a similar pre-existing file. If it finds one, it will continue the Log for that file as the source from which it might have been copied.\\n\\nTo enable this feature by default, set the Low-Level Property `log.file.followCopies` in the Preferences."
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.hdl:"
+msgid "Do you want to re-run the Log with copy-detection enabled?"
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.tle:"
+msgid "Follow Copies"
+msgstr ""
 
 msgctxt "dlgSgFindObject.edt:"
 msgid "Repository Path, Commit ID or Ref"
@@ -4393,6 +5041,46 @@ msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle:"
 msgid "Run Garbage Collector"
 msgstr ""
 
+msgctxt "dlgSgGitConfigEditConfigNotFound.fur:"
+msgid "The file $1config could not be opened for editing."
+msgstr ""
+
+msgctxt "dlgSgGitConfigEditConfigNotFound.hdl:"
+msgid "The file config was not found."
+msgstr ""
+
+msgctxt "dlgSgGitConfigEditConfigNotFound.tle:"
+msgid "Edit Config"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
+msgid "Refresh"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
+msgid "Select"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.col:"
+msgid "Number"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.col:"
+msgid "Title"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.hdl:"
+msgid "Select commit message by GitHub issue"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.inf:"
+msgid "The selected issue summary will be used as commit message."
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.tle:"
+msgid "Select Issue"
+msgstr ""
+
 msgctxt "dlgSgGitHubGenerateToken.btn:"
 msgid "Authenticate"
 msgstr ""
@@ -4589,6 +5277,26 @@ msgctxt "dlgSgGitLabSettingsInvalidToken.tle:"
 msgid "Input Validation"
 msgstr ""
 
+msgctxt "dlgSgGitNoteAdd.btn:"
+msgid "Add Note"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.edt:"
+msgid "Category"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.hdl:"
+msgid "Add a note to a commit"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.inf:"
+msgid "Provider the text which should be added to the selected commit."
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.tle:"
+msgid "Add Note"
+msgstr ""
+
 msgctxt "dlgSgHeadMessageListenerReplaceMessage.btn:"
 msgid "Don't Replace"
 msgstr "Не заменять"
@@ -4615,6 +5323,10 @@ msgstr "Фиксация изменений"
 
 msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
 msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
+msgstr ""
+
+msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
+msgid "To modify commits of a different branch, you need to first check out this branch."
 msgstr ""
 
 msgctxt "dlgSgHistoryCommitCantBeModified.hdl:"
@@ -4663,6 +5375,26 @@ msgstr ""
 
 msgctxt "dlgSgHistoryEditAuthor.tle:"
 msgid "Edit Author"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.btn:"
+msgid "From Commit"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.btn:"
+msgid "From Failed Command"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.fur:"
+msgid "A previous Edit Message command invocation failed for this commit. Decide whether to use the commit message from the failed run or the commit's message."
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.hdl:"
+msgid "Which commit message you like to use?"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.tle:"
+msgid "Edit Message"
 msgstr ""
 
 msgctxt "dlgSgHistoryEditMessage.btn:"
@@ -4814,6 +5546,10 @@ msgid "Do you want to modify commits which are already pushed?"
 msgstr "Вы хотите изменить ранее отправленные коммиты?"
 
 msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.tle:"
+msgid "Edit Author"
+msgstr ""
+
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.tle:"
 msgid "Edit Message"
 msgstr "Изменение сообщения"
 
@@ -4859,6 +5595,10 @@ msgstr ""
 
 msgctxt "dlgSgHistorySplitConfirm.tle:"
 msgid "Split Commit"
+msgstr ""
+
+msgctxt "dlgSgHistorySquash.btn:"
+msgid "Add co-authors"
 msgstr ""
 
 msgctxt "dlgSgHistorySquash.btn:"
@@ -4986,8 +5726,36 @@ msgid "The entered URL is invalid - it should look like https://server"
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Azure DevOps Server account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Azure DevOps account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Bitbucket Server account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Bitbucket account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitHub Enterprise account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Add GitHub account"
 msgstr "Добавить учетную запись GitHub"
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitLab \\(Self Hosted\\) account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitLab account"
+msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Configure a new hosting provider account"
@@ -5011,6 +5779,10 @@ msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.lbl:"
 msgid "Provide a 'personal access token' which you can generate in your GitHub account settings."
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.lbl:"
+msgid "Required scopes are 'api' and 'write_repository'."
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.lbl:"
@@ -5408,6 +6180,10 @@ msgstr ".gitignore в корне репозитория"
 msgctxt "dlgSgIgnoreFile.edt:"
 msgid "Ignore File"
 msgstr "Файл игнорирования"
+
+msgctxt "dlgSgIgnoreFile.err:"
+msgid "Enter a pattern for the file\\(s\\) to be ignored. Use \\* to match multiple or ? for a single arbitrary character."
+msgstr ""
 
 msgctxt "dlgSgIgnoreFile.err:"
 msgid "The pattern must match all selected file names. For instance, '$1' is not matched."
@@ -5873,6 +6649,10 @@ msgctxt "dlgSgMergeHowToMerge.fur:"
 msgid "If there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
 msgstr "Если нет конфликтов, то Git автоматически создает коммит слияния. Вместо этого, вы можете выбрать ручное объединение в рабочем каталоге, выбрав один из вариантов.\\nВариант 'Объединить в рабочем каталоге' подготовит коммит слияния, а 'Создать объединенный коммит \\(squash\\)' создаст обычный коммит \\(отбросив информацию о том, какие коммиты были объединены\\). В обоих случаях, изменения необходимо будет зафиксировать вручную."
 
+msgctxt "dlgSgMergeHowToMerge.fur:"
+msgid "You are about to perform an Octopus Merge from $1 source branches.\\n\\nIf there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
+msgstr ""
+
 msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from branch '$1'?"
 msgstr "Как объединить с веткой '$1'?"
@@ -5880,6 +6660,10 @@ msgstr "Как объединить с веткой '$1'?"
 msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from tag '$1'?"
 msgstr "Как объединить с меткой '$1'?"
+
+msgctxt "dlgSgMergeHowToMerge.hdl:"
+msgid "How to merge the $1 selected branches?"
+msgstr ""
 
 msgctxt "dlgSgMergeHowToMerge.tle:"
 msgid "Merge"
@@ -5933,6 +6717,26 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.tle:"
 msgid "Add or Create Repository"
 msgstr ""
 
+msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
+msgid "Inner Repository"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
+msgid "Outer Repository"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.fur:"
+msgid "At the specified path nested repositories were found.\\nInner repository: $1\\nOuter repository: $2"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.hdl:"
+msgid "Do you want to open the outer or inner repository?"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.tle:"
+msgid "Add or Create Repository"
+msgstr ""
+
 msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur:"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr ""
@@ -5967,6 +6771,10 @@ msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Abort failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Add Branch failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -6026,6 +6834,18 @@ msgid "Command Discard failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Discard produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Edit Author produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Edit Message failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Fetch Pull Request produced warnings."
 msgstr ""
 
@@ -6035,6 +6855,10 @@ msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Fetch produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command LFS Install failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -6054,6 +6878,10 @@ msgid "Command Move produced warnings."
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Pull \\(Merge\\) failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Pull \\(Merge\\) produced warnings."
 msgstr ""
 
@@ -6070,6 +6898,14 @@ msgid "Command Push failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Rebase HEAD \\($1\\) to $2 failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Rebase HEAD \\($1\\) to $2 produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase Interactive failed!"
 msgstr ""
 
@@ -6079,6 +6915,10 @@ msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Remove Worktree failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -6126,6 +6966,10 @@ msgid "Command Start Support Branch failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Tool $1 produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Unregister Submodule failed!"
 msgstr ""
 
@@ -6142,11 +6986,39 @@ msgid "Not all refs have been pushed."
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "The command output below contains more details on the problem."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "The working tree has local changes."
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Tool $1 succeeded."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "You have not concluded your merge \\(MERGE_HEAD exists\\)."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "stash failed \\(return code $1\\)"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to access '$1': Could not resolve host: $2"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to access '$1': server certificate verification failed. CAfile: $2 CRLfile: $3"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to auto-detect email address \\(got '$1.\\(none\\)'\\)"
 msgstr ""
 
 msgctxt "dlgSgOutput.mni:"
@@ -6175,6 +7047,10 @@ msgstr ""
 
 msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "Please check the repository URL.\\n\\n$1"
+msgstr ""
+
+msgctxt "dlgSgPingRepositoryFailed.fur:"
+msgid "repository '$1' not found."
 msgstr ""
 
 msgctxt "dlgSgPingRepositoryFailed.hdl:"
@@ -6230,6 +7106,10 @@ msgid "Import"
 msgstr "Импорт"
 
 msgctxt "dlgSgPreferences.btn:"
+msgid "Load All Stored Secrets"
+msgstr ""
+
+msgctxt "dlgSgPreferences.btn:"
 msgid "Move Down"
 msgstr "Вниз"
 
@@ -6260,6 +7140,10 @@ msgstr "Сбросить"
 msgctxt "dlgSgPreferences.btn:"
 msgid "Show Password"
 msgstr "Показать пароль"
+
+msgctxt "dlgSgPreferences.cdl:"
+msgid "AI Integration"
+msgstr ""
 
 msgctxt "dlgSgPreferences.cdl:"
 msgid "Authentication"
@@ -6362,6 +7246,10 @@ msgid "Allow modifying pushed commits \\(e.g. forced-push\\)"
 msgstr "Разрешать изменение отправленных коммитов \\(т.е. принудительную отправку\\)"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Allow modifying pushed commits \\(e.g. forced-push\\):"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Allow to open multiple Log windows for the same repository/file"
 msgstr "Разрешить открытие нескольких окон истории для одного репозитория/файла"
 
@@ -6414,6 +7302,18 @@ msgid "Configure SmartGit as credential helper \\(for repository authentication\
 msgstr "Настроить SmartGit как помощника по учетным данным \\(для аутентификации в репозиториях\\)"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Configure SmartGit as credential helper for Git command line"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Configure newly cloned repository to use SmartGit as credential helper on Git command line"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Delete branch"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Detect local changes in closed 'favorite' repositories"
 msgstr "Отслеживать локальные изменения в закрытых 'избранных' репозиториях"
 
@@ -6426,8 +7326,16 @@ msgid "Detect renames \\(for added and removed files, as command line Git does\\
 msgstr "Определять переименования \\(для добавленных и удаляемых файлов по аналогии с командами Git\\)"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Disable AI integration \\(globally\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Distinguish between content and EOL-only changes \\(slightly more expensive\\)"
 msgstr "Различать изменения только в окончании строк \\(чуть более затратно\\)"
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Enable AI integration"
+msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
 msgid "Enable integration for configured hosting providers \\(pull requests, comments\\)"
@@ -6494,6 +7402,10 @@ msgid "Push all tags"
 msgstr "Отправлять все метки"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Quick Polls \\(help shape SmartGit\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Refresh file system also while SmartGit is in background"
 msgstr ""
 
@@ -6550,6 +7462,10 @@ msgid "Sign all commits"
 msgstr "Подписывать все коммиты"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "SmartGit-related announcements"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Swap 'ours' and 'theirs' on Rebase conflicts for easier understanding"
 msgstr ""
 
@@ -6599,6 +7515,11 @@ msgstr "Автоматический выбор светлой/темной те
 
 msgctxt "dlgSgPreferences.cmb:"
 msgid "Custom..."
+msgstr "Своя..."
+
+# [decode] msgid "Custom…"
+msgctxt "dlgSgPreferences.cmb:"
+msgid "Custom\\u2026"
 msgstr "Своя..."
 
 msgctxt "dlgSgPreferences.cmb:"
@@ -6656,6 +7577,10 @@ msgstr "Команда + аргументы"
 msgctxt "dlgSgPreferences.col:"
 msgid "Command"
 msgstr "Команда"
+
+msgctxt "dlgSgPreferences.col:"
+msgid "Credential"
+msgstr ""
 
 msgctxt "dlgSgPreferences.col:"
 msgid "Default"
@@ -6782,6 +7707,10 @@ msgid "Name"
 msgstr ""
 
 msgctxt "dlgSgPreferences.edt:"
+msgid "Notify about"
+msgstr ""
+
+msgctxt "dlgSgPreferences.edt:"
 msgid "On startup"
 msgstr "При запуске"
 
@@ -6902,6 +7831,10 @@ msgid "Changing these low-level properties can be harmful to the stability or pe
 msgstr "Изменение низкоуровненых параметров может привести к нарушению стабильности или производительности Smartgit. Продолжайте, только если вы уверены в том, что делаете. Измененные свойства со знаком \\* в конце требуют перезапуска для применения."
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Changing these low-level properties may harm the stability or performance of SmartGit.\\n\\[_ Changed properties\\] with a trailing \\\\\\* need a restart to be applied."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Checkout \\(Switch branch\\)"
 msgstr "Переключение \\(Смена ветки\\)"
 
@@ -6938,8 +7871,16 @@ msgid "External tool:"
 msgstr "Внешний:"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Finish Feature"
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Garbage Collector"
 msgstr "Сборщик мусора"
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "General"
+msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "Here you can edit your account's 'gitconfig' which contains the defaults for all repositories."
@@ -6962,8 +7903,16 @@ msgid "In order to use all SmartGit functionality, you need to have command line
 msgstr "Для использования всех функций SmartGit необходимо указать путь к установленному в системе git. Укажите полный путь к исполняемому файлу."
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Learn how to tailor AI for your projects with the complete \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI SmartGit AI Integration documentation\\]."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Local and Remote Changes"
 msgstr "Локальные и внешние изменения"
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "Note: Some repositories may already have per-repository AI settings."
+msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "Note: The password will be stored in plain text in SmartGit's configuration area!"
@@ -7006,6 +7955,22 @@ msgid "Stash"
 msgstr "Прятать"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*configured globally\\*. Change it via AI button > \\*Reconfigure\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*disabled globally\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*manually configured\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*not yet configured\\* \\(globally\\)."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "The last check was performed on $1."
 msgstr "Последняя проверка была $1."
 
@@ -7018,6 +7983,14 @@ msgid "This file will be sent as is: $1"
 msgstr "Этот файл отправляется как есть: $1"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "To change it, edit your Git config files directly."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "To configure, click the AI button in the Commit Message view or the Commit dialog."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "To manually update in-place use the '...' button located next to the version number in the About dialog."
 msgstr ""
 
@@ -7028,6 +8001,10 @@ msgstr "Просмотрщик:"
 msgctxt "dlgSgPreferences.lbl:"
 msgid "When comparing files, this list is searched from top to bottom to find a matching diff tool. If none is found, the built-in file compare is used for text files."
 msgstr "При сравнении файлов, этот список просматривается сверху вниз для подбора подходящего инструмента. Если ничего не найдено, то для текстовых файлов будет использован встроенный."
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "When enabled, the AI button appears in the Commit Message view and the Commit dialog. Click it to complete the initial setup."
+msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "When invoking the Conflict Solver feature, this list is searched from top to bottom to find a matching entry. If none is found, the built-in Conflict Solver is used for text files."
@@ -7115,6 +8092,10 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.mni:"
 msgid "Copy Selection in Column"
+msgstr ""
+
+msgctxt "dlgSgPreferences.mni:"
+msgid "Credential"
 msgstr ""
 
 msgctxt "dlgSgPreferences.mni:"
@@ -7266,6 +8247,10 @@ msgid "Exact case \\('Foo' will match 'Foo', but not 'foo'\\)"
 msgstr "Точный регистр \\('Файл' соответсвует 'Файл', но не 'файл'\\)"
 
 msgctxt "dlgSgPreferences.rbt:"
+msgid "For all branches"
+msgstr ""
+
+msgctxt "dlgSgPreferences.rbt:"
 msgid "Ignore case \\('Foo' will match 'Foo' and 'foo'\\)"
 msgstr "Игнорирование регистра \\('Файл' соответсвует 'Файл' и 'файл'\\)"
 
@@ -7280,6 +8265,10 @@ msgstr ""
 msgctxt "dlgSgPreferences.rbt:"
 msgid "Log graph \\(commit oriented\\)"
 msgstr "Граф \\(ориентирован на коммиты\\)"
+
+msgctxt "dlgSgPreferences.rbt:"
+msgid "Only for feature branches"
+msgstr ""
 
 msgctxt "dlgSgPreferences.rbt:"
 msgid "Other Git Executable:"
@@ -7351,6 +8340,10 @@ msgstr "Поведение"
 
 msgctxt "dlgSgPreferences.tab:"
 msgid "Colors"
+msgstr ""
+
+msgctxt "dlgSgPreferences.tab:"
+msgid "Credential Helper"
 msgstr ""
 
 msgctxt "dlgSgPreferences.tab:"
@@ -7453,6 +8446,10 @@ msgctxt "dlgSgProcessKiller.lbl:"
 msgid "If you think the process is hanging, click the 'Kill Process' button, otherwise 'Wait'."
 msgstr ""
 
+msgctxt "dlgSgProcessKiller.lbl:"
+msgid "SmartGit is waiting for the following process to finish."
+msgstr ""
+
 msgctxt "dlgSgProcessKiller.tle:"
 msgid "Process Not Responding"
 msgstr ""
@@ -7477,12 +8474,44 @@ msgctxt "dlgSgProviderCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr ""
 
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.btn:"
+msgid "Confirm"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.cmb:"
+msgid "github.com"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.edt:"
+msgid "Provider"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.hdl:"
+msgid "Select which GitHub account to use"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.inf:"
+msgid "Select which account you want to use for connecting to '$1'."
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.tle:"
+msgid "Select GitHub account"
+msgstr ""
+
 msgctxt "dlgSgProviderGenerateToken.btn:"
 msgid "Authenticate"
 msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
+msgstr ""
+
+msgctxt "dlgSgProviderGenerateToken.hdl:"
+msgid "Generate a new API token for $1"
+msgstr ""
+
+msgctxt "dlgSgProviderGenerateToken.inf:"
+msgid "Authenticate at GitHub and grant access to SmartGit."
 msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.inf:"
@@ -7789,6 +8818,14 @@ msgctxt "dlgSgPushConfirmSingleTag.chk:"
 msgid "Don't show again"
 msgstr "Не показывать снова"
 
+msgctxt "dlgSgPushConfirmSingleTag.fur:"
+msgid "$1 tag will be pushed to '$2'."
+msgstr ""
+
+msgctxt "dlgSgPushConfirmSingleTag.hdl:"
+msgid "Do you want to push tag '$1'?"
+msgstr ""
+
 msgctxt "dlgSgPushConfirmSingleTag.tle:"
 msgid "Push"
 msgstr "Отправка"
@@ -7802,7 +8839,7 @@ msgid "Pushing to the remote branch is not fast-forward, so the push has to be f
 msgstr "Отправка во внешнюю ветку не является перемоткой вперед, поэтому отправка должна быть принудительной. Коммиты во внешней ветке будут потеряны."
 
 msgctxt "dlgSgPushForced.hdl:"
-msgid "Do you want to force-push \\(replace\\) the remote branch?"
+msgid "Do you want to force-push \\(replace\\) the remote branch '$1'?"
 msgstr ""
 
 msgctxt "dlgSgPushForced.tle:"
@@ -8133,6 +9170,46 @@ msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle:"
 msgid "Rebase"
 msgstr ""
 
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.btn:"
+msgid "Continue \\(Resume\\)"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.fur:"
+msgid "Clicking 'Continue' will resume the rebase, e.g. to finish after having modified the commit\\(s\\)."
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.hdl:"
+msgid "Do you want to continue the modify-commit-rebase?"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.tle:"
+msgid "Modify Commit"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.btn:"
+msgid "Step"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.fur:"
+msgid "Clicking 'Step' will continue the rebase and stop at the next commit. Use it to step through all pending commits, e.g. to verify whether they successfully build."
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.hdl:"
+msgid "Do you want to step to the next commit?"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.tle:"
+msgid "Modify Commit"
+msgstr ""
+
 msgctxt "dlgSgRebaseContinueNothingToCommitSkip.btn:"
 msgid "Skip Commit"
 msgstr ""
@@ -8345,6 +9422,14 @@ msgctxt "dlgSgRebaseInteractiveMessage.tle:"
 msgid "Edit Message"
 msgstr "Изменение сообщения коммита"
 
+msgctxt "dlgSgRebaseInteractiveNoAutomaticSquashableCommitsFound.fur:"
+msgid "Auto-Squash searches for commits with identical messages and amend-commits them."
+msgstr ""
+
+msgctxt "dlgSgRebaseInteractiveNoAutomaticSquashableCommitsFound.hdl:"
+msgid "No automatic squashable commits found."
+msgstr ""
+
 msgctxt "dlgSgRebaseInteractiveRemoveCommit.btn:"
 msgid "Remove"
 msgstr ""
@@ -8373,6 +9458,14 @@ msgctxt "dlgSgRebaseNoop.tle:"
 msgid "Merge"
 msgstr ""
 
+msgctxt "dlgSgRebaseNoopParent.fur:"
+msgid "Rebasing a commit onto its parent is allowed by Git but will not create a new commit or any meaningful changes."
+msgstr ""
+
+msgctxt "dlgSgRebaseNoopParent.hdl:"
+msgid "There is nothing to rebase."
+msgstr ""
+
 msgctxt "dlgSgRebaseNoopSelf.fur:"
 msgid "Rebasing a commit onto itself is allowed by Git but will not create a new commit or any meaningful changes."
 msgstr ""
@@ -8383,6 +9476,18 @@ msgstr ""
 
 msgctxt "dlgSgRebaseNoopSelf.tle:"
 msgid "Rebase"
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.btn:"
+msgid "Rebase Single Commit"
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.fur:"
+msgid "You are about to rebase your branch onto its own history. This action is allowed by Git but will not create a new commit or any meaningful changes.\\n\\nTo rebase a single commit, you can do so now.\\n\\nTo rebase a range of commits, select them in the Graph and drag & drop to the target commit."
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.hdl:"
+msgid "Do you want to rebase only the HEAD commit?"
 msgstr ""
 
 msgctxt "dlgSgRebaseTagCommit.btn:"
@@ -8697,6 +9802,10 @@ msgctxt "dlgSgRenameBranch.edt:"
 msgid "Name"
 msgstr "Имя"
 
+msgctxt "dlgSgRenameBranch.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
+
 msgctxt "dlgSgRenameBranch.hdl:"
 msgid "Rename branch"
 msgstr "Переименование ветки"
@@ -8716,6 +9825,10 @@ msgstr "Переименовать"
 msgctxt "dlgSgRenameFile.edt:"
 msgid "Path"
 msgstr "Путь"
+
+msgctxt "dlgSgRenameFile.err:"
+msgid "No valid path specified."
+msgstr ""
 
 msgctxt "dlgSgRenameFile.hdl:"
 msgid "Move or Rename the file"
@@ -8857,6 +9970,10 @@ msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Close"
 msgstr ""
 
+msgctxt "dlgSgRepositoryClose.btn:"
+msgid "Force Exit"
+msgstr ""
+
 msgctxt "dlgSgRepositoryClose.fur:"
 msgid "Note that currently running Git processes might not be interrupted."
 msgstr ""
@@ -8867,6 +9984,10 @@ msgstr ""
 
 msgctxt "dlgSgRepositoryClose.tle:"
 msgid "Close"
+msgstr ""
+
+msgctxt "dlgSgRepositoryClose.tle:"
+msgid "Exit"
 msgstr ""
 
 msgctxt "dlgSgRepositoryFrameCloseWithoutPush.btn:"
@@ -8986,6 +10107,10 @@ msgid "Always fetch new commits, tags and branches from submodule"
 msgstr "Всегда забирать новые коммиты, метки и ветки для субмодуля"
 
 msgctxt "dlgSgRepositorySettings.chk:"
+msgid "Configure SmartGit as credential helper for Git command line"
+msgstr ""
+
+msgctxt "dlgSgRepositorySettings.chk:"
 msgid "Initialize new submodules"
 msgstr "Инициализировать новые субмодули"
 
@@ -9058,12 +10183,16 @@ msgid "Edit the repository settings"
 msgstr "Изменение настроек репозитория"
 
 msgctxt "dlgSgRepositorySettings.inf:"
-msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
-msgstr "Здесь вы можете изменить настройки Git для репозитория. Параметры по умолчанию можно найти в меню Параметры"
+msgid "Here you can edit the Git settings for the repository. The default settings can be found in the Preferences."
+msgstr ""
 
 msgctxt "dlgSgRepositorySettings.lbl:"
 msgid "\\* if repository commit references non-pushed submodule commit"
 msgstr "\\* если коммит репозитория ссылается на неотправленный коммит субмодуля"
+
+msgctxt "dlgSgRepositorySettings.tab:"
+msgid "Credential Helper"
+msgstr ""
 
 msgctxt "dlgSgRepositorySettings.tab:"
 msgid "Encoding"
@@ -9111,6 +10240,10 @@ msgstr ""
 
 msgctxt "dlgSgRepositorySettings.ttpGroupPatterns:"
 msgid "Patterns will show up in the GUI using auto-generated labels which are derived from their regular expression. You can assign a custom label <tt>label</tt> to a pattern by prefixing it by <tt>label:</tt>; a label may only contain letters, digits and '_'."
+msgstr ""
+
+msgctxt "dlgSgRepositorySettings.wrn:"
+msgid "It is recommended to set an email address used for committing."
 msgstr ""
 
 msgctxt "dlgSgRepositorySettings.wrn:"
@@ -9233,19 +10366,19 @@ msgctxt "dlgSgResolve.rbt:"
 msgid "Open Conflict Solver"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"ours\", $2\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"theirs\", $2\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebase target \\(\"theirs\", $1\\)"
 msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
 msgstr ""
 
@@ -9774,11 +10907,23 @@ msgid "Send usage statistics"
 msgstr ""
 
 msgctxt "dlgSgSetup.chk:"
+msgid "Use SmartGit for authentication \\(ignoring your current credential.helper configuration\\)"
+msgstr ""
+
+msgctxt "dlgSgSetup.chk:"
 msgid "Use gravatar.com to show images for the users"
 msgstr ""
 
 msgctxt "dlgSgSetup.edt:"
 msgid "Email"
+msgstr ""
+
+msgctxt "dlgSgSetup.edt:"
+msgid "Full Name"
+msgstr ""
+
+msgctxt "dlgSgSetup.edt:"
+msgid "Git Email"
 msgstr ""
 
 msgctxt "dlgSgSetup.edt:"
@@ -9801,8 +10946,32 @@ msgctxt "dlgSgSetup.edt:"
 msgid "User Name"
 msgstr ""
 
+msgctxt "dlgSgSetup.hdl:"
+msgid "Git Executable"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "License"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "Privacy"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "Style"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "User Information"
+msgstr ""
+
 msgctxt "dlgSgSetup.inf:"
 msgid "If you are using SSH to connect to other Git repositories, select what SSH client to use. You can change it later in the Preferences."
+msgstr ""
+
+msgctxt "dlgSgSetup.inf:"
+msgid "Please review the following privacy options. You can change them later in the Preferences."
 msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
@@ -9819,6 +10988,10 @@ msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
 msgid "User name and email will be stored as part of your commits. Here you can configure the default values which are stored in .gitconfig."
+msgstr ""
+
+msgctxt "dlgSgSetup.inf:"
+msgid "User name and email will be stored as part of your commits. Here you can configure the default values which are stored in ~/.gitconfig."
 msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
@@ -9886,6 +11059,10 @@ msgid "may be harder to configure and use for new users, but is more flexible"
 msgstr ""
 
 msgctxt "dlgSgSetup.rbt:"
+msgid "Bundled Git"
+msgstr ""
+
+msgctxt "dlgSgSetup.rbt:"
 msgid "Commits \\(Log History\\)"
 msgstr ""
 
@@ -9899,6 +11076,10 @@ msgstr ""
 
 msgctxt "dlgSgSetup.rbt:"
 msgid "Non-commercial use only \\(most features, no support\\)"
+msgstr ""
+
+msgctxt "dlgSgSetup.rbt:"
+msgid "Other Git Executable:"
 msgstr ""
 
 msgctxt "dlgSgSetup.rbt:"
@@ -9938,7 +11119,7 @@ msgid "Use Standard Window"
 msgstr ""
 
 msgctxt "dlgSgSetupStdWnd.fur:"
-msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
+msgid "We recommend the Standard window for \\*new SmartGit users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 msgstr ""
 
 msgctxt "dlgSgSetupStdWnd.hdl:"
@@ -10222,6 +11403,10 @@ msgid "Automatically save stash"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.fur:"
+msgid "Add Branch may require a clean working tree to complete successfully. After the Add Branch succeeded, the stashed local changes will be automatically reapplied."
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.fur:"
 msgid "Check Out may require a clean working tree to complete successfully. After the Check Out succeeded, the stashed local changes will be automatically reapplied."
 msgstr ""
 
@@ -10250,6 +11435,10 @@ msgid "Squash Commits may require a clean working tree to complete successfully.
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
+msgid "Do you want to save local changes to a stash and retry Add Branch?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "Do you want to save local changes to a stash and retry Check Out?"
 msgstr ""
 
@@ -10267,6 +11456,10 @@ msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "Do you want to save local changes to a stash and retry Reorder Commits?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
+msgid "Do you want to save local changes to a stash and retry Squash Commits?"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
@@ -10294,15 +11487,43 @@ msgid "Checkout"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Edit Message"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Reorder Commits"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Reset"
 msgstr "Сброс изменений"
 
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Squash Commits"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.fur:"
+msgid "It might be hard or impossible to restore them!"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.hdl:"
+msgid "Do you really want to discard the local changes?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.tle:"
+msgid "Reset"
+msgstr ""
+
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
-msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
+msgid "Once you have concluded the Reorder Commits, you should manually apply the latest stash to get your local changes back into the working tree."
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl:"
@@ -10410,7 +11631,23 @@ msgid "Directory '$1' already exists."
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.err:"
+msgid "Please specify the URL of the remote repository or the path of the local repository that should be cloned."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.err:"
 msgid "Please specify the URL of the remote repository to be cloned."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.err:"
+msgid "The specified directory is not the root of a repository."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hdl:"
+msgid "Path"
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hdl:"
+msgid "Repository"
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.hnt:"
@@ -10418,7 +11655,16 @@ msgid "No repository found."
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.hnt:"
+msgid "No repository matches the entered filter."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hnt:"
 msgid "Searching ..."
+msgstr ""
+
+# [decode] msgid "Searching …"
+msgctxt "dlgSgSubmoduleAdd.hnt:"
+msgid "Searching \\u2026"
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.inf:"
@@ -10500,6 +11746,14 @@ msgstr "Записи о субмодулях будут добавлены в .g
 msgctxt "dlgSgSubmoduleInitAll.tle:"
 msgid "Initialize Submodule"
 msgstr "Инициализация субмодулей"
+
+msgctxt "dlgSgSubmoduleInitAllConfigured.fur:"
+msgid "You may now pull individual submodules or on the root directory to clone the configured repositories."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleInitAllConfigured.hdl:"
+msgid "Submodules have been configured."
+msgstr ""
 
 msgctxt "dlgSgSubmoduleInitGit.btn:"
 msgid "Initialize && Pull"
@@ -10617,8 +11871,24 @@ msgctxt "dlgSgSubmoduleUnregisterConfirm.fur:"
 msgid "All relevant files will be adjusted. Afterwards you will only need to perform a commit to finish the operation. To just skip the submodule from the working tree, use Deinit."
 msgstr ""
 
+msgctxt "dlgSgSubmoduleUnregisterConfirm.hdl:"
+msgid "Do you want to unregister submodule '$1'?"
+msgstr ""
+
 msgctxt "dlgSgSubmoduleUnregisterConfirm.tle:"
 msgid "Unregister Submodule"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Configure"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Go Back"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.chk:"
@@ -10642,11 +11912,64 @@ msgid "Local Path"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.edt:"
+msgid "Relative Path"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.edt:"
 msgid "Remote"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.edt:"
 msgid "Repository URL"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "A local branch with this name already exists. Use a different name."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Consecutive dots are not allowed."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Consecutive slashes are not allowed."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Directory '$1' already exists."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Enter the name of the local branch."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Please enter a valid relative path. The submodule will be created at this path inside the repository."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Please select a valid branch."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "The name must not contain control characters, space, ~, ^, :, ?, \\*, \\[, < or >."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.hdl:"
+msgid "Path"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.hdl:"
+msgid "Repository"
+msgstr ""
+
+# [decode] msgid "Searching …"
+msgctxt "dlgSgSubtreeAdd.hnt:"
+msgid "Searching \\u2026"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.inf:"
@@ -10657,8 +11980,16 @@ msgctxt "dlgSgSubtreeAdd.inf:"
 msgid "Specify the repository to clone as subtree."
 msgstr ""
 
+msgctxt "dlgSgSubtreeAdd.inf:"
+msgid "Specify the repository to clone as subtree.\\nTo configure multiple accounts of the same hosting provider, use the Preferences."
+msgstr ""
+
 msgctxt "dlgSgSubtreeAdd.lbl:"
 msgid "Local branches for subtrees will only be useful if you plan to use Subtree-Split and Subtree-Reset operations."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.lbl:"
+msgid "Steps"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.lbl:"
@@ -10675,6 +12006,90 @@ msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.tle:"
 msgid "Add Subtree"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.fur:"
+msgid "Subtree operations are now available in \\*Branches\\* and \\*Graph\\* view, for \\*$1\\* and refs belonging to the \\*$2\\* remote."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.fur:"
+msgid "Subtree operations are now available in \\*Branches\\* and \\*Graph\\* view, for refs belonging to the \\*$1\\* remote."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.hdl:"
+msgid "Subtree '$1' has been successfully added."
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.btn:"
+msgid "Merge"
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.fur:"
+msgid "Changes from '$1' will be merged into sub-directory '$2'."
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.hdl:"
+msgid "Do you want to merge subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.chk:"
+msgid "Annotate generated history with prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.chk:"
+msgid "Rejoin generated history \\(for more efficient future splits\\)"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.edt:"
+msgid "Prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.hdl:"
+msgid "Do you want to push back subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.inf:"
+msgid "HEAD changes from sub-directory '$1' will be rewritten onto '$2' and pushed back."
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.btn:"
+msgid "Reset"
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.fur:"
+msgid "This will reset the sub-directory '$1' in your main history to the same state as in the subtree history at '$2'.\\n\\nChanges in the sub-directory which are only present in your main history commits will be lost. Only use this operation after your changes have been merged into the subtree history!"
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.hdl:"
+msgid "Do you want to reset subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.chk:"
+msgid "Annotate generated history with prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.chk:"
+msgid "Rejoin generated history \\(for more efficient future splits\\)"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.edt:"
+msgid "Prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.edt:"
+msgid "Subtree-Branch to update"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.hdl:"
+msgid "Do you want to update subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.inf:"
+msgid "HEAD changes from sub-directory '$1' will be rewritten onto '$2'."
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.lbl:"
+msgid "The selected branch pointer will be set to the HEAD of the generated history."
 msgstr ""
 
 msgctxt "dlgSgSvnClientCertificate.btn:"
@@ -10705,7 +12120,7 @@ msgctxt "dlgSgSvnClientCertificate.tle:"
 msgid "SVN Authentication"
 msgstr ""
 
-msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
+msgctxt "dlgSgSvnClientCertificate.wrn:"
 msgid "Authentication to the SVN repository '$1' failed with error: $2'"
 msgstr ""
 
@@ -10871,6 +12286,10 @@ msgstr "Горячие клавиши"
 
 msgctxt "dlgSgToolEdit.err:"
 msgid "Please enter the name for this command."
+msgstr ""
+
+msgctxt "dlgSgToolEdit.err:"
+msgid "Select the command which should be invoked."
 msgstr ""
 
 msgctxt "dlgSgToolEdit.hdl:"
@@ -11161,6 +12580,254 @@ msgctxt "dlgShPushTrackingLocalSvnBranches.tle:"
 msgid "Push"
 msgstr ""
 
+msgctxt "dlgStdCheckoutCommit.btn:"
+msgid "Add Branch && Checkout"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.edt:"
+msgid "Branch"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.hdl:"
+msgid "Add branch at commit $1"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.inf:"
+msgid "Enter the name of the local branch to create. It will be checked out."
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.rbt:"
+msgid "Checkout local branch:"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.rbt:"
+msgid "Create local branch:"
+msgstr ""
+
+msgctxt "dlgStdDiscard.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdDiscard.fur:"
+msgid "You won't be able to restore them."
+msgstr ""
+
+msgctxt "dlgStdDiscard.hdl:"
+msgid "Do you want to discard local changes?"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.fur:"
+msgid "You are about to delete untracked files permanently. This action cannot be undone."
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.hdl:"
+msgid "Do you want to delete untracked files?"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.tle:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.btn:"
+msgid "Confirm"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Feature Prefix"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Main Branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Main Branches"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.hdl:"
+msgid "Configure main and feature branches"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.hdl:"
+msgid "Configure main branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.inf:"
+msgid "Set the main branch for your repository and an optional prefix for feature branches."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.inf:"
+msgid "Set the main branch for your repository."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.lbl:"
+msgid "Example: develop, release-.\\*"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.lbl:"
+msgid "The 'main branch' represents the main development branch of your repository and serves as a foundation for releases. Usually it is named 'develop', 'master' or 'main'.\\n\\nBranches that are used to develop a single new feature, bugfix or other related changes \\(temporarily\\) isolated from the main branch are called 'feature branch' \\(or short 'feature'\\). They typically have a special name prefix, e.g. 'feature/'.\\n\\nNew features will be forked off from a main branch using 'Start'. For an existing feature, new changes from the main branch will be integrated using 'Integrate'. Once you have finished the feature, you can incorporate it into the main branch using 'Finish'.\\n\\nFor extended configuration options, invoke '\\u30d6\\u30e9\\u30f3\\u30c1 \\| Feature \\u306e\\u8a2d\\u5b9a'."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.ttp:"
+msgid "The <b>Feature Prefix</b> is optional. <tt>feature/</tt>is commonly used and compatible with Git-Flow."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.ttp:"
+msgid "You can configure one or more <b>Main Branches</b> by specifying their names separated by semicolon. To specify patterns instead of singular names, use regular expressions. For example: <tt>main,release-.\\*</tt>."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfigurationSimple.hdl:"
+msgid "'$1' has been configured as main branch and '$2' as feature-prefix."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.btn:"
+msgid "Select"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Create merge commit"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Delete feature branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Push results"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.edt:"
+msgid "Merge Message"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.hdl:"
+msgid "Finish feature '$1'"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.inf:"
+msgid "Choose how to finish the feature branch '$1'. This operation will integrate the feature branch into the '$2' branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.rbt:"
+msgid "Create Pull Request"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.rbt:"
+msgid "Finish to main branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinishFeatureEmpty.fur:"
+msgid "Your feature branch does not contain any new commits. Finishing now will simply remove the branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinishFeatureEmpty.hdl:"
+msgid "Feature branch is empty."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "Branch '$1' is ahead of '$2'.\\n\\nConsolidate the '$3'-branch, then invoke Integrate again."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "The feature branch has been rebased onto '$1'.\\n\\nYou may now verify and push the branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "The local feature branch has been rebased onto the remote branch '$1'.\\n\\nYou may now verify and push the branch, then invoke Integrate again."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Resolve diverged main branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Verify integrated main changes."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Verify integrated remote changes."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.lbl:"
+msgid "Steps"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.btn:"
+msgid "Start"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.edt:"
+msgid "Feature Name"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.hdl:"
+msgid "Start a new feature"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.inf:"
+msgid "Enter the name of the new feature branch. This operation will fork a new branch from '$1'."
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.lbl:"
+msgid "Resulting Branch: $1"
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.btn:"
+msgid "Switch Anyway"
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.fur:"
+msgid "Your working tree currently has local modifications, and you are not currently on the main branch. Initiating a new feature now will require switching commits, which can potentially fail due to the presence of local changes.\\n\\nThe recommended course of action is either to commit your local changes \\(if they pertain to the current branch\\) or stash them away in order to have a clean working tree before starting a new feature."
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.hdl:"
+msgid "Do you want to switch to a different branch despite having local changes?"
+msgstr ""
+
+msgctxt "dlgStdOutputCommandConflicts.fur:"
+msgid "These conflicts must be resolved before continuing. Select the conflicted files in the Local Files view and use the Conflict Solver to resolve them, then continue the operation."
+msgstr ""
+
+msgctxt "dlgStdOutputCommandConflicts.hdl:"
+msgid "SmartGit encountered conflicts during the Integrate main operation."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.fur:"
+msgid "Commit or stash local changes before cherry-picking."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.fur:"
+msgid "Commit or stash local changes before reverting."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.hdl:"
+msgid "The working tree contains local changes."
+msgstr ""
+
+msgctxt "dlgStdRemove.btn:"
+msgid "Delete Local Files"
+msgstr ""
+
+msgctxt "dlgStdRemove.btn:"
+msgid "Keep Local Files"
+msgstr ""
+
+msgctxt "dlgStdRemove.fur:"
+msgid "You can just remove the files from the repository \\(keeping the local files, e.g. to mark them later as ignored\\), or also delete the local files."
+msgstr ""
+
+msgctxt "dlgStdRemove.hdl:"
+msgid "How do you want to remove the files from the repository?"
+msgstr ""
+
 msgctxt "dlgTxtEditor.fileModified.btn:"
 msgid "Keep Content"
 msgstr ""
@@ -11174,7 +12841,7 @@ msgid "Unless you want to see the old file state, it is recommended to reload."
 msgstr ""
 
 msgctxt "dlgTxtEditor.fileModified.hdl:"
-msgid "The file config was changed. Reload it?"
+msgid "The file $1 was changed. Reload it?"
 msgstr ""
 
 msgctxt "dlgTxtEditor.fileModified.tle:"
@@ -11282,6 +12949,10 @@ msgid "In case you are encountering strange errors or unexpected dialog popups, 
 msgstr ""
 
 msgctxt "ntmCredentialHelper:"
+msgid "In general this should be fine and is the recommended configuration when working with multiple Git clients. If unexpected credential popups or weird errors occur, try to let SmartGit handle the authentication itself."
+msgstr ""
+
+msgctxt "ntmCredentialHelper:"
 msgid "In general this should be fine and is the recommended configuration when working with multiple Git clients. In case you are encountering strange errors or unexpected dialog popups, try to disable this configuration and let SmartGit handle the authentication itself."
 msgstr ""
 
@@ -11295,6 +12966,18 @@ msgstr ""
 
 msgctxt "ntmCredentialHelper:"
 msgid "To disable this configuration, open the above config file, locate the <b>\\[credential\\]</b>-section and comment out the <b>helper\\=</b> line using <b>#</b>"
+msgstr ""
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Directory '$1' \\($2\\) has been excluded from file monitoring because it's listed in some .gitignore file."
+msgstr ""
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Sometimes ignored directories are containing tracked files in which case changes to these files might not show up automatically. If this is the case for you, you may disable this optimization by setting system property 'fileMonitor.excludeIgnoredDirectories\\=false'."
+msgstr ""
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Usually this does not cause any problems but improves Refreshing performance and reduces required inotify handles."
 msgstr ""
 
 msgctxt "ntmFollowUsOnTwitter:"
@@ -11342,16 +13025,40 @@ msgid "poll for opinions on how to implement new or change existing features"
 msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Bluesky</link1>: news"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Bluesky</link1>: news, polls, discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
 msgid "<link1>Facebook</link1>: news"
 msgstr "<link1>Facebook</link1>: новости"
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Mastodon</link1>: news"
+msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
 msgid "<link1>Mastodon</link1>: news, polls, discussions"
 msgstr "<link1>Mastodon</link1>: новости, опросы, обсуждения"
 
 msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Reddit</link1>: discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>UserEcho</link1>: feature requests, voting"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
 msgid "<link1>UserEcho</link1>: improvement ideas, discussions"
 msgstr "<link1>UserEcho</link1>: новые идеи, обсуждения"
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>X</link1>: news"
+msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
 msgid "<link1>X</link1>: news, polls, discussions"
@@ -11381,6 +13088,10 @@ msgctxt "ntmHostingProviderIntegrationNotYetConfigured:"
 msgid "SmartGit provides special support for $1. The integration can be configured in the Preferences."
 msgstr ""
 
+msgctxt "ntmLcTypeProblem:"
+msgid "If you experience problems with garbled file names/paths containing non-US-ASCII characters, consider to set the environment variables <tt>LC_ALL</tt>, or both <tt>LC_CTYPE</tt> and <tt>LANG</tt> to a country code which ends with \"<tt>.UTF-8</tt>\"."
+msgstr ""
+
 msgctxt "ntmMarkRepositoriesAsFavorite:"
 msgid "Git repositories marked as 'favorites' will be refreshed and fetched automatically in the background."
 msgstr ""
@@ -11401,6 +13112,10 @@ msgctxt "ntmRepositoryGitCleanup:"
 msgid "The repository '$1' contains a significant amount of loose or even unused 'objects'. Running a cleanup will reduce disk space and increase performance. SmartGit will try to do so, when it is idle."
 msgstr "Репозиторий '$1' содержит неиспользуемые 'объекты' и иной мусор. Запуск очистки сократит занимаемое место на диске и ускорит использование. SmartGit почистит сам во время простоя."
 
+msgctxt "ntmRepositoryRefsReadingManyLoose:"
+msgid "The repository '$1' contains many 'loose' refs which makes refreshing inefficient. Repacking the refs will improve performance."
+msgstr ""
+
 msgctxt "ntmSupportExpired:"
 msgid "To extend your support, please purchase an update license and upgrade to the latest SmartGit version."
 msgstr ""
@@ -11409,8 +13124,22 @@ msgctxt "ntmSupportExpired:"
 msgid "You may continue to use SmartGit, just your support period expired."
 msgstr ""
 
+msgctxt "ntmUpdateCheckChannelSubscribePolls:"
+msgid "Occasionally, you'll be invited to quick polls here in the notification area. Your feedback helps shape SmartGit's future. You can turn this off anytime in the Preferences."
+msgstr ""
+
 msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
+msgstr ""
+
+# TODO: Check if the variable range is correct.
+#| msgid "SmartGit 25.1.093 needs to be restarted now for the changes to take effect."
+msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+msgid "$1 needs to be restarted now for the changes to take effect."
+msgstr ""
+
+msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
 msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
@@ -11433,8 +13162,24 @@ msgctxt "ntmVoteForUs:"
 msgid "vote at <link1>alternativeto.net</link1>"
 msgstr ""
 
+msgctxt "ntmWslWorkaround:"
+msgid "To work around some problems with WSL, please check our documentation."
+msgstr ""
+
+msgctxt "nttCredentialHelper:"
+msgid "External Credential Helper detected"
+msgstr ""
+
 msgctxt "nttCredentialHelper:"
 msgid "External Credentials Helper detected"
+msgstr ""
+
+msgctxt "nttCredentialHelper:"
+msgid "Let SmartGit handle Authentication"
+msgstr ""
+
+msgctxt "nttFileMonitorDirectoriesExcluded:"
+msgid "Ignored directories are not monitored"
 msgstr ""
 
 msgctxt "nttFollowUsOnTwitter:"
@@ -11461,6 +13206,10 @@ msgctxt "nttGeneral:"
 msgid "Remind me later"
 msgstr "Напомнить позже"
 
+msgctxt "nttGeneral:"
+msgid "Skip this Poll"
+msgstr ""
+
 msgctxt "nttHighMemoryUsage:"
 msgid "Contact Support"
 msgstr "Написать в поддержку"
@@ -11475,6 +13224,10 @@ msgstr ""
 
 msgctxt "nttHostingProviderIntegrationNotYetConfigured:"
 msgid "Configure Now"
+msgstr ""
+
+msgctxt "nttLcTypeProblem:"
+msgid "Experience problems with non-US-ASCII file names?"
 msgstr ""
 
 msgctxt "nttMarkRepositoriesAsFavorite:"
@@ -11509,6 +13262,18 @@ msgctxt "nttRepositoryGitCleanup:"
 msgid "Run Garbage Collector Now"
 msgstr "Запустить очистку сейчас"
 
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Do not warn me again for this repository"
+msgstr ""
+
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Many loose refs"
+msgstr ""
+
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Repack"
+msgstr ""
+
 msgctxt "nttSupportExpired:"
 msgid "Purchase Update"
 msgstr ""
@@ -11517,8 +13282,28 @@ msgctxt "nttSupportExpired:"
 msgid "Your support period has expired on $1."
 msgstr ""
 
+msgctxt "nttUpdateCheck:"
+msgid "Quick Poll: $1"
+msgstr ""
+
+msgctxt "nttUpdateCheck:"
+msgid "Vote"
+msgstr ""
+
+msgctxt "nttUpdateCheckChannelSubscribePolls:"
+msgid "Turn on"
+msgstr ""
+
+msgctxt "nttUpdateCheckChannelSubscribePolls:"
+msgid "Want to influence SmartGit's development?"
+msgstr ""
+
 msgctxt "nttUpdateCheckFetchVersionStart:"
 msgid "Started downloading version $1 \\($2\\)."
+msgstr ""
+
+msgctxt "nttUpdateCheckFetchVersionStart:"
+msgid "Started downloading version $1."
 msgstr ""
 
 msgctxt "nttUpdateCheckFetchVersionSuccess:"
@@ -11541,8 +13326,20 @@ msgctxt "nttVoteForUs:"
 msgid "What do you like in SmartGit?"
 msgstr ""
 
+msgctxt "nttWslWorkaround:"
+msgid "It seems that you're running SmartGit in WSL."
+msgstr ""
+
+msgctxt "nttWslWorkaround:"
+msgid "Open Documentation"
+msgstr ""
+
 msgctxt "pop:"
 msgid "$1 succeeded."
+msgstr ""
+
+msgctxt "pop:"
+msgid "Already up-to-date"
 msgstr ""
 
 msgctxt "pop:"
@@ -11587,6 +13384,10 @@ msgstr ""
 
 msgctxt "pop:"
 msgid "The dropped directory is no Git repository."
+msgstr ""
+
+msgctxt "pop:"
+msgid "The working tree contains local changes."
 msgstr ""
 
 msgctxt "pop:"
@@ -11637,7 +13438,7 @@ msgctxt "ttpBranches:"
 msgid "<b>Incoming</b> from repository <b>$1</b> branch <b>$2</b> to branch <b>$3</b>"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
+msgctxt "ttpBranches:"
 msgid "<b>Last Updated By: </b>$1"
 msgstr ""
 
@@ -11645,12 +13446,12 @@ msgctxt "ttpBranches:"
 msgid "<b>Local Branch:\\t</b>$1"
 msgstr "<b>Локальная ветка:\\t</b>$1"
 
-msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
+msgctxt "ttpBranches:"
 msgid "<b>On: </b>$1"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
-msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
+msgctxt "ttpBranches:"
+msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>$3</b>"
 msgstr ""
 
 msgctxt "ttpBranches:"
@@ -11728,6 +13529,10 @@ msgstr "<b>Отслеживаемое состояние:\\t</b>1 коммит �
 msgctxt "ttpBranches:"
 msgid "<b>Tracking State:\\t</b>identical"
 msgstr "<b>Отслеживаемое состояние:\\t</b>Идентичны"
+
+msgctxt "ttpBranches:"
+msgid "<b>Worktree:\\t</b>$1"
+msgstr ""
 
 msgctxt "ttpBranches:"
 msgid "<b>\\t</b><col1>Tracking is configured in .git/config but the tracked branch is not present \\(any more\\)."
@@ -11830,6 +13635,10 @@ msgid "<b>Remotes:\\t</b>"
 msgstr ""
 
 msgctxt "ttpRepositories:"
+msgid "<b>Tracked Branch:\\t</b>$1"
+msgstr ""
+
+msgctxt "ttpRepositories:"
 msgid "<b>Tracked Branch:\\t</b>$1<col1>$2</col1>"
 msgstr "<b>Отслеживаемая ветка:\\t</b>$1<col1>$2</col1>"
 
@@ -11892,6 +13701,62 @@ msgstr ""
 msgctxt "ttpRepositories:"
 msgid "The remote repository contains new commits."
 msgstr "В удаленном репозитории есть новые изменения."
+
+msgctxt "wnd.mni:"
+msgid "About SmartGit"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Contact Support"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "License Agreement"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open File"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open in Terminal"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open in VSCode"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Reveal in Finder"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "SmartGit Website"
+msgstr ""
+
+msgctxt "wnd.mniBisectTryCommit:"
+msgid "Try Commit"
+msgstr ""
+
+msgctxt "wnd.mniFixCaseChange:"
+msgid "Fix Case-Change"
+msgstr ""
+
+msgctxt "wnd.mniIntegrateMain:"
+msgid "Integrate Main"
+msgstr ""
+
+msgctxt "wnd.mniShowInMyHistory:"
+msgid "Show in My History"
+msgstr ""
+
+msgctxt "wnd.mniWindow-maximize:"
+msgid "Zoom"
+msgstr ""
+
+msgctxt "wnd.mniWindowMaximizeRestore:"
+msgid "Maximize View"
+msgstr ""
 
 msgctxt "wndAnnotate.cmb:"
 msgid "Age"
@@ -12052,6 +13917,16 @@ msgstr "Документ"
 msgctxt "wndAnnotate.tab:"
 msgid "History of current line"
 msgstr "История текущей строки"
+
+# $1: File Name $2 Relative path
+msgctxt "wndAnnotate.tle:"
+msgid "$1 - Blame of $2"
+msgstr ""
+
+# $1: File Name ,$2 Relative path ,$3:CommitID
+msgctxt "wndAnnotate.tle:"
+msgid "$1 - Blame of $2@$3"
+msgstr ""
 
 msgctxt "wndAnnotate.tle:"
 msgid "$1 - Blame"
@@ -12341,6 +14216,11 @@ msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame \\(in progress...\\)"
 msgstr ""
 
+# [decode] msgid "Blame \(in progress…\)"
+msgctxt "wndDeepgit.lblBlameHeader:"
+msgid "Blame \\(in progress\\u2026\\)"
+msgstr ""
+
 msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame for"
 msgstr ""
@@ -12577,6 +14457,10 @@ msgctxt "wndDeepgit.mniDgFilterSetSelection:"
 msgid "Set Selection as Filter"
 msgstr ""
 
+msgctxt "wndDeepgit.mniDgFollowInsignificantMerges:"
+msgid "Follow Insignificant Merges \\(experimental\\)"
+msgstr ""
+
 msgctxt "wndDeepgit.mniDgFollowRenames:"
 msgid "Follow Renames"
 msgstr ""
@@ -12738,7 +14622,16 @@ msgid "Files changed in commit $1"
 msgstr ""
 
 msgctxt "wndDeepgit.tab:"
+msgid "Files"
+msgstr ""
+
+msgctxt "wndDeepgit.tab:"
 msgid "Navigation \\(initializing...\\)"
+msgstr ""
+
+# [decode] msgid "Navigation \(initializing…\)"
+msgctxt "wndDeepgit.tab:"
+msgid "Navigation \\(initializing\\u2026\\)"
 msgstr ""
 
 msgctxt "wndDeepgit.tab:"
@@ -12873,6 +14766,10 @@ msgctxt "wndEditor.mni:"
 msgid "LF \\(Unix, macOS\\)"
 msgstr ""
 
+msgctxt "wndEditor.mniBlockSelection:"
+msgid "Block Selection"
+msgstr ""
+
 msgctxt "wndEditor.mniEdit-undo:"
 msgid "Undo"
 msgstr ""
@@ -12923,6 +14820,10 @@ msgstr ""
 
 msgctxt "wndGit.indexEditor.mni:"
 msgid "Stage Line"
+msgstr ""
+
+msgctxt "wndGit.indexEditor.mni:"
+msgid "Stage Lines"
 msgstr ""
 
 msgctxt "wndGit.indexEditor.mni:"
@@ -13002,19 +14903,156 @@ msgid "$1 - Index Editor"
 msgstr "$1 - Редакторирование изменений"
 
 msgctxt "wndLog.hnt:"
+msgid "No commit matches the filter."
+msgstr ""
+
+msgctxt "wndLog.hnt:"
 msgid "No graph roots selected."
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Add $1 Git repositories to Group '$2'"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Continue in Background"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Continue with Description"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Copy Name <email>"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Drop All Notes"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Explain Commit"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "On Manual Intervention"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Reconfigure"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Reword '@ai' and 'WIP' commits"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Stop"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "generate \\(active\\)"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "github \\(active\\)"
+msgstr ""
+
+msgctxt "wndLog.mniCopyCommitId:"
+msgid "Copy"
 msgstr ""
 
 msgctxt "wndLog.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr "Исправить изменение регистра"
 
+msgctxt "wndLog.mniGitNoteAdd:"
+msgid "Add Note"
+msgstr ""
+
+# [decode] msgid "Graph \(Initializing Subtree-Cache…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Initializing Subtree-Cache\\u2026\\)"
+msgstr ""
+
+# [decode] msgid "Graph \(Loading…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Loading\\u2026\\)"
+msgstr ""
+
+# [decode] msgid "Graph \(Running log…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Running log\\u2026\\)"
+msgstr ""
+
+# [decode] msgid "Graph \(Scanning WT…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Scanning WT\\u2026\\)"
+msgstr ""
+
+msgctxt "wndLog.tbt:"
+msgid "Hidden toolbar items..."
+msgstr ""
+
 msgctxt "wndLog.tbt:"
 msgid "Refresh information from GitHub."
 msgstr "Обновить информацию с GitHub."
 
+#| msgid "Rewording 1 commits\\u2026"
+msgctxt "wndLog.tbtAi.commitMessageCompose:"
+msgid "Rewording $1 commits\\u2026"
+msgstr ""
+
+msgctxt "wndLog.tbtFlowContext:"
+msgid "Start a new Git-Flow feature."
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Base"
+msgstr ""
+
 msgctxt "wndProject.mni:"
 msgid "Log Selection"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "New_key"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "PR_Review"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Review_Tool"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Show Rewritten Behind Commits"
+msgstr ""
+
+msgctxt "wndProject.mniCopyCommitId:"
+msgid "Copy"
+msgstr ""
+
+msgctxt "wndProject.mniFixCaseChange:"
+msgid "Fix Case-Change"
+msgstr ""
+
+msgctxt "wndProject.mniOpen:"
+msgid "Open"
 msgstr ""
 
 msgctxt "wndStd.btn:"
@@ -13046,7 +15084,24 @@ msgid "Commit files: select 1 commit\\nDiff between Commits: select 2 commits"
 msgstr ""
 
 msgctxt "wndStd.hnt:"
+msgid "Filter by repository name or path"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
 msgid "Loading ..."
+msgstr ""
+
+# [decode] msgid "Loading …"
+msgctxt "wndStd.hnt:"
+msgid "Loading \\u2026"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "No files below the selected directory"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "No graph roots selected."
 msgstr ""
 
 msgctxt "wndStd.hnt:"
@@ -13055,6 +15110,14 @@ msgstr ""
 
 msgctxt "wndStd.hnt:"
 msgid "No locally changed files"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "The repository's\\nreflog is empty."
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "This repository has\\nno stashes yet."
 msgstr ""
 
 msgctxt "wndStd.lbl:"
@@ -13090,6 +15153,10 @@ msgid "All files, incl. ignored"
 msgstr ""
 
 msgctxt "wndStd.mni:"
+msgid "All my branches"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Apply Stash"
 msgstr ""
 
@@ -13099,6 +15166,38 @@ msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Changed files"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Close Others"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Close to the Right"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Continue in Background"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Continue with Description"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Copy Path"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Don't Show Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Drop All Notes"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Explain Commit"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -13122,11 +15221,23 @@ msgid "Log"
 msgstr ""
 
 msgctxt "wndStd.mni:"
-msgid "On master: SmartGit: automatic stash on Pull."
+msgid "On $1: SmartGit: automatic stash on Pull."
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "On Manual Intervention"
 msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Only current branch \\(HEAD\\)"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Open in GitHub"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Open"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -13146,7 +15257,31 @@ msgid "Reset"
 msgstr ""
 
 msgctxt "wndStd.mni:"
+msgid "Reword '@ai' and 'WIP' commits"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Save Stash"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show 'My' Pull Requests \\(involving me\\)"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show 'My' and Unassigned Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show All Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show Tags"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -13157,6 +15292,10 @@ msgctxt "wndStd.mni:"
 msgid "Sort by Path"
 msgstr ""
 
+msgctxt "wndStd.mni:"
+msgid "Stop"
+msgstr ""
+
 msgctxt "wndStd.mniBisectTryCommit:"
 msgid "Try Commit"
 msgstr ""
@@ -13165,8 +15304,20 @@ msgctxt "wndStd.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr ""
 
+msgctxt "wndStd.mniGitNoteAdd:"
+msgid "Add Note"
+msgstr ""
+
+msgctxt "wndStd.mniIndexEditor:"
+msgid "Edit in Index Editor"
+msgstr ""
+
 msgctxt "wndStd.mniIntegrateMain:"
 msgid "Integrate Main"
+msgstr ""
+
+msgctxt "wndStd.mniStdCiResultOpenInBrowser:"
+msgid "Open CI Result"
 msgstr ""
 
 msgctxt "wndStd.mniStdOpenSubmodule:"
@@ -13175,6 +15326,18 @@ msgstr ""
 
 msgctxt "wndStd.mniStdOpenSubmoduleFromFile:"
 msgid "Open this Submodule"
+msgstr ""
+
+msgctxt "wndStd.mniStdProviderOpenFileInBrowser:"
+msgid "Open in GitHub"
+msgstr ""
+
+msgctxt "wndStd.mniStdProviderOpenInBrowser:"
+msgid "Open in $1"
+msgstr ""
+
+msgctxt "wndStd.mniStdProviderOpenRefInBrowser:"
+msgid "Open in GitHub"
 msgstr ""
 
 msgctxt "wndStd.mniStdSetModeHistory:"
@@ -13193,13 +15356,33 @@ msgctxt "wndStd.tbr:"
 msgid "Submodule"
 msgstr ""
 
+msgctxt "wndStd.tbt:"
+msgid "History"
+msgstr ""
+
+msgctxt "wndStd.tbt:"
+msgid "Show filter input field."
+msgstr ""
+
+msgctxt "wndStd.tbtFlowFeatureFinish:"
+msgid "Finish the current feature branch."
+msgstr ""
+
 msgctxt "wndStd.tbtFlowFeatureStart:"
 msgid "Start a new feature branch."
+msgstr ""
+
+msgctxt "wndStd.tbtIntegrateMain:"
+msgid "Integrate latest changes from the main branch into the current feature branch."
 msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).lblStatusBarMessage:"
 msgid "Ready"
 msgstr "Готов"
+
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
+msgid "Enter Full Screen"
+msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
 msgid "Full Screen"
@@ -13208,6 +15391,10 @@ msgstr "Полный экран"
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
 msgid "Maximize"
 msgstr "Развернуть"
+
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
+msgid "Zoom"
+msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore:"
 msgid "Restore"
@@ -13715,10 +15902,6 @@ msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).lbl:"
 msgid "Files"
-msgstr ""
-
-msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
-msgid "Show Rewritten Behind Commits"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mni:"
@@ -14367,6 +16550,10 @@ msgstr "Показывать только выбранные ветки и ме�
 
 msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Show Only Selected Refs"
+msgstr ""
+
+msgctxt "wnd(Log|Project|Std|).mni:"
+msgid "Show Rewritten Behind Commits"
 msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mni:"
@@ -15777,10 +17964,6 @@ msgctxt "wnd(Log|Project|Std|).tab:"
 msgid "Repositories"
 msgstr "Репозитории"
 
-msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
-msgid "History"
-msgstr "История"
-
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Add Branch"
 msgstr "Создать ветку"
@@ -15864,6 +18047,10 @@ msgstr ""
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Git-Flow"
 msgstr "Git-Flow"
+
+msgctxt "wnd(Log|Project|Std|).tbr:"
+msgid "History"
+msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Ignore WS"
@@ -16289,6 +18476,10 @@ msgctxt "wnd(Log|Project|Std|).tle:"
 msgid "$1 \\[$2\\] - Log for $3"
 msgstr ""
 
+msgctxt "wnd(Log|Std|).mniOpen:"
+msgid "Open from Working Tree"
+msgstr ""
+
 #~ msgctxt "(wndLog|wndProject).lblStatusBarMessage:"
 #~ msgid "Please wait"
 #~ msgstr "Пожалуйста, подождите..."
@@ -16297,12 +18488,28 @@ msgstr ""
 #~ msgid "\\[$1\\] - $2"
 #~ msgstr ""
 
+#~ msgctxt "dlgSgAbortRebasingConfirm.fur:"
+#~ msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
+#~ msgstr "Рабочий каталог находится в состоянии 'перемещения'. Вы можете прервать перемещение. Если хотите просто пропустить текущий патч, используйте Ветки\\|Переместить\\|Пропустить.\\n\\nПри отмене будут удалены любые локальные изменения \\(путем вызова 'git rebase --abort'\\)!"
+
 #~ msgctxt "dlgSgAbortRevertingConfirm.hdl"
 #~ msgid "Do you want to abort the current revert?"
 #~ msgstr ""
 
+#~ msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
+#~ msgid "Skip large files \\(\"partial clone\"\\)"
+#~ msgstr "Пропустить большие файлы \\(\"частичное клонирование\"\\)"
+
+#~ msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
+#~ msgid "Simple commit \\(one parent, \"squash\"\\)"
+#~ msgstr ""
+
 #~ msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
 #~ msgid "\\[$1\\] - \\[$2\\] - $3"
+#~ msgstr ""
+
+#~ msgctxt "dlgSgErrorUtilsClientException.fur:"
+#~ msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
 #~ msgstr ""
 
 #~ msgctxt "dlgSgHostingProviderAdd.inf"
@@ -16313,6 +18520,70 @@ msgstr ""
 #~ msgid "Generate a new API token for $1"
 #~ msgstr ""
 
+#~ msgctxt "dlgSgPushForced.hdl:"
+#~ msgid "Do you want to force-push \\(replace\\) the remote branch?"
+#~ msgstr ""
+
+#~ msgctxt "dlgSgRepositorySettings.inf:"
+#~ msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
+#~ msgstr "Здесь вы можете изменить настройки Git для репозитория. Параметры по умолчанию можно найти в меню Параметры"
+
 #~ msgctxt "dlgSgResetAdv.inf"
 #~ msgid "Reset the current branch (HEAD) to the selected commit and optionally update Index and working tree."
 #~ msgstr ""
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
+#~ msgid "Set to $1 \\(\"ours\", $2\\)"
+#~ msgstr ""
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
+#~ msgid "Set to $1 \\(\"theirs\", $2\\)"
+#~ msgstr ""
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
+#~ msgid "Set to rebase target \\(\"theirs\", $1\\)"
+#~ msgstr ""
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
+#~ msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
+#~ msgstr ""
+
+#~ msgctxt "dlgSgSetupStdWnd.fur:"
+#~ msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
+#~ msgstr ""
+
+#~ msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
+#~ msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
+#~ msgstr ""
+
+#~ msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
+#~ msgid "Authentication to the SVN repository '$1' failed with error: $2'"
+#~ msgstr ""
+
+#~ msgctxt "dlgTxtEditor.fileModified.hdl:"
+#~ msgid "The file config was changed. Reload it?"
+#~ msgstr ""
+
+#~ msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
+#~ msgid "<b>Last Updated By: </b>$1"
+#~ msgstr ""
+
+#~ msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
+#~ msgid "<b>On: </b>$1"
+#~ msgstr ""
+
+#~ msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
+#~ msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
+#~ msgstr ""
+
+#~ msgctxt "wndStd.mni:"
+#~ msgid "On master: SmartGit: automatic stash on Pull."
+#~ msgstr ""
+
+#~ msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
+#~ msgid "Show Rewritten Behind Commits"
+#~ msgstr ""
+
+#~ msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
+#~ msgid "History"
+#~ msgstr "История"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -733,10 +733,6 @@ msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr ""
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
-msgid "\\[$1\\] - $2"
-msgstr ""
-
 msgctxt "dlgScConflictSolverUnresolvedConflicts.chk"
 msgid "Don't warn me again"
 msgstr "Не предупреждать больше"
@@ -2373,13 +2369,13 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr "Вы можете потерять неотправленные изменения, восстановить ветку\\(и\\) будет затруднительно!"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
-msgid "Do you want to delete $1 local branches?"
-msgstr "Вы хотите удалить $1 локальные ветки?"
-
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
+
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
+msgid "Do you want to delete $1 local branches?"
+msgstr "Вы хотите удалить $1 локальные ветки?"
 
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle"
 msgid "Delete"
@@ -2413,13 +2409,13 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.fur:"
 msgid "Your local branch is tracking branch '$1'. Decide whether you also want to delete this branch from the remote repository."
 msgstr "Локальная ветка отслеживает '$1'. Решите, хотите ли также удалить отслеживаемую ветку во внешнем репозитории."
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
-msgid "Do you want to delete the local branch '$1'?"
-msgstr "Вы хотите удалить локальную ветку '$1'?"
-
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
+
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
+msgid "Do you want to delete the local branch '$1'?"
+msgstr "Вы хотите удалить локальную ветку '$1'?"
 
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle"
 msgid "Delete"
@@ -2437,6 +2433,10 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "Удалить"
 
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
+msgid "Delete from remote repository '$1'"
+msgstr "Удалить во внешнем репозитории '$1'"
+
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
 msgstr ""
@@ -2445,13 +2445,13 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
-msgid "Delete from remote repository '$1'"
-msgstr "Удалить во внешнем репозитории '$1'"
-
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
 msgstr "Если не удалить ветку во внешнем репозитории, то она может вернуться при следующем получении обновлений."
+
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
+msgid "Do you want to delete the branch '$1'?"
+msgstr "Хотите удалить ветку '$1'?"
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the branch '$1'?"
@@ -2460,10 +2460,6 @@ msgstr ""
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr ""
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
-msgid "Do you want to delete the branch '$1'?"
-msgstr "Хотите удалить ветку '$1'?"
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle"
 msgid "Delete"
@@ -3503,10 +3499,6 @@ msgstr ""
 
 msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
 msgid "The right file is not editable because of mixed line-endings."
-msgstr ""
-
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
-msgid "\\[$1\\] - \\[$2\\] - $3"
 msgstr ""
 
 msgctxt "dlgSgConflictResolverExternalStarted.btn:"
@@ -7511,10 +7503,6 @@ msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
-msgstr ""
-
-msgctxt "dlgSgProviderGenerateToken.hdl"
-msgid "Generate a new API token for $1"
 msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.inf"

--- a/po/ru_RU.po
+++ b/po/ru_RU.po
@@ -2510,7 +2510,7 @@ msgstr ""
 
 msgctxt "dlgSgAiSetup.hdl:"
 msgid "Please wait"
-msgstr ""
+msgstr "Пожалуйста, подождите..."
 
 msgctxt "dlgSgAiSetup.hdl:"
 msgid "Stash Messages"
@@ -3450,7 +3450,7 @@ msgstr ""
 
 msgctxt "dlgSgClone.chk:"
 msgid "Skip large files \\(\"partial clone\"\\)"
-msgstr ""
+msgstr "Пропустить большие файлы \\(\"частичное клонирование\"\\)"
 
 msgctxt "dlgSgClone.edt:"
 msgid "Check Out Branch"
@@ -15358,7 +15358,7 @@ msgstr ""
 
 msgctxt "wndStd.tbt:"
 msgid "History"
-msgstr ""
+msgstr "История"
 
 msgctxt "wndStd.tbt:"
 msgid "Show filter input field."
@@ -18050,7 +18050,7 @@ msgstr "Git-Flow"
 
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "History"
-msgstr ""
+msgstr "История"
 
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Ignore WS"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6931,7 +6931,7 @@ msgctxt "dlgSgPreferences.lbl:"
 msgid "Changing these low-level properties can be harmful to the stability or performance of SmartGit. You should only continue if you are sure of what you are doing. Changed properties with a trailing \\* need a restart to be applied."
 msgstr "更改这些低级别属性可能会损害 SmartGit 的稳定性或性能。只有在确定自己在做什么的情况下才能继续。结尾含 \\* 的属性更改之后需要重新启动才能生效。"
 
-msgctxt "dlgSgPreferences.lbl\"Checkout \\(Switch branch\\)\""
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Checkout \\(Switch branch\\)"
 msgstr ""
 
@@ -7179,7 +7179,7 @@ msgctxt "dlgSgPreferences.mni:"
 msgid "GitHub"
 msgstr ""
 
-msgctxt "dlgSgPreferences.mni\"GitLab \\(Self Hosted\\)\""
+msgctxt "dlgSgPreferences.mni:"
 msgid "GitLab \\(Self Hosted\\)"
 msgstr ""
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2013,10 +2013,6 @@ msgctxt "dlgSgAbortRebasingConfirm.tle:"
 msgid "Abort"
 msgstr "丢弃"
 
-msgctxt "dlgSgAbortRebasingConfirm.tle:"
-msgid "Abort"
-msgstr ""
-
 msgctxt "dlgSgAbortRevertingConfirm.btn:"
 msgid "Abort Revert"
 msgstr "中止还原"
@@ -2373,10 +2369,6 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr "您确定要删除 $1 本地分支吗？"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
-msgid "Do you want to delete $1 local branches?"
-msgstr ""
-
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle:"
 msgid "Delete"
 msgstr "删除"
@@ -2413,10 +2405,6 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "您确定要删除本地分支 “$1” 吗？"
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
-msgid "Do you want to delete the local branch '$1'?"
-msgstr ""
-
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle:"
 msgid "Delete"
 msgstr "删除"
@@ -2432,10 +2420,6 @@ msgstr ""
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "删除"
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
-msgid "Delete from remote repository '$1'"
-msgstr ""
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
@@ -3759,10 +3743,6 @@ msgid "Discard"
 msgstr "丢弃"
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
-msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-msgstr ""
-
-msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Commit '$1' was not found in repository."
 msgstr "未在仓库内找到提交 '$1'."
 
@@ -3777,6 +3757,10 @@ msgstr "位于 '$1' 的仓库的 GIT_DIR 不存在。"
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Repository '$1' is not valid."
 msgstr "仓库 “$1” 无效。"
+
+msgctxt "dlgSgErrorUtilsClientException.fur:"
+msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
+msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "svn: $1"
@@ -10306,16 +10290,16 @@ msgid "What to do with the working tree or Index changes?"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
-msgid "Reset"
-msgstr ""
-
-msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Checkout"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
 msgstr "拉取"
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Reset"
+msgstr ""
 
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
 msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
@@ -14814,11 +14798,6 @@ msgctxt "wnd(Log|Project|Std|).mniFixup:"
 msgid "Use Message for Commit"
 msgstr "修复"
 
-#, fuzzy
-msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
-msgid "Configure"
-msgstr "配置"
-
 msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure Features"
 msgstr ""
@@ -15009,11 +14988,6 @@ msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open from Working Tree"
 msgstr "打开"
 
-#, fuzzy
-msgctxt "wnd(Log|Project|Std|).mniOpen:"
-msgid "Open from Working Tree"
-msgstr "打开"
-
 msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open"
 msgstr ""
@@ -15109,10 +15083,6 @@ msgstr "跳过"
 msgctxt "wnd(Log|Project|Std|).mniRebaseStep:"
 msgid "Step"
 msgstr "步骤"
-
-msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
-msgid "Rebase to HEAD"
-msgstr "变基至 HEAD"
 
 msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD \\($1\\)"
@@ -15293,10 +15263,6 @@ msgstr "配置"
 msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase:"
 msgid "Dump Database"
 msgstr "转储数据库"
-
-msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
-msgid "Create Pull Request"
-msgstr "创建拉取请求"
 
 msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Merge Request"
@@ -16209,10 +16175,6 @@ msgstr "将 HEAD 提交应用于所选提交。"
 msgctxt "wnd(Log|Project|Std|).tbtRefresh:"
 msgid "Refresh the log view."
 msgstr "刷新日志视图。"
-
-msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
-msgid "Fetch commits from current remote repository."
-msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from all remote repositories."

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -39,7 +39,7 @@ msgstr "确定"
 
 msgctxt "*.chk:"
 msgid "Don't show again"
-msgstr ""
+msgstr "不再显示"
 
 msgctxt "*.hnt:"
 msgid "Filter"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -18499,25 +18499,13 @@ msgctxt "wnd(Log|Std|).mniOpen:"
 msgid "Open from Working Tree"
 msgstr ""
 
-#~ msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
-#~ msgid "\\[$1\\] - $2"
-#~ msgstr ""
-
 #~ msgctxt "dlgSgAbortRebasingConfirm.fur:"
 #~ msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 #~ msgstr "您的工作区处于 “变基” 状态。你可以放弃变基; 如果您只想跳过当前的补丁，请使用 分支 \\| 变基 \\| 将 HEAD 变基至。\\n\\n中止将清除任何本地修改 \\(通过调用 “git reset --hard”\\)！"
 
-#~ msgctxt "dlgSgAbortRevertingConfirm.hdl"
-#~ msgid "Do you want to abort the current revert?"
-#~ msgstr ""
-
 #~ msgctxt "dlgSgAbortRevertingConfirm.tle"
 #~ msgid "Discard"
 #~ msgstr "丢弃"
-
-#~ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
-#~ msgid "Do you want to delete the branch '$1'?"
-#~ msgstr ""
 
 #~ msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
 #~ msgid "Skip large files \\(\"partial clone\"\\)"
@@ -18526,14 +18514,6 @@ msgstr ""
 #~ msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
 #~ msgid "Simple commit \\(one parent, \"squash\"\\)"
 #~ msgstr "简单提交 \\(1个父系, “压缩”\\)"
-
-#~ msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
-#~ msgid "\\[$1\\] - \\[$2\\] - $3"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgErrorUtilsClientException.fur:"
-#~ msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-#~ msgstr ""
 
 #~ msgctxt "dlgSgFlowHotfixFinish.hdl"
 #~ msgid "Finish a hotfix"
@@ -18547,18 +18527,6 @@ msgstr ""
 #~ msgid "Configure a new hosting provider account"
 #~ msgstr "配置新的主机提供商账户"
 
-#~ msgctxt "dlgSgHostingProviderAdd.inf"
-#~ msgid "Set or select the options according to your account."
-#~ msgstr ""
-
-#~ msgctxt "dlgSgOutput.lbl:"
-#~ msgid "stash failed \\(return code $1\\)"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgProviderGenerateToken.hdl"
-#~ msgid "Generate a new API token for $1"
-#~ msgstr ""
-
 #~ msgctxt "dlgSgPushForced.hdl:"
 #~ msgid "Do you want to force-push \\(replace\\) the remote branch?"
 #~ msgstr "你想强制推送 \\(替换\\) 远程分支吗？"
@@ -18566,10 +18534,6 @@ msgstr ""
 #~ msgctxt "dlgSgRepositorySettings.inf:"
 #~ msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
 #~ msgstr "在这里, 您可以编辑该仓库的 Git 设置. 默认设置可以在首选项中找到."
-
-#~ msgctxt "dlgSgResetAdv.inf"
-#~ msgid "Reset the current branch (HEAD) to the selected commit and optionally update Index and working tree."
-#~ msgstr ""
 
 #~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
 #~ msgid "Set to $1 \\(\"ours\", $2\\)"
@@ -18591,14 +18555,6 @@ msgstr ""
 #~ msgid "Reveal Commit"
 #~ msgstr "显示提交"
 
-#~ msgctxt "dlgSgRollbackToCommit.hdl"
-#~ msgid "Do you want to rollback the Index to the state of commit $1?"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgRollbackToFiles.hdl"
-#~ msgid "Do you want to rollback the selected files to the state of commit $1?"
-#~ msgstr ""
-
 #~ msgctxt "dlgSgSetupStdWnd.fur:"
 #~ msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 #~ msgstr "对于 \\*初出茅庐的 Git 用户\\* ，我们推荐使用标准窗口。如果您对 SmartGit 的老版本十分熟悉，或许会对标准窗口与自己熟悉的界面 \\*十分不同\\* 感到诧异。若您对旧有体验情有独钟，可以考虑启用 \\*日志图\\* 或 \\*工作区\\* 窗口。"
@@ -18615,34 +18571,10 @@ msgstr ""
 #~ msgid "The file config was changed. Reload it?"
 #~ msgstr "该文件配置已变更. 是否重新加载?"
 
-#~ msgctxt "ntmUpdateCheckFetchVersionSuccess:"
-#~ msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
-#~ msgstr ""
-
-#~ msgctxt "nttUpdateCheck:"
-#~ msgid "Quick Poll: $1"
-#~ msgstr ""
-
-#~ msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
-#~ msgid "<b>Last Updated By: </b>$1"
-#~ msgstr ""
-
-#~ msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
-#~ msgid "<b>On: </b>$1"
-#~ msgstr ""
-
-#~ msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
-#~ msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
-#~ msgstr ""
-
 #, fuzzy
 #~ msgctxt "wndProject.col:"
 #~ msgid "LFS"
 #~ msgstr "LFS"
-
-#~ msgctxt "wndStd.mni:"
-#~ msgid "On master: SmartGit: automatic stash on Pull."
-#~ msgstr ""
 
 #~ msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
 #~ msgid "Show Rewritten Behind Commits"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -125,7 +125,7 @@ msgctxt "dlgCommitGitHubConfirmEmail.fur"
 msgid "If this repository is open-source, you might want to hide your email address, as \\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\], and use instead <username>@users.noreply.github.com."
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.hdl%1"
+msgctxt "dlgCommitGitHubConfirmEmail.hdl"
 msgid "Commit with default email address $1?"
 msgstr ""
 
@@ -325,11 +325,11 @@ msgctxt "dlgProgress.tle:"
 msgid "Verifying executables"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.fur%1"
+msgctxt "dlgQBugFileSendingFailed.fur"
 msgid "Maybe you need to configure a proxy or our server is temporarily down.\\nDetails: $1"
 msgstr "也许您需要配置代理才能访问我们服务器或我们的服务器暂时关闭。\\n详情：$1"
 
-msgctxt "dlgQBugFileSendingFailed.hdl%1"
+msgctxt "dlgQBugFileSendingFailed.hdl"
 msgid "Could not send the crash logs to $1"
 msgstr "无法将崩溃记录发送到 $1"
 
@@ -401,7 +401,7 @@ msgctxt "dlgQDockManagerClosedView.fur"
 msgid "To reopen it again, use the corresponding menu item from the Window menu."
 msgstr "要再次重新打开，请使用窗口菜单中的相应菜单项。"
 
-msgctxt "dlgQDockManagerClosedView.hdl%1"
+msgctxt "dlgQDockManagerClosedView.hdl"
 msgid "You've closed the view '$1'."
 msgstr "您已经关闭了视图 $1。"
 
@@ -417,7 +417,7 @@ msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur"
 msgid "To save to a different file, click 'Cancel'."
 msgstr "要保存到其他文件，请单击 “取消”。"
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl%1"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl"
 msgid "The file $1 already exists. Do you want to overwrite it?"
 msgstr "文件 $1 已存在。你确定覆盖吗？"
 
@@ -449,11 +449,11 @@ msgctxt "dlgQFrameManagerExit.tle"
 msgid "Exit"
 msgstr "退出"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.fur%2"
+msgctxt "dlgQIntegerInputProviderInvalidValue.fur"
 msgid "Port must be in the range from $1 to $2."
 msgstr "端口必须在 $1 到 $2 的范围内。"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.hdl%1"
+msgctxt "dlgQIntegerInputProviderInvalidValue.hdl"
 msgid "The text in field '$1' is not valid."
 msgstr "字段 “$1” 中的文本无效。"
 
@@ -513,7 +513,7 @@ msgctxt "dlgQProxyConnectionFailed.fur"
 msgid "Details: syntevo.com"
 msgstr "详情：syntevo.com"
 
-msgctxt "dlgQProxyConnectionFailed.hdl%1"
+msgctxt "dlgQProxyConnectionFailed.hdl"
 msgid "Could not connect to $1."
 msgstr "无法连接到 $1。"
 
@@ -549,7 +549,7 @@ msgctxt "dlgQUpdateCheckForNewVersion.tle"
 msgid "Check for New Version"
 msgstr "检查新版本"
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.fur%1"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.fur"
 msgid "Details: Failed to connect to '$1'."
 msgstr "详细信息：无法连接到 “$1”。"
 
@@ -577,7 +577,7 @@ msgctxt "dlgQUpdateCheckLatestBuild.tle"
 msgid "Check for Latest Build"
 msgstr "检查最新编译版本"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur%1"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur"
 msgid "Details: $1"
 msgstr "详细信息：$1"
 
@@ -673,7 +673,7 @@ msgctxt "dlgScAboutUpdateInstallation.fur"
 msgid "This will take a few moments and has to restart SmartGit."
 msgstr "这将需要些时间，必须重新启动 SmartGit。"
 
-msgctxt "dlgScAboutUpdateInstallation.hdl%1"
+msgctxt "dlgScAboutUpdateInstallation.hdl"
 msgid "Do you want to upgrade the installation directory to version $1?"
 msgstr "是否要将安装目录升级到版本 $1？"
 
@@ -729,11 +729,11 @@ msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl"
 msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr "文件包含混合不一致的行尾序列."
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%1"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - 冲突解决工具"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle%2"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 msgid "\\[$1\\] - $2"
 msgstr ""
 
@@ -925,7 +925,7 @@ msgctxt "dlgScDevOpsCredentials.edt:"
 msgid "User Name"
 msgstr "用户名"
 
-msgctxt "dlgScDevOpsCredentials.hdl%1"
+msgctxt "dlgScDevOpsCredentials.hdl"
 msgid "Login to '$1'"
 msgstr "登录 “$1”"
 
@@ -957,7 +957,7 @@ msgctxt "dlgScDevOpsSslClientCertificate.edt:"
 msgid "Passphrase"
 msgstr "密码"
 
-msgctxt "dlgScDevOpsSslClientCertificate.hdl%1"
+msgctxt "dlgScDevOpsSslClientCertificate.hdl"
 msgid "Select the client certificate for $1"
 msgstr "选择 $1 的客户端证书"
 
@@ -1049,7 +1049,7 @@ msgctxt "dlgScDialogAssertionHandlerOutOfMemory.btn:"
 msgid "Force Exit"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur%1"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur"
 msgid "It is strongly recommended to restart SmartGit.\\n\\nTo increase the maximum memory limit edit $1, increase the value of the -Xmx option, for example to -Xmx1024m \\(or add it if not yet existing\\) and restart SmartGit."
 msgstr ""
 
@@ -1069,11 +1069,11 @@ msgctxt "dlgScEvaluationReminderContinue.btn:"
 msgid "Register"
 msgstr "注册"
 
-msgctxt "dlgScEvaluationReminderContinue.fur%2"
+msgctxt "dlgScEvaluationReminderContinue.fur"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
 msgstr "在商业环境中使用 SmartGit，您必须 \\[$1 购买许可证 \\]。\\n\\n对于 \\[$2 某些用途 \\]，我们授予免费许可证。"
 
-msgctxt "dlgScEvaluationReminderContinue.hdl%1"
+msgctxt "dlgScEvaluationReminderContinue.hdl"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr "您的 SmartGit 试用将在 $1 天后结束。"
 
@@ -1081,11 +1081,11 @@ msgctxt "dlgScEvaluationReminderContinue.tle"
 msgid "Evaluation"
 msgstr "试用"
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl%2"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl"
 msgid "Cannot run program \"$1\": $2"
 msgstr "无法运行 \"$1\": $2"
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle%1"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - 冲突解决工具"
 
@@ -1249,7 +1249,7 @@ msgctxt "dlgScFilePatternsEdit.edt:"
 msgid "File Pattern"
 msgstr "文件模式"
 
-msgctxt "dlgScFilePatternsEdit.hdl%1"
+msgctxt "dlgScFilePatternsEdit.hdl"
 msgid "Language: $1"
 msgstr "语言：$1"
 
@@ -1381,7 +1381,7 @@ msgctxt "dlgScJiraResolveIssue.edt:"
 msgid "Summary"
 msgstr "摘要"
 
-msgctxt "dlgScJiraResolveIssue.hdl%1"
+msgctxt "dlgScJiraResolveIssue.hdl"
 msgid "Resolve issue $1"
 msgstr "解决问题 $1"
 
@@ -1513,7 +1513,7 @@ msgctxt "dlgScPropertiesReset.fur"
 msgid "The new values will be active after restarting SmartGit."
 msgstr "新值只有在重新启动 SmartGit 后才会激活。"
 
-msgctxt "dlgScPropertiesReset.hdl%1"
+msgctxt "dlgScPropertiesReset.hdl"
 msgid "Do you want to reset $1 system properties to their defaults?"
 msgstr "是否要将系统属性 $1 重置为默认值？"
 
@@ -1529,7 +1529,7 @@ msgctxt "dlgScPropertyEdit.hdl"
 msgid "Edit low-level property value"
 msgstr "编辑低级属性值"
 
-msgctxt "dlgScPropertyEdit.inf%1"
+msgctxt "dlgScPropertyEdit.inf"
 msgid "Set the value for property '$1'"
 msgstr "设置属性 “$1” 的值"
 
@@ -1901,7 +1901,7 @@ msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle"
 msgid "SmartGit Installation Update"
 msgstr "SmartGit 安装更新"
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur%1"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur"
 msgid "Please get rid of '$1' manually and retry the upgrade."
 msgstr "请手动删除 '$1' 并重试."
 
@@ -1917,7 +1917,7 @@ msgctxt "dlgScUpdateInstallationUpgrade.btn:"
 msgid "Upgrade Now"
 msgstr "立即升级"
 
-msgctxt "dlgScUpdateInstallationUpgrade.fur%1"
+msgctxt "dlgScUpdateInstallationUpgrade.fur"
 msgid "The new version $1 has been downloaded which needs to be installed."
 msgstr "新版本 $1 已经下载，需要安装。"
 
@@ -2113,7 +2113,7 @@ msgctxt "dlgSgAbout.tle"
 msgid "About SmartGit"
 msgstr "关于 SmartGit"
 
-msgctxt "dlgSgApplicationAlreadyRunning.fur%1"
+msgctxt "dlgSgApplicationAlreadyRunning.fur"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
 msgstr ""
 
@@ -2157,7 +2157,7 @@ msgctxt "dlgSgAuthenticationShowPassword.edt:"
 msgid "Password"
 msgstr "密码"
 
-msgctxt "dlgSgAuthenticationShowPassword.tle%1"
+msgctxt "dlgSgAuthenticationShowPassword.tle"
 msgid "Password for $1"
 msgstr "$1 的密码"
 
@@ -2201,7 +2201,7 @@ msgctxt "dlgSgBisectResult.btn:"
 msgid "Leave Bisect"
 msgstr "离开二分"
 
-msgctxt "dlgSgBisectResult.fur%1"
+msgctxt "dlgSgBisectResult.fur"
 msgid "$1"
 msgstr "$1"
 
@@ -2325,7 +2325,7 @@ msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr "单击 “取消” 以选择其他分支名称。"
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl%1"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr "分支 “$1” 已经存在。你想覆盖吗？"
 
@@ -2377,7 +2377,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl%1"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl"
 msgid "Do you want to delete $1 local branches?"
 msgstr "您确定要删除 $1 本地分支吗？"
 
@@ -2417,7 +2417,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl%1"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "您确定要删除本地分支 “$1” 吗？"
 
@@ -2445,7 +2445,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr "从远程仓库中删除 '$1'"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk%1"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr "您要删除远程分支 “$1” 吗？"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl%1"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
 msgid "Do you want to delete the branch '$1'?"
 msgstr ""
 
@@ -2477,7 +2477,7 @@ msgctxt "dlgSgBranchTrackingResetConfirm.fur"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "必要的配置将在 .git/config 文件中执行。"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.hdl%2"
+msgctxt "dlgSgBranchTrackingResetConfirm.hdl"
 msgid "Should branch '$1' stop tracking '$2'?"
 msgstr "分支 '$1' 是否应该停止跟踪 '$2'？"
 
@@ -2493,7 +2493,7 @@ msgctxt "dlgSgBranchTrackingSetConfirm.fur"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "必要的配置将在 .git/config 文件中执行。"
 
-msgctxt "dlgSgBranchTrackingSetConfirm.hdl%2"
+msgctxt "dlgSgBranchTrackingSetConfirm.hdl"
 msgid "Do you want to configure '$1' to track '$2'?"
 msgstr "你想配置 '$1' 跟踪 '$2' 吗？"
 
@@ -2569,7 +2569,7 @@ msgctxt "dlgSgCheckoutFastForwardMerge.fur"
 msgid "Fast-forward-merging automatically moves the branch forward to the tracked remote branch."
 msgstr "快进合并会自动将分支向前移动到跟踪的远程分支。"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.hdl%1"
+msgctxt "dlgSgCheckoutFastForwardMerge.hdl"
 msgid "Do you want to fast-forward-merge remote changes after checking out '$1'?"
 msgstr "检出 “$1” 后，您想要快进合并远程变更吗？"
 
@@ -2585,11 +2585,11 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.chk"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.fur%1"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.fur"
 msgid "This will make '$1' your current branch."
 msgstr "这将使 “$1” 成为您当前的分支。"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl%1"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl"
 msgid "Do you want to checkout the branch '$1'?"
 msgstr "你想检出 “$1” 分支吗?"
 
@@ -2677,7 +2677,7 @@ msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr "单击 “取消” 以选择其他分支名称。"
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl%1"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr "分支 “$1” 已经存在。您想覆盖吗？"
 
@@ -3506,7 +3506,7 @@ msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle%3"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
 msgid "\\[$1\\] - \\[$2\\] - $3"
 msgstr ""
 
@@ -3642,7 +3642,7 @@ msgctxt "dlgSgDeleteDirTrash.fur"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.hdl%1"
+msgctxt "dlgSgDeleteDirTrash.hdl"
 msgid "Do you want to delete '$1' recursively?"
 msgstr ""
 
@@ -3650,11 +3650,11 @@ msgctxt "dlgSgDeleteDirTrash.tle"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgDeleteFileTrash.hdl%1"
+msgctxt "dlgSgDeleteFileTrash.hdl"
 msgid "Do you want to delete '$1'?"
 msgstr "确定要删除 “$1” 吗？"
 
-msgctxt "dlgSgDeleteFilesTrash.hdl%1"
+msgctxt "dlgSgDeleteFilesTrash.hdl"
 msgid "Do you want to delete the $1 selected files?"
 msgstr "您确定要删除所选的 $1 文件吗？"
 
@@ -3750,11 +3750,11 @@ msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToHead.hdl%1"
+msgctxt "dlgSgDiscardRevertToHead.hdl"
 msgid "Do you want to reset $1 files back to their HEAD state?"
 msgstr "您确定要将 $1 文件重置为 HEAD 状态吗？"
 
-msgctxt "dlgSgDiscardRevertToIndex.hdl%1"
+msgctxt "dlgSgDiscardRevertToIndex.hdl"
 msgid "Do you want to reset $1 files back to their Index state?"
 msgstr "您确定要将 $1 文件重置为其索引状态吗？"
 
@@ -3826,7 +3826,7 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.btn:"
 msgid "Force Opening"
 msgstr ""
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl%1"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl"
 msgid "Could not open Conflict Solver for '$1', because it seems to be no text file."
 msgstr ""
 
@@ -3834,7 +3834,7 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle"
 msgid "Conflict Solver"
 msgstr ""
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.hdl%1"
+msgctxt "dlgSgFileCompareInvokerFailedIO.hdl"
 msgid "'$1' could not be invoked."
 msgstr ""
 
@@ -3874,11 +3874,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.btn:"
 msgid "Fast-Forward"
 msgstr "快进"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur%3"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur"
 msgid "The local branch '$1' is behind its tracked branch '$2'. You may fast-forward now or do it manually later, e.g. by checking out the branch '$3'."
 msgstr "本地分支 “$1” 位于其跟踪分支 “$2” 的后面。您可以现在快进，也可以稍后手动前进，例如签出分支 $3 。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl"
 msgid "Should branch '$1' be fast-forwarded to '$2'?"
 msgstr "分支 “$1” 是否应快速转发到 “$2”？"
 
@@ -3890,11 +3890,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.btn:"
 msgid "Replace"
 msgstr "替换"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur"
 msgid "The local branch '$1' seems to contain more recent but rewritten commits of remote branch '$2'.\\n\\nIf you are not sure whether the local branch is actually more recent than the remote branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr "本地分支 “$1” 似乎包含远程分支 “$2” 的更新但已重写的提交。\\n\\n如果您不确定本地分支是否实际比远程分支更新，则最好取消此操作并更详细地审查本地和远程变更。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl"
 msgid "Should branch '$1' replace remote branch '$2'?"
 msgstr "分支 “$1” 是否应替换远程分支 “$2”？"
 
@@ -3906,11 +3906,11 @@ msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.btn:"
 msgid "Reset"
 msgstr "重置"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur"
 msgid "The remote branch '$1' seems to contain more recent but rewritten commits of local branch '$2'.\\n\\nIf you are not sure whether the remote branch is actually more recent than the local branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr "远程分支 '$1' 似乎包含更近期但被重写的本地分支 '$2' 的提交。\\r\\n如果您不确定远程分支是否实际上比本地分支更新，您应该取消此操作并进行审查本地和远程变更更详细。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl%2"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl"
 msgid "Should branch '$1' be reset to remote branch '$2'?"
 msgstr "分支 '$1' 是否应重置为远程分支 '$2' ？"
 
@@ -4094,7 +4094,7 @@ msgctxt "dlgSgFlowFeatureStart.hdl"
 msgid "Start a new feature"
 msgstr "开始新 feature"
 
-msgctxt "dlgSgFlowFeatureStart.inf%1"
+msgctxt "dlgSgFlowFeatureStart.inf"
 msgid "Enter the name of the new feature branch. This operation will fork a new branch from the '$1' branch."
 msgstr "输入新 feature 分支的名称。此操作将从 $1 分支派生出新的分支。"
 
@@ -4198,7 +4198,7 @@ msgctxt "dlgSgFlowHotfixStart.hdl"
 msgid "Start a new hotfix"
 msgstr "启动新的修补程序"
 
-msgctxt "dlgSgFlowHotfixStart.inf%1"
+msgctxt "dlgSgFlowHotfixStart.inf"
 msgid "Enter the name of the new hotfix branch. This operation will fork a new branch from the '$1' branch."
 msgstr "输入新修补程序分支的名称。 此操作将从 '$1' 分支中分叉出新分支。"
 
@@ -4218,7 +4218,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.chk:"
 msgid "Fetch latest '$1' commits from remote repository"
 msgstr "从远程仓库获取最新的 “$1” 提交"
 
-msgctxt "dlgSgFlowIntegrateDevelop.hdl%1"
+msgctxt "dlgSgFlowIntegrateDevelop.hdl"
 msgid "Integrate commits from '$1'"
 msgstr "整合来自 “$1” 的提交"
 
@@ -4330,7 +4330,7 @@ msgctxt "dlgSgFlowReleaseStart.hdl"
 msgid "Start a new release"
 msgstr "开始新版本"
 
-msgctxt "dlgSgFlowReleaseStart.inf%1"
+msgctxt "dlgSgFlowReleaseStart.inf"
 msgid "Enter the name of the new release branch. This operation will fork a new branch from the '$1' branch."
 msgstr "输入新发布分支的名称。 此操作将从 '$1' 分支中分叉一个新分支。"
 
@@ -4366,7 +4366,7 @@ msgctxt "dlgSgFlowSupportStart.hdl"
 msgid "Start a new support"
 msgstr "Start a new support"
 
-msgctxt "dlgSgFlowSupportStart.inf%1"
+msgctxt "dlgSgFlowSupportStart.inf"
 msgid "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 
@@ -4790,7 +4790,7 @@ msgctxt "dlgSgHistoryModifySplitConfirm.fur"
 msgid "'Modify' will stop after the commit.\\n\\n'Split' will put the changes into the Index. You may discard some changes that should go into the second commit.\\n\\nAfter you've done the changes, process the remaining commits by continuing the rebase."
 msgstr "提交后，修改将停止。\\n\\n 拆分 会将变更放入索引中。您可以放弃应该进入第二次提交的一些变更。\\n\\n完成变更后，通过继续变基处理剩余的提交。"
 
-msgctxt "dlgSgHistoryModifySplitConfirm.hdl%1"
+msgctxt "dlgSgHistoryModifySplitConfirm.hdl"
 msgid "Do you want to modify or split commit $1?"
 msgstr "你想修改或拆分提交 $1 吗？"
 
@@ -4806,7 +4806,7 @@ msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr "推送到远程分支不是快进，所以必须强制推送。远程分支中的提交将丢失。"
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl%1"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl"
 msgid "Do you want to replace the remote branch by commit $1?"
 msgstr "是否要用提交 $1 替换远程分支？"
 
@@ -4822,7 +4822,7 @@ msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur"
 msgid "All commits up to the selected commit will be pushed to the remote repository."
 msgstr "对所选提交的所有提交都将被推送到远程仓库。"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl%1"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl"
 msgid "Do you want to push changes up to commit $1?"
 msgstr "是否要将变更向上推送到提交 $1？"
 
@@ -5186,11 +5186,11 @@ msgctxt "dlgSgHostingProviderEdit.err:"
 msgid "The provided SSL client certificate path is invalid."
 msgstr "提供的 SSL 客户端证书路径无效."
 
-msgctxt "dlgSgHostingProviderEdit.hdl%1"
+msgctxt "dlgSgHostingProviderEdit.hdl"
 msgid "Configure $1 account"
 msgstr "配置 $1 账户"
 
-msgctxt "dlgSgHostingProviderEdit.inf%1"
+msgctxt "dlgSgHostingProviderEdit.inf"
 msgid "Please specify your credentials to connect to $1."
 msgstr "请指定您的凭据以连接到 $1。"
 
@@ -5302,11 +5302,11 @@ msgctxt "dlgSgHostingProvider(Add|Edit).lbl:"
 msgid "Optional SSL configuration"
 msgstr "可选的 SSL 配置"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur%3"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur"
 msgid "The OAuth-access token could not be requested. Most likely your $1 configuration has changed and SmartGit's stored OAuth credentials are invalid.\\n\\nTo resolve, recreate the $2 hosting provider in the Preferences.\\n\\nDetails:\\n\\n$3"
 msgstr "无法请求 OAuth 访问令牌。很可能您的 $1 配置已更改且 SmartGit 存储的 OAuth 凭据无效。\\n\\n要解析，请在偏好设置中重新创建 $2 主机提供商。\\n\\n详细信息：\\n\\n $3"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl%1"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl"
 msgid "$1 OAuth-authentication failed"
 msgstr "$1 OAuth 身份验证失败"
 
@@ -5330,7 +5330,7 @@ msgctxt "dlgSgHttpPasswordCredentials.edt:"
 msgid "User Name"
 msgstr "用户名"
 
-msgctxt "dlgSgHttpPasswordCredentials.hdl%1"
+msgctxt "dlgSgHttpPasswordCredentials.hdl"
 msgid "Login to '$1'"
 msgstr "登录到 “$1”"
 
@@ -5382,7 +5382,7 @@ msgctxt "dlgSgIgnoreDirectoryConfirm.fur"
 msgid "The directory name will be added to the ignore file. If the ignore file does not exist, it will be created."
 msgstr "目录名称将添加到忽略文件中。如果忽略文件不存在，则将自动创建。"
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.hdl%1"
+msgctxt "dlgSgIgnoreDirectoryConfirm.hdl"
 msgid "Do you want to ignore directory '$1'?"
 msgstr "你想忽略目录 “$1” 吗？"
 
@@ -5506,11 +5506,11 @@ msgctxt "dlgSgJournalDoubleClick.btn:"
 msgid "Open Log"
 msgstr "打开日志"
 
-msgctxt "dlgSgJournalDoubleClick.fur%1"
+msgctxt "dlgSgJournalDoubleClick.fur"
 msgid "Select either to check out '$1' or to open the Log for the selected commit."
 msgstr "选择以检出 '$1' 或打开所选提交的日志."
 
-msgctxt "dlgSgJournalDoubleClick.hdl%1"
+msgctxt "dlgSgJournalDoubleClick.hdl"
 msgid "Do you want to check out '$1'?"
 msgstr "确定要检出 '$1' 吗?"
 
@@ -5586,7 +5586,7 @@ msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.btn:"
 msgid "Revert"
 msgstr "还原"
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur%1"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur"
 msgid "You are about to apply lines from the Index to the working tree file '$1'. The modifications will be saved immediately."
 msgstr "您将要将索引中的行应用到工作区文件 “$1”。修改将立即保存。"
 
@@ -5638,7 +5638,7 @@ msgctxt "dlgSgLogCheckoutFileAs.tle"
 msgid "Save File As"
 msgstr "文件另存为"
 
-msgctxt "dlgSgLogCommentDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogCommentDeleteConfirm.hdl"
 msgid "Do you really want to delete comment '$1'?"
 msgstr "您真的想删除 “$1” 注释吗？"
 
@@ -5654,7 +5654,7 @@ msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle"
 msgid "Delete Comment"
 msgstr "删除注释"
 
-msgctxt "dlgSgLogCommentsDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogCommentsDeleteConfirm.hdl"
 msgid "Do you really want to delete $1 comments?"
 msgstr "您真的想删除 $1 注释吗？"
 
@@ -5798,7 +5798,7 @@ msgctxt "dlgSgLogRefActionsDeleteConfirm.fur"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr "您可能会丢失未推送的变更，或还原分支可能会很复杂 \\(es\\)！"
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl%1"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl"
 msgid "Do you really want to delete the local branch '$1'?"
 msgstr "你真的想删除本地分支 “$1” 吗？"
 
@@ -5814,11 +5814,11 @@ msgctxt "dlgSgLogRefreshRepositoryInvalid.btn:"
 msgid "Remove Repository"
 msgstr "移除仓库"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.fur%1"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.fur"
 msgid "This could mean that the repository at\\n\\n$1was removed or renamed outside SmartGit."
 msgstr "这可能意味着在\\n\\n $1 的仓库被删除或在 SmartGit 外部重命名。"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl%1"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl"
 msgid "The opened repository '$1' became invalid."
 msgstr "打开的仓库 “$1” 变为无效。"
 
@@ -5954,7 +5954,7 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.fur"
 msgid "The specified directory does not appear to be a valid Git repository."
 msgstr "指定的目录似乎不是有效的 Git 仓库。"
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.hdl%1"
+msgctxt "dlgSgOpenRepositoryInitializeGit.hdl"
 msgid "Should '$1' be initialized as a new Git repository?"
 msgstr "是否应该将 '$1' 初始化为新的 Git 仓库？"
 
@@ -5962,7 +5962,7 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.tle"
 msgid "Add or Create Repository"
 msgstr "添加或创建仓库"
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur%1"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 
@@ -6202,11 +6202,11 @@ msgctxt "dlgSgOutput.tle:"
 msgid "Output"
 msgstr "输出"
 
-msgctxt "dlgSgPingRepositoryFailed.fur%1"
+msgctxt "dlgSgPingRepositoryFailed.fur"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr "请检查仓库 URL。\\n\\n$1"
 
-msgctxt "dlgSgPingRepositoryFailed.hdl%1"
+msgctxt "dlgSgPingRepositoryFailed.hdl"
 msgid "Could not connect to the repository '$1'."
 msgstr "无法连接到仓库 “$1”。"
 
@@ -7515,7 +7515,7 @@ msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.hdl%1"
+msgctxt "dlgSgProviderGenerateToken.hdl"
 msgid "Generate a new API token for $1"
 msgstr ""
 
@@ -7575,7 +7575,7 @@ msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur"
 msgid "The merge request itself will not be deleted on the server."
 msgstr "拉取请求本身不会在服务器上删除。"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl%1"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl"
 msgid "Do you really want to drop the local commits of merge request $1?"
 msgstr "是否确定要删除请求 $1 的本地提交？"
 
@@ -7593,7 +7593,7 @@ msgstr "拉取请求本身不会在服务器上删除。"
 
 #, fuzzy
 #| msgid "Do you really want to drop the local commits of pull request $1?"
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl%1"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl"
 msgid "Do you want to drop the local commits of pull request $1?"
 msgstr "是否确定要删除请求 $1 的本地提交？"
 
@@ -7729,7 +7729,7 @@ msgctxt "dlgSgPullMergeInsteadOfRebase.btn:"
 msgid "Rebase"
 msgstr "变基"
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.fur%1"
+msgctxt "dlgSgPullMergeInsteadOfRebase.fur"
 msgid "Amongst the changes to rebase there is merge-commit $1. Rebasing merge-commits can easily cause troubles."
 msgstr "在变基的变更中有合并提交 $1。 变基合并提交很容易造成麻烦。"
 
@@ -7777,7 +7777,7 @@ msgctxt "dlgSgPullOrJustFetch.fur"
 msgid "You can change the Pull behavior in the Repository Settings."
 msgstr "您可以在仓库设置中变更拉取行为。"
 
-msgctxt "dlgSgPullOrJustFetch.hdl%1"
+msgctxt "dlgSgPullOrJustFetch.hdl"
 msgid "Do you want to pull or just fetch $1 repositories?"
 msgstr "你想拉取或只是获取 $1 的仓库？"
 
@@ -7805,11 +7805,11 @@ msgctxt "dlgSgPushConfirmSingleBranch.chk"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgPushConfirmSingleBranch.fur%1"
+msgctxt "dlgSgPushConfirmSingleBranch.fur"
 msgid "1 branch will be pushed to '$1'."
 msgstr "分支将被推至 “$1” 。"
 
-msgctxt "dlgSgPushConfirmSingleBranch.hdl%1"
+msgctxt "dlgSgPushConfirmSingleBranch.hdl"
 msgid "Do you want to push branch '$1'?"
 msgstr "你想要推送分支 “$1” 吗？"
 
@@ -7993,11 +7993,11 @@ msgctxt "dlgSgPushToRemote.edt:"
 msgid "Target Repository"
 msgstr "目标仓库"
 
-msgctxt "dlgSgPushToRemote.hdl%1"
+msgctxt "dlgSgPushToRemote.hdl"
 msgid "Push '$1' branches to another remote"
 msgstr "将 '$1' 分支推送到其他远程"
 
-msgctxt "dlgSgPushToRemote.inf%1"
+msgctxt "dlgSgPushToRemote.inf"
 msgid "All branches of '$1' \\(as locally represented by the corresponding remote branches\\) will be pushed to the target repository."
 msgstr "'$1' 的所有分支（在本地由相应的远程分支代表）将被推送到目标仓库."
 
@@ -8053,7 +8053,7 @@ msgctxt "dlgSgPushTrackingConfigureSingle.fur"
 msgid "For your current branch tracking \\(its corresponding remote branch\\) has not been configured yet. Configuring tracking will keep your local branches in sync with the remote branches."
 msgstr "对于当前分支跟踪 \\(其对应的远程分支\\) 尚未配置。配置跟踪将使本地分支与远程分支保持同步。"
 
-msgctxt "dlgSgPushTrackingConfigureSingle.hdl%1"
+msgctxt "dlgSgPushTrackingConfigureSingle.hdl"
 msgid "Do you want to configure tracking for '$1' branch?"
 msgstr "是否要为 “$1” 分支配置跟踪？"
 
@@ -8089,7 +8089,7 @@ msgctxt "dlgSgRebaseConfirmUnreachable.fur"
 msgid "You only might be able to access this commit using the 'Recyclable Commits' option of the Branches view."
 msgstr "你只能使用分支视图中的'可循环提交'选项才能访问该提交."
 
-msgctxt "dlgSgRebaseConfirmUnreachable.hdl%1"
+msgctxt "dlgSgRebaseConfirmUnreachable.hdl"
 msgid "The Commit $1 would become unreachable by refs."
 msgstr "该提交 $1 将会被引用变为不可访问."
 
@@ -8105,7 +8105,7 @@ msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur%1"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur"
 msgid "The splitting of commit $1 still is in progress and all changes of this commit have been applied."
 msgstr "提交 $1 的拆分仍在进行中，并且已应用此提交的所有变更。"
 
@@ -8245,7 +8245,7 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.btn:"
 msgid "Put Changes into Index"
 msgstr "将变更放入索引"
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur%1"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur"
 msgid "The splitting of commit $1 still is in progress, but not all changes of this commit have been applied.\\n\\nIf this is intentional, you can continue. Otherwise, you should click 'Put Changes into Index' and review your changes."
 msgstr "提交 $1 的拆分仍在进行中，但并未应用此提交的所有变更。\\n\\n如果这是故意的，您可以继续。否则，您应单击 “将变更置于索引中” 并查看变更。"
 
@@ -8257,19 +8257,19 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle"
 msgid "Rebase"
 msgstr "变基"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur%1"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) onto the selected commit."
 msgstr "这将把工作区分支 “$1” \\(HEAD\\) 的所有提交应用到所选提交。"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl%1"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl"
 msgid "Do you want to rebase '$1' onto the selected commit?"
 msgstr "是否要将 “$1” 变基至所选提交？"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur%2"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) to '$2'."
 msgstr "这将应用从工作区分支 “$1” \\(HEAD\\) 到 “$2” 的所有提交。"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl%2"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl"
 msgid "Do you want to rebase '$1' to '$2'?"
 msgstr "是否要将 “$1” 变基至 “$2”？"
 
@@ -8389,7 +8389,7 @@ msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur"
 msgid "It might become hard or impossible to recover the commit again."
 msgstr "再次恢复提交可能变得困难或不可能。"
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl%1"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl"
 msgid "Do you want to remove the selected commit $1?"
 msgstr "您确定要删除所选的提交 $1 吗？"
 
@@ -8433,7 +8433,7 @@ msgctxt "dlgSgRebaseTagCommit.fur"
 msgid "After the rebase, the remaining commit won't be reachable anymore."
 msgstr "在变基之后，剩余的提交将不再可用。"
 
-msgctxt "dlgSgRebaseTagCommit.hdl%1"
+msgctxt "dlgSgRebaseTagCommit.hdl"
 msgid "Should commit $1 be tagged?"
 msgstr "应该标记提交 $1 吗？"
 
@@ -8525,7 +8525,7 @@ msgctxt "dlgSgRemoteDeleteConfirm.fur"
 msgid "This will just delete the link to the remote repository."
 msgstr "这只会删除到远程仓库的链接。"
 
-msgctxt "dlgSgRemoteDeleteConfirm.hdl%1"
+msgctxt "dlgSgRemoteDeleteConfirm.hdl"
 msgid "Do you want to delete the remote repository '$1'?"
 msgstr "是否要删除远程仓库 “$1”？"
 
@@ -8685,7 +8685,7 @@ msgctxt "dlgSgRemotesAdd.tle"
 msgid "Add Remote Repository"
 msgstr "添加远程仓库"
 
-msgctxt "dlgSgRemotesNoRemoteDetected.fur%1"
+msgctxt "dlgSgRemotesNoRemoteDetected.fur"
 msgid "To perform the operation the repository configuration for $1 must contain one uniquely determined remote."
 msgstr "要执行该操作，$1 仓库配置必须包含一个唯一确定的远程地址."
 
@@ -8737,7 +8737,7 @@ msgctxt "dlgSgRenameBranch.hdl"
 msgid "Rename branch"
 msgstr "重命名分支"
 
-msgctxt "dlgSgRenameBranch.inf%1"
+msgctxt "dlgSgRenameBranch.inf"
 msgid "Enter the new name for the branch '$1'."
 msgstr "输入分支 “$1” 的新名称。"
 
@@ -8933,7 +8933,7 @@ msgctxt "dlgSgRepositoryOpen.fur"
 msgid "If it is relocated, remove it and add its new location."
 msgstr "如果重新定位，请将其删除并添加其新位置。"
 
-msgctxt "dlgSgRepositoryOpen.hdl%1"
+msgctxt "dlgSgRepositoryOpen.hdl"
 msgid "Do you want to remove the missing repository '$1'?"
 msgstr "你想删除丢失的仓库 '$1' 吗？"
 
@@ -8945,7 +8945,7 @@ msgctxt "dlgSgRepositoryRemoveFailed1.fur"
 msgid "This could happen if the repository is open in another window or currently commands are executed."
 msgstr "如果仓库在另一个窗口中打开或当前正在执行命令, 可能会发生这种情况."
 
-msgctxt "dlgSgRepositoryRemoveFailed1.hdl%1"
+msgctxt "dlgSgRepositoryRemoveFailed1.hdl"
 msgid "The repository '$1' could not be removed."
 msgstr "无法移除仓库 '$1'"
 
@@ -8957,7 +8957,7 @@ msgctxt "dlgSgRepositoryRemoveMultiGroup.fur"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "已删除组中的仓库将从该组中移出。"
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl%1"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl"
 msgid "Do you want to remove $1 groups?"
 msgstr "您确定要删除 $1 组吗？"
 
@@ -8965,7 +8965,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepo.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl%1"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl"
 msgid "Do you want to remove $1 repositories?"
 msgstr "您确定要删除 $1 仓库吗？"
 
@@ -8973,7 +8973,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl"
 msgid "Do you want to remove $1 repositories and $2 groups?"
 msgstr "您确定要删除 $1 仓库和 $2 组吗？"
 
@@ -8981,7 +8981,7 @@ msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl"
 msgid "Do you want to remove $1 repositories and the group \"$2\"?"
 msgstr "您确定要删除 $1 仓库和组 “$2” 吗？"
 
@@ -8989,7 +8989,7 @@ msgctxt "dlgSgRepositoryRemoveSingleGroup.fur"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl%1"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl"
 msgid "Do you want to remove the group \"$1\"?"
 msgstr "您确定要删除 “$1” 组吗？"
 
@@ -8997,7 +8997,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepo.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl%1"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl"
 msgid "Do you want to remove the repository \"$1\"?"
 msgstr "您确定要删除 $1 的仓库吗？"
 
@@ -9005,7 +9005,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl"
 msgid "Do you want to remove the repository \"$1\" and $2 groups?"
 msgstr "您确定要删除仓库 “$1” 和 $2 组吗？"
 
@@ -9013,7 +9013,7 @@ msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl%2"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl"
 msgid "Do you want to remove the repository \"$1\" and the group \"$2\"?"
 msgstr "您确定要删除仓库 “$1” 和组 “$2” 吗？"
 
@@ -9173,7 +9173,7 @@ msgctxt "dlgSgResetAdv.chk:"
 msgid "Thoroughly fix line-endings according to .gitattributes"
 msgstr "根据 .gitattributes 彻底修复行尾序列"
 
-msgctxt "dlgSgResetAdv.hdl%1"
+msgctxt "dlgSgResetAdv.hdl"
 msgid "Reset to commit $1"
 msgstr "重置提交 $1"
 
@@ -9233,7 +9233,7 @@ msgctxt "dlgSgResetConfirm.fur"
 msgid "Current staged and local changes will be lost!"
 msgstr "当前暂存和本地变更将丢失！"
 
-msgctxt "dlgSgResetConfirm.hdl%1"
+msgctxt "dlgSgResetConfirm.hdl"
 msgid "Do you want to reset the HEAD to commit $1?"
 msgstr "您确定要将 HEAD 重置为提交 $1 吗？"
 
@@ -9293,7 +9293,7 @@ msgctxt "dlgSgResolveManuallyModifiedSingle.btn:"
 msgid "Overwrite"
 msgstr "覆盖"
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.fur%1"
+msgctxt "dlgSgResolveManuallyModifiedSingle.fur"
 msgid "$1 seems to contain manual conflict resolutions. They will be lost when continuing."
 msgstr "$1 似乎包含手动冲突解决方案。如果继续，它们将会丢失。"
 
@@ -9341,7 +9341,7 @@ msgctxt "dlgSgRevealCommitLocalOrTracked.chk"
 msgid "Always reveal local branch"
 msgstr "始终显示当地分支"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.fur%2"
+msgctxt "dlgSgRevealCommitLocalOrTracked.fur"
 msgid "Select whether to reveal '$1' or '$2'."
 msgstr "选择是否显示 “$1” 或 “$2” 。"
 
@@ -9729,7 +9729,7 @@ msgctxt "dlgSgRollbackToCommit.fur"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr ""
 
-msgctxt "dlgSgRollbackToCommit.hdl%1"
+msgctxt "dlgSgRollbackToCommit.hdl"
 msgid "Do you want to rollback the Index to the state of commit $1?"
 msgstr ""
 
@@ -9981,7 +9981,7 @@ msgctxt "dlgSgSetupStdWnd.hdl"
 msgid "Do you want to use the Standard Window?"
 msgstr "您是否想要使用标准窗口?"
 
-msgctxt "dlgSgSetupStdWnd.tle%1"
+msgctxt "dlgSgSetupStdWnd.tle"
 msgid "Setup SmartGit $1"
 msgstr "设置 SmartGit $1"
 
@@ -9989,7 +9989,7 @@ msgctxt "dlgSgShowLocalChanges.btn:"
 msgid "Compare"
 msgstr "比较"
 
-msgctxt "dlgSgShowLocalChanges.hdl%1"
+msgctxt "dlgSgShowLocalChanges.hdl"
 msgid "File $1 modified in Index and working tree"
 msgstr "在索引和工作区中修改了文件 $1"
 
@@ -10089,7 +10089,7 @@ msgctxt "dlgSgSshCredentials.hdl"
 msgid "SSH Credentials"
 msgstr "SSH 凭据"
 
-msgctxt "dlgSgSshCredentials.inf%2"
+msgctxt "dlgSgSshCredentials.inf"
 msgid "Provide the credentials for authenticating to the SSH server '$1' as user '$2'."
 msgstr "提供用于以 “root” 身份向 SSH 服务器 “git” 进行身份验证的凭据。"
 
@@ -10121,7 +10121,7 @@ msgctxt "dlgSgStageConflict.fur"
 msgid "The file contains conflict markers which indicate that you have not resolved all conflicts."
 msgstr "该文件包含冲突标记，这些标记指示您尚未解决所有冲突。"
 
-msgctxt "dlgSgStageConflict.hdl%1"
+msgctxt "dlgSgStageConflict.hdl"
 msgid "Should $1 really be staged?"
 msgstr "$1 真的应该暂存吗？"
 
@@ -10510,7 +10510,7 @@ msgctxt "dlgSgSubmoduleDeinitConfirm.fur"
 msgid "The submodule will be skipped from the working tree. To get rid from the \\(remote\\) repository, you have to use Unregister instead."
 msgstr "子模块将从工作区中跳过。 要摆脱 \\(远程\\) 仓库，您必须使用取消注册。"
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.hdl%1"
+msgctxt "dlgSgSubmoduleDeinitConfirm.hdl"
 msgid "Do you want to deinit submodule '$1'?"
 msgstr "你想要删除子模块 '$1' 吗？"
 
@@ -10586,7 +10586,7 @@ msgctxt "dlgSgSubmoduleResetConfirm.fur"
 msgid "The corresponding commit will be checked out, so the submodule content will match the content of the registered commit."
 msgstr "将检出相应的提交，因此子模块内容将匹配已注册提交的内容。"
 
-msgctxt "dlgSgSubmoduleResetConfirm.hdl%1"
+msgctxt "dlgSgSubmoduleResetConfirm.hdl"
 msgid "Do you want to reset submodule '$1' to the commit registered in the repository?"
 msgstr "是否要将子模块 $1 重置为仓库中注册的提交？"
 
@@ -10734,7 +10734,7 @@ msgctxt "dlgSgSvnClientCertificate.hdl"
 msgid "Client Certificate"
 msgstr "客户端证书"
 
-msgctxt "dlgSgSvnClientCertificate.inf%1"
+msgctxt "dlgSgSvnClientCertificate.inf"
 msgid "Provide the client certificate for authentication to the SVN repository '$1'."
 msgstr "为 SVN 仓库 “$1” 提供身份验证的客户端证书。"
 
@@ -10842,7 +10842,7 @@ msgctxt "dlgSgTagAddOverwrite.fur"
 msgid "Click 'Cancel' to choose a different tag name."
 msgstr "单击 “取消” 以选择其他标签名称。"
 
-msgctxt "dlgSgTagAddOverwrite.hdl%1"
+msgctxt "dlgSgTagAddOverwrite.hdl"
 msgid "The tag '$1' already exists. Do you want to overwrite it?"
 msgstr "标签 '$1' 已经存在。 你想覆盖吗？"
 
@@ -10858,7 +10858,7 @@ msgctxt "dlgSgTagDeleteConfirmSingle.chk"
 msgid "Delete from all remotes"
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk%1"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk"
 msgid "Delete from remote '$1'"
 msgstr "从远程 “$1” 删除"
 
@@ -10866,7 +10866,7 @@ msgctxt "dlgSgTagDeleteConfirmSingle.fur"
 msgid "You will not be able to restore it."
 msgstr "你将无法恢复它。"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.hdl%1"
+msgctxt "dlgSgTagDeleteConfirmSingle.hdl"
 msgid "Do you want to delete the tag '$1'?"
 msgstr "您确定要删除 “$1” 标签吗？"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -6762,6 +6762,11 @@ msgctxt "dlgSgOutput.chk:"
 msgid "Show automatically for failed command"
 msgstr "自动显示失败的命令"
 
+# $1: Command name, $2: Return code
+msgctxt "dlgSgOutput.lbl:"
+msgid "$1 failed \\(return code $2\\)"
+msgstr ""
+
 msgctxt "dlgSgOutput.lbl:"
 msgid "Authentication using OAuth failed \\(see details below\\)"
 msgstr ""
@@ -7005,10 +7010,6 @@ msgstr ""
 msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
 msgstr "您对以下文件的本地更改将被签出覆盖:\\n无法分离 HEAD"
-
-msgctxt "dlgSgOutput.lbl:"
-msgid "stash failed \\(return code $1\\)"
-msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "unable to access '$1': Could not resolve host: $2"
@@ -13137,14 +13138,9 @@ msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
 msgstr "After the new version has been downloaded successfully, you will be notified again."
 
-# TODO: Check if the variable range is correct.
-#| msgid "SmartGit 25.1.093 needs to be restarted now for the changes to take effect."
+# $1: Software name and version
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
 msgid "$1 needs to be restarted now for the changes to take effect."
-msgstr ""
-
-msgctxt "ntmUpdateCheckFetchVersionSuccess:"
-msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
 msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
@@ -13286,10 +13282,6 @@ msgstr "购买更新"
 msgctxt "nttSupportExpired:"
 msgid "Your support period has expired on $1."
 msgstr "您的支持服务将于 $1 过期."
-
-msgctxt "nttUpdateCheck:"
-msgid "Quick Poll: $1"
-msgstr ""
 
 msgctxt "nttUpdateCheck:"
 msgid "Vote"
@@ -18559,6 +18551,10 @@ msgstr ""
 #~ msgid "Set or select the options according to your account."
 #~ msgstr ""
 
+#~ msgctxt "dlgSgOutput.lbl:"
+#~ msgid "stash failed \\(return code $1\\)"
+#~ msgstr ""
+
 #~ msgctxt "dlgSgProviderGenerateToken.hdl"
 #~ msgid "Generate a new API token for $1"
 #~ msgstr ""
@@ -18618,6 +18614,14 @@ msgstr ""
 #~ msgctxt "dlgTxtEditor.fileModified.hdl:"
 #~ msgid "The file config was changed. Reload it?"
 #~ msgstr "该文件配置已变更. 是否重新加载?"
+
+#~ msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+#~ msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
+#~ msgstr ""
+
+#~ msgctxt "nttUpdateCheck:"
+#~ msgid "Quick Poll: $1"
+#~ msgstr ""
 
 #~ msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
 #~ msgid "<b>Last Updated By: </b>$1"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -37,6 +37,10 @@ msgctxt "*.btn:"
 msgid "OK"
 msgstr "确定"
 
+msgctxt "*.chk:"
+msgid "Don't show again"
+msgstr ""
+
 msgctxt "*.hnt:"
 msgid "Filter"
 msgstr "过滤器"
@@ -161,6 +165,18 @@ msgctxt "dlgCommitInvisibleIndex.tle:"
 msgid "Commit"
 msgstr ""
 
+msgctxt "dlgCommitNoEmailConfigured.fur:"
+msgid "Before committing you will have to configure your name and email, e.g. in the SmartGit Preferences."
+msgstr ""
+
+msgctxt "dlgCommitNoEmailConfigured.hdl:"
+msgid "Please configure the email for commit."
+msgstr ""
+
+msgctxt "dlgCommitNoEmailConfigured.tle:"
+msgid "Commit"
+msgstr ""
+
 msgctxt "dlgCommitView.hiddenOptions.chk:"
 msgid "Don't show again"
 msgstr ""
@@ -269,6 +285,18 @@ msgctxt "dlgDgSetPerspectiveCantSwitch.tle:"
 msgid "Origins Perspective"
 msgstr "原始视角"
 
+msgctxt "dlgHostingProvider.canBeConfigured.btn:"
+msgid "Configure Hosting Provider"
+msgstr ""
+
+msgctxt "dlgHostingProvider.canBeConfigured.fur:"
+msgid "The easiest way to access the repository at $1 is through a hosting provider."
+msgstr ""
+
+msgctxt "dlgHostingProvider.canBeConfigured.hdl:"
+msgid "Do you want to configure a GitLab hosting provider?"
+msgstr ""
+
 msgctxt "dlgInfo.tle:"
 msgid "Discard"
 msgstr "丢弃"
@@ -279,6 +307,11 @@ msgstr "停止"
 
 msgctxt "dlgProgress.lbl:"
 msgid "Please wait ..."
+msgstr ""
+
+# [decode] msgid "Please wait …"
+msgctxt "dlgProgress.lbl:"
+msgid "Please wait \\u2026"
 msgstr ""
 
 msgctxt "dlgProgress.tle:"
@@ -730,6 +763,10 @@ msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr "文件包含混合不一致的行尾序列."
 
 msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
+msgid "\\[$1\\] - $2"
+msgstr ""
+
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - 冲突解决工具"
 
@@ -1033,9 +1070,17 @@ msgctxt "dlgScDialogAssertionHandlerLinkageError.btn:"
 msgid "Force Exit"
 msgstr "强制退出"
 
+msgctxt "dlgScDialogAssertionHandlerLinkageError.btn:"
+msgid "Just Exit"
+msgstr ""
+
 msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
 msgid "SmartGit has detected inconsistencies within its installation files \\(JAR files\\), what has most likely been caused by a faulty installation.\\n\\nPlease uninstall SmartGit completely, make sure there are no more installation files left \\(especially JAR files\\), then reinstall.\\n\\nIf the problem persists, send following log file as an attachment to smartgit@syntevo.com."
 msgstr "SmartGit 已检测到其安装文件 \\(JAR 文件\\) 中的不一致，这很可能是由安装错误引起的。\\n\\n请完全卸载 SmartGit，确保没有剩余的安装文件 \\(尤其是 JAR 文件\\) ，然后重新安装。\\n\\n如果问题仍然存在，请将以下记录文件作为附件发送到 smartgit@syntevo.com。"
+
+msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
+msgid "Your SmartGit-installation seems to be damaged."
+msgstr ""
 
 msgctxt "dlgScDialogAssertionHandlerLinkageError.tle:"
 msgid "Internal Error"
@@ -1073,9 +1118,45 @@ msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr "您的 SmartGit 试用将在 $1 天后结束。"
 
+msgctxt "dlgScEvaluationReminderContinue.hdl:"
+msgid "Your SmartGit evaluation ends today."
+msgstr ""
+
 msgctxt "dlgScEvaluationReminderContinue.tle:"
 msgid "Evaluation"
 msgstr "试用"
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "&Continue \\($1\\)"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "&Continue"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Continue \\($1\\)"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Exit"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.btn:"
+msgid "Register"
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.fur:"
+msgid "To use SmartGit, you will have to register a license file.\\n\\nIn a commercial environment you need to \\[https://www.syntevo.com/smartgit/purchase?evaluationReminderNotification purchase a license\\].\\n\\nFor \\[https://www.syntevo.com/register-non-commercial/?evaluationReminderNotification certain uses\\] we grant free licenses."
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.hdl:"
+msgid "Your evaluation has already expired."
+msgstr ""
+
+msgctxt "dlgScEvaluationReminderExpiredGrace.tle:"
+msgid "Evaluation"
+msgstr ""
 
 msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl:"
 msgid "Cannot run program \"$1\": $2"
@@ -1084,6 +1165,30 @@ msgstr "无法运行 \"$1\": $2"
 msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - 冲突解决工具"
+
+msgctxt "dlgScExternalFileStarterCommandNoFile.fur:"
+msgid "Be sure to add arguments to the appropriate input field."
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterCommandNoFile.hdl:"
+msgid "The specified command is no file."
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterCommandNoFile.tle:"
+msgid "Input Validation"
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterEmptyCommand.fur:"
+msgid "Select the command which should be invoked."
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterEmptyCommand.hdl:"
+msgid "The Command input field must not be empty!"
+msgstr ""
+
+msgctxt "dlgScExternalFileStarterEmptyCommand.tle:"
+msgid "Input Validation"
+msgstr ""
 
 msgctxt "dlgScFileComparatorAdd.hdl:"
 msgid "Add external diff tool"
@@ -1473,6 +1578,10 @@ msgctxt "dlgScMasterPasswordEnter.inf:"
 msgid "A stored password or passphrase has been requested from the password store."
 msgstr "已从密码库中申请了存储的密码或口令。"
 
+msgctxt "dlgScMasterPasswordEnter.lbl:"
+msgid "Forgot it? Reset it in the preferences, 'Authentication' page."
+msgstr ""
+
 msgctxt "dlgScMasterPasswordEnter.tle:"
 msgid "Passwords"
 msgstr "密码"
@@ -1566,6 +1675,10 @@ msgid "Free Updates Until"
 msgstr "免费更新有效期"
 
 msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
+msgid "License ID"
+msgstr ""
+
+msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "Name"
 msgstr "用户名"
 
@@ -1609,6 +1722,34 @@ msgctxt "dlgScRegisterRequestRejected.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit 许可证"
 
+msgctxt "dlgScSecretToken.btn:"
+msgid "Connect"
+msgstr ""
+
+msgctxt "dlgScSecretToken.edt:"
+msgid "API Key"
+msgstr ""
+
+msgctxt "dlgScSecretToken.hdl:"
+msgid "Provide API key for '$1'"
+msgstr ""
+
+msgctxt "dlgScSecretToken.inf:"
+msgid "An API key is required to access the AI at '$1'. It will be stored in SmartGit's password store."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://console.anthropic.com/settings/keys Anthropic account\\]."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://console.mistral.ai/api-keys Mistral account\\]."
+msgstr ""
+
+msgctxt "dlgScSecretToken.lbl:"
+msgid "The API key can be created in your \\[https://platform.openai.com/settings/organization/api-keys OpenAI account\\]."
+msgstr ""
+
 msgctxt "dlgScSetupLicense.btn:"
 msgid "Configure Proxy"
 msgstr "设置代理"
@@ -1644,6 +1785,26 @@ msgstr "请提供您在购买后通过电子邮件收到的 SmartGit 许可文�
 msgctxt "dlgScSetupLicense.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit 许可证"
+
+msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
+msgid "Exit Later"
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.btn:"
+msgid "Restart Now"
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.fur:"
+msgid "You can do that now or manually later."
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.hdl:"
+msgid "SmartGit has to be restarted for the license change to take effect."
+msgstr ""
+
+msgctxt "dlgScSetupLicenseNeedsRestart.tle:"
+msgid "SmartGit License"
+msgstr ""
 
 msgctxt "dlgScSpellCheckDictionaryAdd.err:"
 msgid "Please enter a name."
@@ -2002,8 +2163,8 @@ msgid "Abort Rebase"
 msgstr "中止变基"
 
 msgctxt "dlgSgAbortRebasingConfirm.fur:"
-msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
-msgstr "您的工作区处于 “变基” 状态。你可以放弃变基; 如果您只想跳过当前的补丁，请使用 分支 \\| 变基 \\| 将 HEAD 变基至。\\n\\n中止将清除任何本地修改 \\(通过调用 “git reset --hard”\\)！"
+msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use $1 instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
+msgstr ""
 
 msgctxt "dlgSgAbortRebasingConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
@@ -2034,6 +2195,10 @@ msgid "Discard"
 msgstr ""
 
 msgctxt "dlgSgAbout.btn:"
+msgid "Copy Evaluation-ID"
+msgstr ""
+
+msgctxt "dlgSgAbout.btn:"
 msgid "Register"
 msgstr "注册"
 
@@ -2048,6 +2213,10 @@ msgstr "地址"
 msgctxt "dlgSgAbout.edt:"
 msgid "Build Date"
 msgstr "编译日期"
+
+msgctxt "dlgSgAbout.edt:"
+msgid "Demo Until"
+msgstr ""
 
 msgctxt "dlgSgAbout.edt:"
 msgid "Email"
@@ -2086,6 +2255,10 @@ msgid "User Count"
 msgstr "用户数量"
 
 msgctxt "dlgSgAbout.edt:"
+msgid "Valid Until"
+msgstr ""
+
+msgctxt "dlgSgAbout.edt:"
 msgid "Version"
 msgstr "版本"
 
@@ -2104,6 +2277,376 @@ msgstr "授权信息"
 msgctxt "dlgSgAbout.tle:"
 msgid "About SmartGit"
 msgstr "关于 SmartGit"
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.btn:"
+msgid "Drop"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.fur:"
+msgid "This will remove all AI-related Git notes from the repository."
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.hdl:"
+msgid "Do you want to drop all AI-related Git notes?"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorDropAllNotes.tle:"
+msgid "Drop AI Notes"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.btn:"
+msgid "Swap"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.edt:"
+msgid "New \\(To\\)"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.edt:"
+msgid "Old \\(From\\)"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.hdl:"
+msgid "Choose the diff direction"
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.inf:"
+msgid "The two commits have diverged, so they can be compared in either direction. The diff represents the changes from Old to New."
+msgstr ""
+
+msgctxt "dlgSgAiAnnotatorSelectOldAndNewCommit.tle:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
+msgid "Allow"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.btn:"
+msgid "Deny"
+msgstr ""
+
+# $1: rootFile , $2: typeName , $3: details
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.fur:"
+msgid "This is the first time that SmartGit will access the AI service for this repository:\\n\\n$1\\n\\nPlease confirm whether uploads to $2 are allowed. $3\\n\\nThis is a one-time safety check, and your choice will apply to all future requests for this repository with this AI service."
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.hdl:"
+msgid "Do you allow SmartGit to upload repository data to $1?"
+msgstr ""
+
+msgctxt "dlgSgAiApiKeyRepoLlmConsent.tle:"
+msgid "AI Upload Consent"
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorError.hdl:"
+msgid "Failed to annotate selected commits."
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorError.tle:"
+msgid "Annotate Commits"
+msgstr ""
+
+msgctxt "dlgSgAiCommitAnnotatorOutput.tle:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.fur:"
+msgid "Click the AI button again to generate your first commit message."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.hdl:"
+msgid "GitHub models are now configured."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeActionSetup.tle:"
+msgid "AI Commit Message Compose"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.fur:"
+msgid "No modifications found."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.hdl:"
+msgid "AI generation of the commit message failed."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageComposeError.tle:"
+msgid "AI Commit Message Compose"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageNoModifications.fur:"
+msgid "There are no uncommitted changes in your working tree, so an AI commit message cannot be generated."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageNoModifications.hdl:"
+msgid "No local changes detected."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.btn:"
+msgid "Reword"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.fur:"
+msgid "SmartGit has detected a commit message containing an AI-generation marker. If the commit has not yet been pushed, it can be automatically reworded in the background.\\n\\nYou can enable or disable this option from the AI popup menu."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.hdl:"
+msgid "Do you want to reword marked commits in the background?"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageReworder.tle:"
+msgid "Commit Message Rewording"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.fur:"
+msgid "Your settings exclude untracked files from commits, so they will not be used to generate the AI commit message.\\n\\nTo include untracked files in commits, update the setting in Preferences."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.hdl:"
+msgid "Untracked files are excluded."
+msgstr ""
+
+msgctxt "dlgSgAiCommitMessageSkippedUntrackedFiles.tle:"
+msgid "AI Commit Message"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.hdl:"
+msgid "Configure AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.inf:"
+msgid "SmartGit supports AI-generated commit messages, with more AI features coming. GitHub models can be used out-of-the-box."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Configure manually \\(view documentation\\)"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Disable AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Use GitHub models for this repository"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.rbt:"
+msgid "Use GitHub models globally"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetup.tle:"
+msgid "AI Integration"
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.btn:"
+msgid "Confirm"
+msgstr ""
+
+# [decode] msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data – either from the working tree or selected commits – to GitHub's servers.\n\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \(see the drop-down menu for configuration\)."
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.fur:"
+msgid "To generate commit messages or other AI-based suggestions, SmartGit transmits the relevant git diff data \\u2013 either from the working tree or selected commits \\u2013 to GitHub's servers.\\n\\nBy default, this transfer only occurs when the operation is explicitly invoked. However, background transfer is also possible \\(see the drop-down menu for configuration\\)."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.hdl:"
+msgid "Git diffs will be sent to GitHub for AI processing."
+msgstr ""
+
+msgctxt "dlgSgAiIntegrationSetupGitHubSingle.tle:"
+msgid "Confirm GitHub AI Usage"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.btn:"
+msgid "Go Back"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable automatic stash messages"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable commit explanation"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Enable commit rewording"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.chk:"
+msgid "Only for current repository"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "API URL"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "Model"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.edt:"
+msgid "URL Query"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Commit Rewording"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Explain Commits"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Please wait"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Stash Messages"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.hdl:"
+msgid "Welcome"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can automatically generate stash messages."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can explain individual commits or commit ranges in the background. Results are stored in Git notes."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit can reword commit messages in the background when using special markers."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "SmartGit offers AI-powered features to enhance productivity, simplify workflows, and assist you with your repositories."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "Verifying connectivity..."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.inf:"
+msgid "Verifying connectivity\\u2026"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Leave the stash message blank to enable auto-generation.\\n- SmartGit will generate a message and safely update the stash in the background.\\n- You can always enable or disable AI stash rewording in the Save Stash dialog.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Select one or more commits to generate a natural language explanation.\\n- For multiple commits, explanations are generated in the background and saved in Git Notes.\\n- Select two different branches to generate an explanation of their differences.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "- Use '@ai' to reword the entire commit message.\\n- 'WIP' will describe Work in Progress with an AI generated commit message.\\n- You can always enable or disable AI commit rewording features from the hamburger menu.\\n"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Optional parameters"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Please wait ..."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Please wait \\u2026"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Select your AI provider. This is the service SmartGit will use to generate AI-powered content."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "SmartGit won't ask about AI features again."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Steps"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.lbl:"
+msgid "Your GitHub credentials from the Hosting Provider configuration will be used. There is nothing more to set up here."
+msgstr ""
+
+msgctxt "dlgSgAiSetup.rbt:"
+msgid "Disable AI integration globally"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.rbt:"
+msgid "Enable AI integration"
+msgstr ""
+
+msgctxt "dlgSgAiSetup.tle:"
+msgid "AI Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.fur:"
+msgid "The configuration has been saved to '$1', which is included by '$2'.\\n\\nYou can now start generating commit messages by clicking the AI button again.\\n\\nAdditional configuration options are available and can be tweaked directly in the configuration file. For details, refer to the \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI documentation\\]."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.hdl:"
+msgid "The AI integration has been configured successfully."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConfigurationSuccess.tle:"
+msgid "AI Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupConnectivityFailed.fur:"
+msgid "Object '$1' not found."
+msgstr ""
+
+msgctxt "dlgSgAiSetupConnectivityFailed.hdl:"
+msgid "Connection to '$1' failed."
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Back to Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Enable and Exit"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.btn:"
+msgid "Exit without Enabling"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.fur:"
+msgid "You have selected some AI features. Do you want to enable them now, or exit the setup without enabling them?"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.hdl:"
+msgid "Enable already selected AI features?"
+msgstr ""
+
+msgctxt "dlgSgAiSetupExitEarly.tle:"
+msgid "AI Setup"
+msgstr ""
+
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.fur:"
+msgid "API URL missing."
+msgstr ""
+
+msgctxt "dlgSgAiSetupLlmConfigurationInvalid.hdl:"
+msgid "Configuration is invalid."
+msgstr ""
 
 msgctxt "dlgSgApplicationAlreadyRunning.fur:"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
@@ -2477,6 +3020,22 @@ msgctxt "dlgSgBranchTrackingSetConfirm.tle:"
 msgid "Set Tracked Branch"
 msgstr "设置跟踪分支"
 
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.btn:"
+msgid "Open"
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.fur:"
+msgid "You can see a detailed list of pull requests in the Log's Branches view and review changes in the Graph."
+msgstr ""
+
+msgctxt "dlgSgBranchesOpenPullRequestsInLog.hdl:"
+msgid "Do you want to review pull requests in the Log?"
+msgstr ""
+
 msgctxt "dlgSgBugReportSettings.btn:"
 msgid "Exit"
 msgstr "退出"
@@ -2573,6 +3132,34 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.tle:"
 msgid "Check Out"
 msgstr "检出"
 
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.btn:"
+msgid "Checkout"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.fur:"
+msgid "The target branch has a different submodules configuration \\(.gitmodules\\). If you were expecting this change, you can proceed as usual.\\n\\nOtherwise, be aware that significant changes to your submodule configuration can lead to complex working tree states. In some cases, it might be simpler to perform a fresh clone of the target branch."
+msgstr ""
+
+msgctxt "dlgSgCheckoutSubmoduleChangeConfirm.hdl:"
+msgid "Do you want to check out branch '$1'?"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.btn:"
+msgid "Switch"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.fur:"
+msgid "A worktree repository already exists for the selected branch. Therefore, you can't check out this branch directly, but you can switch to this worktree."
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.hdl:"
+msgid "Do you want to switch to worktree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgCheckoutSwitchToWorktree.tle:"
+msgid "Check Out"
+msgstr ""
+
 msgctxt "dlgSgCheckoutTarget.btn:"
 msgid "Checkout"
 msgstr "检出"
@@ -2584,6 +3171,10 @@ msgstr "跟踪远程分支 “$1”"
 msgctxt "dlgSgCheckoutTarget.chk:"
 msgid "Track remote branch"
 msgstr "跟踪远程分支"
+
+msgctxt "dlgSgCheckoutTarget.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
 
 msgctxt "dlgSgCheckoutTarget.hdl:"
 msgid "Check out commit"
@@ -2696,6 +3287,10 @@ msgstr "将源 SHA 附加到提交消息"
 msgctxt "dlgSgCherryPickConfirmation.fur:"
 msgid "This will cherry-pick the selected commit into the Working Tree."
 msgstr "选中的提交将会被摘取到工作区中"
+
+msgctxt "dlgSgCherryPickConfirmation.fur:"
+msgid "This will cherry-pick the selected commits into the Working Tree."
+msgstr ""
 
 msgctxt "dlgSgCherryPickConfirmation.hdl:"
 msgid "Do you want to cherry-pick?"
@@ -2818,6 +3413,18 @@ msgctxt "dlgSgClone.btn:"
 msgid "Configure"
 msgstr "配置"
 
+msgctxt "dlgSgClone.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgClone.btn:"
+msgid "Go Back"
+msgstr ""
+
+msgctxt "dlgSgClone.chk:"
+msgid "Configure newly cloned repository to use SmartGit as credential helper"
+msgstr ""
+
 msgctxt "dlgSgClone.chk:"
 msgid "Create upstream remote"
 msgstr "同时创建上游仓库的远程连接"
@@ -2842,9 +3449,9 @@ msgctxt "dlgSgClone.chk:"
 msgid "Map SVN trunk, tags and branches to Git"
 msgstr "将 SVN 主干，标签和分支映射到 Git"
 
-msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
+msgctxt "dlgSgClone.chk:"
 msgid "Skip large files \\(\"partial clone\"\\)"
-msgstr "跳过大文件 \\(“部分克隆”\\)"
+msgstr ""
 
 msgctxt "dlgSgClone.edt:"
 msgid "Check Out Branch"
@@ -2930,6 +3537,11 @@ msgctxt "dlgSgClone.hnt:"
 msgid "Searching ..."
 msgstr ""
 
+# [decode] msgid "Searching …"
+msgctxt "dlgSgClone.hnt:"
+msgid "Searching \\u2026"
+msgstr ""
+
 msgctxt "dlgSgClone.inf:"
 msgid "Customize how and what to clone."
 msgstr "自定义克隆的方式和内容。"
@@ -2965,6 +3577,18 @@ msgstr "例如 https://user@server:port/path/to/repository"
 msgctxt "dlgSgClone.mni:"
 msgid "Add Hosting Provider"
 msgstr "添加主机提供商"
+
+msgctxt "dlgSgClone.mni:"
+msgid "Own Repositories"
+msgstr ""
+
+msgctxt "dlgSgClone.mni:"
+msgid "Starred Repositories"
+msgstr ""
+
+msgctxt "dlgSgClone.mni:"
+msgid "Top Repositories"
+msgstr ""
 
 msgctxt "dlgSgClone.rbt:"
 msgid "Clone all revisions \\(recommended\\)"
@@ -3178,9 +3802,9 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Merge commit \\(multiple parents\\)"
 msgstr "合并提交 \\(多个父系\\)"
 
-msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
+msgctxt "dlgSgCommit.rbt:"
 msgid "Simple commit \\(one parent, \"squash\"\\)"
-msgstr "简单提交 \\(1个父系, “压缩”\\)"
+msgstr ""
 
 msgctxt "dlgSgCommit.rbt:"
 msgid "Staged Changes"
@@ -3351,6 +3975,10 @@ msgid "Select a commit"
 msgstr "选择一个提交"
 
 msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
+msgid "No graph roots selected."
+msgstr ""
+
+msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
 msgid "No repository selected."
 msgstr ""
 
@@ -3480,6 +4108,10 @@ msgstr ""
 
 msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl:"
 msgid "The right file is not editable because of mixed line-endings."
+msgstr ""
+
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle:"
+msgid "\\[$1\\] - \\[$2\\] - $3"
 msgstr ""
 
 msgctxt "dlgSgConflictResolverExternalStarted.btn:"
@@ -3755,12 +4387,12 @@ msgid "GIT_DIR for repository at '$1' does not exist."
 msgstr "位于 '$1' 的仓库的 GIT_DIR 不存在。"
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
-msgid "Repository '$1' is not valid."
-msgstr "仓库 “$1” 无效。"
+msgid "No valid worktree state of the repository."
+msgstr ""
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
-msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
-msgstr ""
+msgid "Repository '$1' is not valid."
+msgstr "仓库 “$1” 无效。"
 
 msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "svn: $1"
@@ -3833,6 +4465,22 @@ msgstr "打开文件将显示比较尽管没有变化？"
 msgctxt "dlgSgFileCompareNoChanges.tle:"
 msgid "File Compare"
 msgstr "文件比较"
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.btn:"
+msgid "Rerun"
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.fur:"
+msgid "For the initial commit\\(s\\) where the file was added, SmartGit will try to find a similar pre-existing file. If it finds one, it will continue the Log for that file as the source from which it might have been copied.\\n\\nTo enable this feature by default, set the Low-Level Property `log.file.followCopies` in the Preferences."
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.hdl:"
+msgid "Do you want to re-run the Log with copy-detection enabled?"
+msgstr ""
+
+msgctxt "dlgSgFileLogFollowCopiesConfirmation.tle:"
+msgid "Follow Copies"
+msgstr ""
 
 msgctxt "dlgSgFindObject.edt:"
 msgid "Repository Path, Commit ID or Ref"
@@ -4394,6 +5042,46 @@ msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle:"
 msgid "Run Garbage Collector"
 msgstr "运行垃圾回收"
 
+msgctxt "dlgSgGitConfigEditConfigNotFound.fur:"
+msgid "The file $1config could not be opened for editing."
+msgstr ""
+
+msgctxt "dlgSgGitConfigEditConfigNotFound.hdl:"
+msgid "The file config was not found."
+msgstr ""
+
+msgctxt "dlgSgGitConfigEditConfigNotFound.tle:"
+msgid "Edit Config"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
+msgid "Refresh"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.btn:"
+msgid "Select"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.col:"
+msgid "Number"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.col:"
+msgid "Title"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.hdl:"
+msgid "Select commit message by GitHub issue"
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.inf:"
+msgid "The selected issue summary will be used as commit message."
+msgstr ""
+
+msgctxt "dlgSgGitHubCommitMessageSelect.tle:"
+msgid "Select Issue"
+msgstr ""
+
 msgctxt "dlgSgGitHubGenerateToken.btn:"
 msgid "Authenticate"
 msgstr "认证"
@@ -4590,6 +5278,26 @@ msgctxt "dlgSgGitLabSettingsInvalidToken.tle:"
 msgid "Input Validation"
 msgstr "输入验证"
 
+msgctxt "dlgSgGitNoteAdd.btn:"
+msgid "Add Note"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.edt:"
+msgid "Category"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.hdl:"
+msgid "Add a note to a commit"
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.inf:"
+msgid "Provider the text which should be added to the selected commit."
+msgstr ""
+
+msgctxt "dlgSgGitNoteAdd.tle:"
+msgid "Add Note"
+msgstr ""
+
 msgctxt "dlgSgHeadMessageListenerReplaceMessage.btn:"
 msgid "Don't Replace"
 msgstr "不替换"
@@ -4616,6 +5324,10 @@ msgstr "提交"
 
 msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
 msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
+msgstr ""
+
+msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
+msgid "To modify commits of a different branch, you need to first check out this branch."
 msgstr ""
 
 msgctxt "dlgSgHistoryCommitCantBeModified.hdl:"
@@ -4665,6 +5377,26 @@ msgstr "输入新的提交作者及其电子邮件地址。"
 msgctxt "dlgSgHistoryEditAuthor.tle:"
 msgid "Edit Author"
 msgstr "编辑作者"
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.btn:"
+msgid "From Commit"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.btn:"
+msgid "From Failed Command"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.fur:"
+msgid "A previous Edit Message command invocation failed for this commit. Decide whether to use the commit message from the failed run or the commit's message."
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.hdl:"
+msgid "Which commit message you like to use?"
+msgstr ""
+
+msgctxt "dlgSgHistoryEditChooseCommitMessage.tle:"
+msgid "Edit Message"
+msgstr ""
 
 msgctxt "dlgSgHistoryEditMessage.btn:"
 msgid "JIRA"
@@ -4815,6 +5547,10 @@ msgid "Do you want to modify commits which are already pushed?"
 msgstr "你想修改已推送的提交吗？"
 
 msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.tle:"
+msgid "Edit Author"
+msgstr ""
+
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.tle:"
 msgid "Edit Message"
 msgstr ""
 
@@ -4861,6 +5597,10 @@ msgstr "是否要将所选提交拆分为多个提交?"
 msgctxt "dlgSgHistorySplitConfirm.tle:"
 msgid "Split Commit"
 msgstr "拆分提交"
+
+msgctxt "dlgSgHistorySquash.btn:"
+msgid "Add co-authors"
+msgstr ""
 
 msgctxt "dlgSgHistorySquash.btn:"
 msgid "JIRA"
@@ -4987,7 +5727,35 @@ msgid "The entered URL is invalid - it should look like https://server"
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Azure DevOps Server account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Azure DevOps account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Bitbucket Server account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add Bitbucket account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitHub Enterprise account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Add GitHub account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitLab \\(Self Hosted\\) account"
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.hdl:"
+msgid "Add GitLab account"
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.hdl:"
@@ -5012,6 +5780,10 @@ msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.lbl:"
 msgid "Provide a 'personal access token' which you can generate in your GitHub account settings."
+msgstr ""
+
+msgctxt "dlgSgHostingProviderAdd.lbl:"
+msgid "Required scopes are 'api' and 'write_repository'."
 msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.lbl:"
@@ -5409,6 +6181,10 @@ msgstr "仓库根目录中的 .gitignore"
 msgctxt "dlgSgIgnoreFile.edt:"
 msgid "Ignore File"
 msgstr "忽略文件"
+
+msgctxt "dlgSgIgnoreFile.err:"
+msgid "Enter a pattern for the file\\(s\\) to be ignored. Use \\* to match multiple or ? for a single arbitrary character."
+msgstr ""
 
 msgctxt "dlgSgIgnoreFile.err:"
 msgid "The pattern must match all selected file names. For instance, '$1' is not matched."
@@ -5874,6 +6650,10 @@ msgctxt "dlgSgMergeHowToMerge.fur:"
 msgid "If there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
 msgstr "如果没有冲突, Git 可以自动创建一个合并提交. 或者, 您可以选择合并到工作区. \\n合并到工作区准备一个合并提交, 而 Squash-Merge 将准备一个普通提交 \\(丢弃关于哪些提交被合并的信息\\) - 在两种情况下都需要稍后手动提交"
 
+msgctxt "dlgSgMergeHowToMerge.fur:"
+msgid "You are about to perform an Octopus Merge from $1 source branches.\\n\\nIf there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
+msgstr ""
+
 msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from branch '$1'?"
 msgstr "如何从分支 “$1” 合并？"
@@ -5881,6 +6661,10 @@ msgstr "如何从分支 “$1” 合并？"
 msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from tag '$1'?"
 msgstr "如何从标签 '$1' 合并?"
+
+msgctxt "dlgSgMergeHowToMerge.hdl:"
+msgid "How to merge the $1 selected branches?"
+msgstr ""
 
 msgctxt "dlgSgMergeHowToMerge.tle:"
 msgid "Merge"
@@ -5934,6 +6718,26 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.tle:"
 msgid "Add or Create Repository"
 msgstr "添加或创建仓库"
 
+msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
+msgid "Inner Repository"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.btn:"
+msgid "Outer Repository"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.fur:"
+msgid "At the specified path nested repositories were found.\\nInner repository: $1\\nOuter repository: $2"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.hdl:"
+msgid "Do you want to open the outer or inner repository?"
+msgstr ""
+
+msgctxt "dlgSgOpenRepositoryOuterOrInner.tle:"
+msgid "Add or Create Repository"
+msgstr ""
+
 msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur:"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
@@ -5969,6 +6773,10 @@ msgstr "需要先合并分支."
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Abort failed!"
 msgstr "终止命令执行失败!"
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Add Branch failed!"
+msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Add Submodule failed!"
@@ -6027,6 +6835,18 @@ msgid "Command Discard failed!"
 msgstr "丢弃命令执行失败!"
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Discard produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Edit Author produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Edit Message failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Fetch Pull Request produced warnings."
 msgstr ""
 
@@ -6037,6 +6857,10 @@ msgstr "拉取命令执行失败!"
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Fetch produced warnings."
 msgstr "获取命令执行时产生了警告."
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command LFS Install failed!"
+msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Merge produced warnings."
@@ -6052,6 +6876,10 @@ msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Move produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Pull \\(Merge\\) failed!"
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
@@ -6071,6 +6899,14 @@ msgid "Command Push failed!"
 msgstr "推送命令执行失败!"
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Rebase HEAD \\($1\\) to $2 failed!"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Rebase HEAD \\($1\\) to $2 produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase Interactive failed!"
 msgstr ""
 
@@ -6081,6 +6917,10 @@ msgstr "变基命令执行失败!"
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Rebase produced warnings."
 msgstr "变基命令执行时产生了警告."
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Command Remove Worktree failed!"
+msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Command Reset failed!"
@@ -6127,6 +6967,10 @@ msgid "Command Start Support Branch failed!"
 msgstr "Command Start Support Branch failed!"
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "Command Tool $1 produced warnings."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "Command Unregister Submodule failed!"
 msgstr ""
 
@@ -6143,12 +6987,40 @@ msgid "Not all refs have been pushed."
 msgstr "有些引用未被推送."
 
 msgctxt "dlgSgOutput.lbl:"
+msgid "The command output below contains more details on the problem."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
 msgid "The working tree has local changes."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "Tool $1 succeeded."
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "You have not concluded your merge \\(MERGE_HEAD exists\\)."
 msgstr ""
 
 msgctxt "dlgSgOutput.lbl:"
 msgid "Your local changes to the following files would be overwritten by checkout:\\ncould not detach HEAD"
 msgstr "您对以下文件的本地更改将被签出覆盖:\\n无法分离 HEAD"
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "stash failed \\(return code $1\\)"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to access '$1': Could not resolve host: $2"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to access '$1': server certificate verification failed. CAfile: $2 CRLfile: $3"
+msgstr ""
+
+msgctxt "dlgSgOutput.lbl:"
+msgid "unable to auto-detect email address \\(got '$1.\\(none\\)'\\)"
+msgstr ""
 
 msgctxt "dlgSgOutput.mni:"
 msgid "Copy Selection"
@@ -6177,6 +7049,10 @@ msgstr "输出"
 msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr "请检查仓库 URL。\\n\\n$1"
+
+msgctxt "dlgSgPingRepositoryFailed.fur:"
+msgid "repository '$1' not found."
+msgstr ""
 
 msgctxt "dlgSgPingRepositoryFailed.hdl:"
 msgid "Could not connect to the repository '$1'."
@@ -6231,6 +7107,10 @@ msgid "Import"
 msgstr "导入"
 
 msgctxt "dlgSgPreferences.btn:"
+msgid "Load All Stored Secrets"
+msgstr ""
+
+msgctxt "dlgSgPreferences.btn:"
 msgid "Move Down"
 msgstr "下移"
 
@@ -6261,6 +7141,10 @@ msgstr "重置"
 msgctxt "dlgSgPreferences.btn:"
 msgid "Show Password"
 msgstr "显示密码"
+
+msgctxt "dlgSgPreferences.cdl:"
+msgid "AI Integration"
+msgstr ""
 
 msgctxt "dlgSgPreferences.cdl:"
 msgid "Authentication"
@@ -6363,6 +7247,10 @@ msgid "Allow modifying pushed commits \\(e.g. forced-push\\)"
 msgstr "允许修改推送的提交 \\(例如：强制推送\\)"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Allow modifying pushed commits \\(e.g. forced-push\\):"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Allow to open multiple Log windows for the same repository/file"
 msgstr "允许为同一仓库/文件打开多个日志窗口"
 
@@ -6415,6 +7303,18 @@ msgid "Configure SmartGit as credential helper \\(for repository authentication\
 msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Configure SmartGit as credential helper for Git command line"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Configure newly cloned repository to use SmartGit as credential helper on Git command line"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Delete branch"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Detect local changes in closed 'favorite' repositories"
 msgstr "检测 “我的收藏” 中已关闭仓库中的本地变更"
 
@@ -6427,8 +7327,16 @@ msgid "Detect renames \\(for added and removed files, as command line Git does\\
 msgstr "检测重命名 \\(创建和删​​除文件，如 Git 命令行所做的那样\\)"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Disable AI integration \\(globally\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Distinguish between content and EOL-only changes \\(slightly more expensive\\)"
 msgstr "区分内容和 EOL-only 的变更 \\(稍微昂贵的代价\\)"
+
+msgctxt "dlgSgPreferences.chk:"
+msgid "Enable AI integration"
+msgstr ""
 
 msgctxt "dlgSgPreferences.chk:"
 msgid "Enable integration for configured hosting providers \\(pull requests, comments\\)"
@@ -6495,6 +7403,10 @@ msgid "Push all tags"
 msgstr "推送所有标签"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "Quick Polls \\(help shape SmartGit\\)"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Refresh file system also while SmartGit is in background"
 msgstr "SmartGit 在后台工作时也刷新文件系统"
 
@@ -6551,6 +7463,10 @@ msgid "Sign all commits"
 msgstr "对所有提交进行签名"
 
 msgctxt "dlgSgPreferences.chk:"
+msgid "SmartGit-related announcements"
+msgstr ""
+
+msgctxt "dlgSgPreferences.chk:"
 msgid "Swap 'ours' and 'theirs' on Rebase conflicts for easier understanding"
 msgstr "在变基冲突上使用 “我们的” 和 “他们的” 显示以便于理解"
 
@@ -6601,6 +7517,11 @@ msgstr ""
 
 msgctxt "dlgSgPreferences.cmb:"
 msgid "Custom..."
+msgstr ""
+
+# [decode] msgid "Custom…"
+msgctxt "dlgSgPreferences.cmb:"
+msgid "Custom\\u2026"
 msgstr ""
 
 msgctxt "dlgSgPreferences.cmb:"
@@ -6658,6 +7579,10 @@ msgstr "命令和参数"
 msgctxt "dlgSgPreferences.col:"
 msgid "Command"
 msgstr "命令"
+
+msgctxt "dlgSgPreferences.col:"
+msgid "Credential"
+msgstr ""
 
 msgctxt "dlgSgPreferences.col:"
 msgid "Default"
@@ -6784,6 +7709,10 @@ msgid "Name"
 msgstr "Name"
 
 msgctxt "dlgSgPreferences.edt:"
+msgid "Notify about"
+msgstr ""
+
+msgctxt "dlgSgPreferences.edt:"
 msgid "On startup"
 msgstr "在启动时"
 
@@ -6904,6 +7833,10 @@ msgid "Changing these low-level properties can be harmful to the stability or pe
 msgstr "更改这些低级别属性可能会损害 SmartGit 的稳定性或性能。只有在确定自己在做什么的情况下才能继续。结尾含 \\* 的属性更改之后需要重新启动才能生效。"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Changing these low-level properties may harm the stability or performance of SmartGit.\\n\\[_ Changed properties\\] with a trailing \\\\\\* need a restart to be applied."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Checkout \\(Switch branch\\)"
 msgstr ""
 
@@ -6940,8 +7873,16 @@ msgid "External tool:"
 msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Finish Feature"
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Garbage Collector"
 msgstr "垃圾收集器"
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "General"
+msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "Here you can edit your account's 'gitconfig' which contains the defaults for all repositories."
@@ -6964,8 +7905,16 @@ msgid "In order to use all SmartGit functionality, you need to have command line
 msgstr "要使用所有 SmartGit 功能，您需要在系统上安装 Git 命令行。在这里提供已安装的 “git” 可执行文件的完整路径。"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "Learn how to tailor AI for your projects with the complete \\[https://docs.syntevo.com/SmartGit/Latest/Manual/Integrations/AI SmartGit AI Integration documentation\\]."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "Local and Remote Changes"
 msgstr "本地和远程更改"
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "Note: Some repositories may already have per-repository AI settings."
+msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "Note: The password will be stored in plain text in SmartGit's configuration area!"
@@ -7008,6 +7957,22 @@ msgid "Stash"
 msgstr "贮藏"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*configured globally\\*. Change it via AI button > \\*Reconfigure\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*disabled globally\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*manually configured\\*."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "The AI integration is \\*not yet configured\\* \\(globally\\)."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "The last check was performed on $1."
 msgstr "最后一次检查是在 $1 进行的."
 
@@ -7020,6 +7985,14 @@ msgid "This file will be sent as is: $1"
 msgstr "将发送文件: $1"
 
 msgctxt "dlgSgPreferences.lbl:"
+msgid "To change it, edit your Git config files directly."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "To configure, click the AI button in the Commit Message view or the Commit dialog."
+msgstr ""
+
+msgctxt "dlgSgPreferences.lbl:"
 msgid "To manually update in-place use the '...' button located next to the version number in the About dialog."
 msgstr "要手动就地更新, 请使用关于对话框中版本号旁边的“...”按钮"
 
@@ -7030,6 +8003,10 @@ msgstr ""
 msgctxt "dlgSgPreferences.lbl:"
 msgid "When comparing files, this list is searched from top to bottom to find a matching diff tool. If none is found, the built-in file compare is used for text files."
 msgstr "比较文件时，将从上到下搜索此列表以查找匹配的差异工具。如果未找到，则内置文件比较用于文本文件。"
+
+msgctxt "dlgSgPreferences.lbl:"
+msgid "When enabled, the AI button appears in the Commit Message view and the Commit dialog. Click it to complete the initial setup."
+msgstr ""
 
 msgctxt "dlgSgPreferences.lbl:"
 msgid "When invoking the Conflict Solver feature, this list is searched from top to bottom to find a matching entry. If none is found, the built-in Conflict Solver is used for text files."
@@ -7118,6 +8095,10 @@ msgstr "复制键"
 msgctxt "dlgSgPreferences.mni:"
 msgid "Copy Selection in Column"
 msgstr "复制列中的选定内容"
+
+msgctxt "dlgSgPreferences.mni:"
+msgid "Credential"
+msgstr ""
 
 msgctxt "dlgSgPreferences.mni:"
 msgid "Default"
@@ -7268,6 +8249,10 @@ msgid "Exact case \\('Foo' will match 'Foo', but not 'foo'\\)"
 msgstr "精确匹配 \\(“Foo” 会匹配 “Foo”, 但不会匹配 “foo”\\)"
 
 msgctxt "dlgSgPreferences.rbt:"
+msgid "For all branches"
+msgstr ""
+
+msgctxt "dlgSgPreferences.rbt:"
 msgid "Ignore case \\('Foo' will match 'Foo' and 'foo'\\)"
 msgstr "忽略大小写 \\(“Foo” 会匹配 “Foo” 和 “foo”\\)"
 
@@ -7282,6 +8267,10 @@ msgstr "日志图"
 msgctxt "dlgSgPreferences.rbt:"
 msgid "Log graph \\(commit oriented\\)"
 msgstr "日志图 \\(面向提交\\)"
+
+msgctxt "dlgSgPreferences.rbt:"
+msgid "Only for feature branches"
+msgstr ""
 
 msgctxt "dlgSgPreferences.rbt:"
 msgid "Other Git Executable:"
@@ -7354,6 +8343,10 @@ msgstr "行为"
 msgctxt "dlgSgPreferences.tab:"
 msgid "Colors"
 msgstr "颜色"
+
+msgctxt "dlgSgPreferences.tab:"
+msgid "Credential Helper"
+msgstr ""
 
 msgctxt "dlgSgPreferences.tab:"
 msgid "Encoding"
@@ -7455,6 +8448,10 @@ msgctxt "dlgSgProcessKiller.lbl:"
 msgid "If you think the process is hanging, click the 'Kill Process' button, otherwise 'Wait'."
 msgstr "如果进程卡住了, 可以终止进程或等待."
 
+msgctxt "dlgSgProcessKiller.lbl:"
+msgid "SmartGit is waiting for the following process to finish."
+msgstr ""
+
 msgctxt "dlgSgProcessKiller.tle:"
 msgid "Process Not Responding"
 msgstr "进程无响应"
@@ -7479,12 +8476,44 @@ msgctxt "dlgSgProviderCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr ""
 
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.btn:"
+msgid "Confirm"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.cmb:"
+msgid "github.com"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.edt:"
+msgid "Provider"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.hdl:"
+msgid "Select which GitHub account to use"
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.inf:"
+msgid "Select which account you want to use for connecting to '$1'."
+msgstr ""
+
+msgctxt "dlgSgProviderCredentialsAutoGeneratorSelector.tle:"
+msgid "Select GitHub account"
+msgstr ""
+
 msgctxt "dlgSgProviderGenerateToken.btn:"
 msgid "Authenticate"
 msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
+msgstr ""
+
+msgctxt "dlgSgProviderGenerateToken.hdl:"
+msgid "Generate a new API token for $1"
+msgstr ""
+
+msgctxt "dlgSgProviderGenerateToken.inf:"
+msgid "Authenticate at GitHub and grant access to SmartGit."
 msgstr ""
 
 msgctxt "dlgSgProviderGenerateToken.inf:"
@@ -7793,6 +8822,14 @@ msgctxt "dlgSgPushConfirmSingleTag.chk:"
 msgid "Don't show again"
 msgstr ""
 
+msgctxt "dlgSgPushConfirmSingleTag.fur:"
+msgid "$1 tag will be pushed to '$2'."
+msgstr ""
+
+msgctxt "dlgSgPushConfirmSingleTag.hdl:"
+msgid "Do you want to push tag '$1'?"
+msgstr ""
+
 msgctxt "dlgSgPushConfirmSingleTag.tle:"
 msgid "Push"
 msgstr ""
@@ -7806,8 +8843,8 @@ msgid "Pushing to the remote branch is not fast-forward, so the push has to be f
 msgstr "推送到远程分支不是快进的，因此必须强制推送。远程分支中的提交将丢失。"
 
 msgctxt "dlgSgPushForced.hdl:"
-msgid "Do you want to force-push \\(replace\\) the remote branch?"
-msgstr "你想强制推送 \\(替换\\) 远程分支吗？"
+msgid "Do you want to force-push \\(replace\\) the remote branch '$1'?"
+msgstr ""
 
 msgctxt "dlgSgPushForced.tle:"
 msgid "Push"
@@ -8137,6 +9174,46 @@ msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle:"
 msgid "Rebase"
 msgstr "变基"
 
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.btn:"
+msgid "Continue \\(Resume\\)"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.fur:"
+msgid "Clicking 'Continue' will resume the rebase, e.g. to finish after having modified the commit\\(s\\)."
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.hdl:"
+msgid "Do you want to continue the modify-commit-rebase?"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyContinue.tle:"
+msgid "Modify Commit"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.btn:"
+msgid "Step"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.fur:"
+msgid "Clicking 'Step' will continue the rebase and stop at the next commit. Use it to step through all pending commits, e.g. to verify whether they successfully build."
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.hdl:"
+msgid "Do you want to step to the next commit?"
+msgstr ""
+
+msgctxt "dlgSgRebaseContinueNothingToCommitModifyStep.tle:"
+msgid "Modify Commit"
+msgstr ""
+
 msgctxt "dlgSgRebaseContinueNothingToCommitSkip.btn:"
 msgid "Skip Commit"
 msgstr "跳过提交"
@@ -8349,6 +9426,14 @@ msgctxt "dlgSgRebaseInteractiveMessage.tle:"
 msgid "Edit Message"
 msgstr "编辑消息"
 
+msgctxt "dlgSgRebaseInteractiveNoAutomaticSquashableCommitsFound.fur:"
+msgid "Auto-Squash searches for commits with identical messages and amend-commits them."
+msgstr ""
+
+msgctxt "dlgSgRebaseInteractiveNoAutomaticSquashableCommitsFound.hdl:"
+msgid "No automatic squashable commits found."
+msgstr ""
+
 msgctxt "dlgSgRebaseInteractiveRemoveCommit.btn:"
 msgid "Remove"
 msgstr "删除"
@@ -8377,6 +9462,14 @@ msgctxt "dlgSgRebaseNoop.tle:"
 msgid "Merge"
 msgstr ""
 
+msgctxt "dlgSgRebaseNoopParent.fur:"
+msgid "Rebasing a commit onto its parent is allowed by Git but will not create a new commit or any meaningful changes."
+msgstr ""
+
+msgctxt "dlgSgRebaseNoopParent.hdl:"
+msgid "There is nothing to rebase."
+msgstr ""
+
 msgctxt "dlgSgRebaseNoopSelf.fur:"
 msgid "Rebasing a commit onto itself is allowed by Git but will not create a new commit or any meaningful changes."
 msgstr ""
@@ -8387,6 +9480,18 @@ msgstr ""
 
 msgctxt "dlgSgRebaseNoopSelf.tle:"
 msgid "Rebase"
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.btn:"
+msgid "Rebase Single Commit"
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.fur:"
+msgid "You are about to rebase your branch onto its own history. This action is allowed by Git but will not create a new commit or any meaningful changes.\\n\\nTo rebase a single commit, you can do so now.\\n\\nTo rebase a range of commits, select them in the Graph and drag & drop to the target commit."
+msgstr ""
+
+msgctxt "dlgSgRebaseSingleCommitConfirm.hdl:"
+msgid "Do you want to rebase only the HEAD commit?"
 msgstr ""
 
 msgctxt "dlgSgRebaseTagCommit.btn:"
@@ -8701,6 +9806,10 @@ msgctxt "dlgSgRenameBranch.edt:"
 msgid "Name"
 msgstr "名称"
 
+msgctxt "dlgSgRenameBranch.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
+
 msgctxt "dlgSgRenameBranch.hdl:"
 msgid "Rename branch"
 msgstr "重命名分支"
@@ -8720,6 +9829,10 @@ msgstr "重命名"
 msgctxt "dlgSgRenameFile.edt:"
 msgid "Path"
 msgstr "路径"
+
+msgctxt "dlgSgRenameFile.err:"
+msgid "No valid path specified."
+msgstr ""
 
 msgctxt "dlgSgRenameFile.hdl:"
 msgid "Move or Rename the file"
@@ -8861,6 +9974,10 @@ msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Close"
 msgstr "强制关闭"
 
+msgctxt "dlgSgRepositoryClose.btn:"
+msgid "Force Exit"
+msgstr ""
+
 msgctxt "dlgSgRepositoryClose.fur:"
 msgid "Note that currently running Git processes might not be interrupted."
 msgstr "请注意，当前运行的 Git 进程可能不会被中断。"
@@ -8872,6 +9989,10 @@ msgstr "你真的想现在关闭吗？"
 msgctxt "dlgSgRepositoryClose.tle:"
 msgid "Close"
 msgstr "关闭"
+
+msgctxt "dlgSgRepositoryClose.tle:"
+msgid "Exit"
+msgstr ""
 
 msgctxt "dlgSgRepositoryFrameCloseWithoutPush.btn:"
 msgid "Close Now"
@@ -8990,6 +10111,10 @@ msgid "Always fetch new commits, tags and branches from submodule"
 msgstr "始终从子模块中获取新的提交，标签和分支"
 
 msgctxt "dlgSgRepositorySettings.chk:"
+msgid "Configure SmartGit as credential helper for Git command line"
+msgstr ""
+
+msgctxt "dlgSgRepositorySettings.chk:"
 msgid "Initialize new submodules"
 msgstr "初始化新的子模块"
 
@@ -9062,12 +10187,16 @@ msgid "Edit the repository settings"
 msgstr "编辑仓库设置"
 
 msgctxt "dlgSgRepositorySettings.inf:"
-msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
-msgstr "在这里, 您可以编辑该仓库的 Git 设置. 默认设置可以在首选项中找到."
+msgid "Here you can edit the Git settings for the repository. The default settings can be found in the Preferences."
+msgstr ""
 
 msgctxt "dlgSgRepositorySettings.lbl:"
 msgid "\\* if repository commit references non-pushed submodule commit"
 msgstr "\\* if repository commit references non-pushed submodule commit"
+
+msgctxt "dlgSgRepositorySettings.tab:"
+msgid "Credential Helper"
+msgstr ""
 
 msgctxt "dlgSgRepositorySettings.tab:"
 msgid "Encoding"
@@ -9115,6 +10244,10 @@ msgstr "<b>多个分组模式</b>"
 
 msgctxt "dlgSgRepositorySettings.ttpGroupPatterns:"
 msgid "Patterns will show up in the GUI using auto-generated labels which are derived from their regular expression. You can assign a custom label <tt>label</tt> to a pattern by prefixing it by <tt>label:</tt>; a label may only contain letters, digits and '_'."
+msgstr ""
+
+msgctxt "dlgSgRepositorySettings.wrn:"
+msgid "It is recommended to set an email address used for committing."
 msgstr ""
 
 msgctxt "dlgSgRepositorySettings.wrn:"
@@ -9237,21 +10370,21 @@ msgctxt "dlgSgResolve.rbt:"
 msgid "Open Conflict Solver"
 msgstr "打开冲突解决工具"
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"ours\", $2\\)"
-msgstr "设置为 $1 \\(“我们的”，$2 \\)"
+msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"theirs\", $2\\)"
-msgstr "设置为 $1 \\(“他们的”，$2 \\)"
+msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebase target \\(\"theirs\", $1\\)"
-msgstr "设置为变基目标 \\(“他们的”，$1\\)"
+msgstr ""
 
-msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
+msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
-msgstr "设置为变基分支 “$1” \\(“我们的”，$2\\)"
+msgstr ""
 
 msgctxt "dlgSgResolve.tle:"
 msgid "Resolve"
@@ -9697,6 +10830,10 @@ msgctxt "dlgSgRollbackToCommit.fur:"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr ""
 
+msgctxt "dlgSgRollbackToCommit.hdl:"
+msgid "Do you want to rollback the Index to the state of commit $1?"
+msgstr ""
+
 msgctxt "dlgSgRollbackToCommit.tle:"
 msgid "Rollback To"
 msgstr ""
@@ -9774,12 +10911,24 @@ msgid "Send usage statistics"
 msgstr "发送使用量统计"
 
 msgctxt "dlgSgSetup.chk:"
+msgid "Use SmartGit for authentication \\(ignoring your current credential.helper configuration\\)"
+msgstr ""
+
+msgctxt "dlgSgSetup.chk:"
 msgid "Use gravatar.com to show images for the users"
 msgstr "使用 gravatar.com 为用户显示资料图片"
 
 msgctxt "dlgSgSetup.edt:"
 msgid "Email"
 msgstr "电子邮箱"
+
+msgctxt "dlgSgSetup.edt:"
+msgid "Full Name"
+msgstr ""
+
+msgctxt "dlgSgSetup.edt:"
+msgid "Git Email"
+msgstr ""
 
 msgctxt "dlgSgSetup.edt:"
 msgid "Git Executable"
@@ -9801,9 +10950,33 @@ msgctxt "dlgSgSetup.edt:"
 msgid "User Name"
 msgstr "用户名"
 
+msgctxt "dlgSgSetup.hdl:"
+msgid "Git Executable"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "License"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "Privacy"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "Style"
+msgstr ""
+
+msgctxt "dlgSgSetup.hdl:"
+msgid "User Information"
+msgstr ""
+
 msgctxt "dlgSgSetup.inf:"
 msgid "If you are using SSH to connect to other Git repositories, select what SSH client to use. You can change it later in the Preferences."
 msgstr "如果您使用 SSH 连接到其他 Git 仓库，请选择要使用的 SSH 客户端。 您可以稍后在偏好设置中进行更改。"
+
+msgctxt "dlgSgSetup.inf:"
+msgid "Please review the following privacy options. You can change them later in the Preferences."
+msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
 msgid "Please review the following privacy options. You can change them later in the preferences."
@@ -9820,6 +10993,10 @@ msgstr "SmartGit 要求在您的系统上安装兼容的 Git。请指定 'git' �
 msgctxt "dlgSgSetup.inf:"
 msgid "User name and email will be stored as part of your commits. Here you can configure the default values which are stored in .gitconfig."
 msgstr "用户名和电子邮件将作为提交的一部分存储。 您可以在此处配置并存储在 .gitconfig。"
+
+msgctxt "dlgSgSetup.inf:"
+msgid "User name and email will be stored as part of your commits. Here you can configure the default values which are stored in ~/.gitconfig."
+msgstr ""
 
 msgctxt "dlgSgSetup.inf:"
 msgid "Welcome to SmartGit! Please confirm that you are accepting the license agreement."
@@ -9886,6 +11063,10 @@ msgid "may be harder to configure and use for new users, but is more flexible"
 msgstr "较难在初次使用时配置与使用，但更灵活"
 
 msgctxt "dlgSgSetup.rbt:"
+msgid "Bundled Git"
+msgstr ""
+
+msgctxt "dlgSgSetup.rbt:"
 msgid "Commits \\(Log History\\)"
 msgstr "日志历史"
 
@@ -9900,6 +11081,10 @@ msgstr "日志图 \\(面向提交\\)"
 msgctxt "dlgSgSetup.rbt:"
 msgid "Non-commercial use only \\(most features, no support\\)"
 msgstr "仅限非商业用途 \\(大多数功能, 无技术支持\\)"
+
+msgctxt "dlgSgSetup.rbt:"
+msgid "Other Git Executable:"
+msgstr ""
 
 msgctxt "dlgSgSetup.rbt:"
 msgid "Registered user, commercial use \\(all features, support\\)"
@@ -9938,8 +11123,8 @@ msgid "Use Standard Window"
 msgstr "使用标准窗口"
 
 msgctxt "dlgSgSetupStdWnd.fur:"
-msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
-msgstr "对于 \\*初出茅庐的 Git 用户\\* ，我们推荐使用标准窗口。如果您对 SmartGit 的老版本十分熟悉，或许会对标准窗口与自己熟悉的界面 \\*十分不同\\* 感到诧异。若您对旧有体验情有独钟，可以考虑启用 \\*日志图\\* 或 \\*工作区\\* 窗口。"
+msgid "We recommend the Standard window for \\*new SmartGit users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
+msgstr ""
 
 msgctxt "dlgSgSetupStdWnd.hdl:"
 msgid "Do you want to use the Standard Window?"
@@ -10222,6 +11407,10 @@ msgid "Automatically save stash"
 msgstr "自动贮藏"
 
 msgctxt "dlgSgStashOnDemandConfirmation.fur:"
+msgid "Add Branch may require a clean working tree to complete successfully. After the Add Branch succeeded, the stashed local changes will be automatically reapplied."
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.fur:"
 msgid "Check Out may require a clean working tree to complete successfully. After the Check Out succeeded, the stashed local changes will be automatically reapplied."
 msgstr "检出操作要求工作区无更改。检出后将会自动重新应用贮藏的本地更改。"
 
@@ -10250,6 +11439,10 @@ msgid "Squash Commits may require a clean working tree to complete successfully.
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
+msgid "Do you want to save local changes to a stash and retry Add Branch?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "Do you want to save local changes to a stash and retry Check Out?"
 msgstr ""
 
@@ -10267,6 +11460,10 @@ msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "Do you want to save local changes to a stash and retry Reorder Commits?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
+msgid "Do you want to save local changes to a stash and retry Squash Commits?"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
@@ -10294,16 +11491,44 @@ msgid "Checkout"
 msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Edit Message"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
 msgstr "拉取"
+
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Reorder Commits"
+msgstr ""
 
 msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Reset"
 msgstr ""
 
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
+msgid "Squash Commits"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.fur:"
+msgid "It might be hard or impossible to restore them!"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.hdl:"
+msgid "Do you really want to discard the local changes?"
+msgstr ""
+
+msgctxt "dlgSgStashOnDemandDiscardConfirmation.tle:"
+msgid "Reset"
+msgstr ""
+
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
-msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
-msgstr "完成拉取操作后，您应该手动应用最新的存储，以将本地变更还原到工作区中。"
+msgid "Once you have concluded the Reorder Commits, you should manually apply the latest stash to get your local changes back into the working tree."
+msgstr ""
 
 msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl:"
 msgid "Your local changes have been stashed away, but could not be reapplied."
@@ -10411,7 +11636,23 @@ msgid "Directory '$1' already exists."
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.err:"
+msgid "Please specify the URL of the remote repository or the path of the local repository that should be cloned."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.err:"
 msgid "Please specify the URL of the remote repository to be cloned."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.err:"
+msgid "The specified directory is not the root of a repository."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hdl:"
+msgid "Path"
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hdl:"
+msgid "Repository"
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.hnt:"
@@ -10419,7 +11660,16 @@ msgid "No repository found."
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.hnt:"
+msgid "No repository matches the entered filter."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleAdd.hnt:"
 msgid "Searching ..."
+msgstr ""
+
+# [decode] msgid "Searching …"
+msgctxt "dlgSgSubmoduleAdd.hnt:"
+msgid "Searching \\u2026"
 msgstr ""
 
 msgctxt "dlgSgSubmoduleAdd.inf:"
@@ -10500,6 +11750,14 @@ msgstr ""
 
 msgctxt "dlgSgSubmoduleInitAll.tle:"
 msgid "Initialize Submodule"
+msgstr ""
+
+msgctxt "dlgSgSubmoduleInitAllConfigured.fur:"
+msgid "You may now pull individual submodules or on the root directory to clone the configured repositories."
+msgstr ""
+
+msgctxt "dlgSgSubmoduleInitAllConfigured.hdl:"
+msgid "Submodules have been configured."
 msgstr ""
 
 msgctxt "dlgSgSubmoduleInitGit.btn:"
@@ -10618,8 +11876,24 @@ msgctxt "dlgSgSubmoduleUnregisterConfirm.fur:"
 msgid "All relevant files will be adjusted. Afterwards you will only need to perform a commit to finish the operation. To just skip the submodule from the working tree, use Deinit."
 msgstr ""
 
+msgctxt "dlgSgSubmoduleUnregisterConfirm.hdl:"
+msgid "Do you want to unregister submodule '$1'?"
+msgstr ""
+
 msgctxt "dlgSgSubmoduleUnregisterConfirm.tle:"
 msgid "Unregister Submodule"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Configure"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Continue"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.btn:"
+msgid "Go Back"
 msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.chk:"
@@ -10643,12 +11917,65 @@ msgid "Local Path"
 msgstr "本地路径"
 
 msgctxt "dlgSgSubtreeAdd.edt:"
+msgid "Relative Path"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.edt:"
 msgid "Remote"
 msgstr "远程"
 
 msgctxt "dlgSgSubtreeAdd.edt:"
 msgid "Repository URL"
 msgstr "仓库 URL"
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "A local branch with this name already exists. Use a different name."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Consecutive dots are not allowed."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Consecutive slashes are not allowed."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Directory '$1' already exists."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Enter the name of the local branch."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Please enter a valid relative path. The submodule will be created at this path inside the repository."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "Please select a valid branch."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "The name must not contain control characters, space, ~, ^, :, ?, \\*, \\[, < or >."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.err:"
+msgid "The name must not end with a slash or dot."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.hdl:"
+msgid "Path"
+msgstr ""
+
+msgctxt "dlgSgSubtreeAdd.hdl:"
+msgid "Repository"
+msgstr ""
+
+# [decode] msgid "Searching …"
+msgctxt "dlgSgSubtreeAdd.hnt:"
+msgid "Searching \\u2026"
+msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.inf:"
 msgid "Provide the path where the subtree should be added relative to the outer repository root directory."
@@ -10658,9 +11985,17 @@ msgctxt "dlgSgSubtreeAdd.inf:"
 msgid "Specify the repository to clone as subtree."
 msgstr "Specify the repository to clone as subtree."
 
+msgctxt "dlgSgSubtreeAdd.inf:"
+msgid "Specify the repository to clone as subtree.\\nTo configure multiple accounts of the same hosting provider, use the Preferences."
+msgstr ""
+
 msgctxt "dlgSgSubtreeAdd.lbl:"
 msgid "Local branches for subtrees will only be useful if you plan to use Subtree-Split and Subtree-Reset operations."
 msgstr "Local branches for subtrees will only be useful if you plan to use Subtree-Split and Subtree-Reset operations."
+
+msgctxt "dlgSgSubtreeAdd.lbl:"
+msgid "Steps"
+msgstr ""
 
 msgctxt "dlgSgSubtreeAdd.lbl:"
 msgid "e.g. https://user@server:port/path/to/repository"
@@ -10677,6 +12012,90 @@ msgstr "远程仓库"
 msgctxt "dlgSgSubtreeAdd.tle:"
 msgid "Add Subtree"
 msgstr "添加子树"
+
+msgctxt "dlgSgSubtreeAddSuccess.fur:"
+msgid "Subtree operations are now available in \\*Branches\\* and \\*Graph\\* view, for \\*$1\\* and refs belonging to the \\*$2\\* remote."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.fur:"
+msgid "Subtree operations are now available in \\*Branches\\* and \\*Graph\\* view, for refs belonging to the \\*$1\\* remote."
+msgstr ""
+
+msgctxt "dlgSgSubtreeAddSuccess.hdl:"
+msgid "Subtree '$1' has been successfully added."
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.btn:"
+msgid "Merge"
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.fur:"
+msgid "Changes from '$1' will be merged into sub-directory '$2'."
+msgstr ""
+
+msgctxt "dlgSgSubtreeMergeWithPrefix.hdl:"
+msgid "Do you want to merge subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.chk:"
+msgid "Annotate generated history with prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.chk:"
+msgid "Rejoin generated history \\(for more efficient future splits\\)"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.edt:"
+msgid "Prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.hdl:"
+msgid "Do you want to push back subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreePush.inf:"
+msgid "HEAD changes from sub-directory '$1' will be rewritten onto '$2' and pushed back."
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.btn:"
+msgid "Reset"
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.fur:"
+msgid "This will reset the sub-directory '$1' in your main history to the same state as in the subtree history at '$2'.\\n\\nChanges in the sub-directory which are only present in your main history commits will be lost. Only use this operation after your changes have been merged into the subtree history!"
+msgstr ""
+
+msgctxt "dlgSgSubtreeReset.hdl:"
+msgid "Do you want to reset subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.chk:"
+msgid "Annotate generated history with prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.chk:"
+msgid "Rejoin generated history \\(for more efficient future splits\\)"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.edt:"
+msgid "Prefix"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.edt:"
+msgid "Subtree-Branch to update"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.hdl:"
+msgid "Do you want to update subtree '$1'?"
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.inf:"
+msgid "HEAD changes from sub-directory '$1' will be rewritten onto '$2'."
+msgstr ""
+
+msgctxt "dlgSgSubtreeSplit.lbl:"
+msgid "The selected branch pointer will be set to the HEAD of the generated history."
+msgstr ""
 
 msgctxt "dlgSgSvnClientCertificate.btn:"
 msgid "Login"
@@ -10706,9 +12125,9 @@ msgctxt "dlgSgSvnClientCertificate.tle:"
 msgid "SVN Authentication"
 msgstr "SVN 认证"
 
-msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
+msgctxt "dlgSgSvnClientCertificate.wrn:"
 msgid "Authentication to the SVN repository '$1' failed with error: $2'"
-msgstr "对 SVN 仓库 “$1” 的身份验证失败，错误：$2"
+msgstr ""
 
 msgctxt "dlgSgSvnSslFingerprintChanged.btn:"
 msgid "Accept"
@@ -10873,6 +12292,10 @@ msgstr "键盘快捷键"
 msgctxt "dlgSgToolEdit.err:"
 msgid "Please enter the name for this command."
 msgstr "请输入此命令的名称。"
+
+msgctxt "dlgSgToolEdit.err:"
+msgid "Select the command which should be invoked."
+msgstr ""
 
 msgctxt "dlgSgToolEdit.hdl:"
 msgid "Edit external tool"
@@ -11162,6 +12585,254 @@ msgctxt "dlgShPushTrackingLocalSvnBranches.tle:"
 msgid "Push"
 msgstr "推送"
 
+msgctxt "dlgStdCheckoutCommit.btn:"
+msgid "Add Branch && Checkout"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.edt:"
+msgid "Branch"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.hdl:"
+msgid "Add branch at commit $1"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.inf:"
+msgid "Enter the name of the local branch to create. It will be checked out."
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.rbt:"
+msgid "Checkout local branch:"
+msgstr ""
+
+msgctxt "dlgStdCheckoutCommit.rbt:"
+msgid "Create local branch:"
+msgstr ""
+
+msgctxt "dlgStdDiscard.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdDiscard.fur:"
+msgid "You won't be able to restore them."
+msgstr ""
+
+msgctxt "dlgStdDiscard.hdl:"
+msgid "Do you want to discard local changes?"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.btn:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.chk:"
+msgid "Don't show again"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.fur:"
+msgid "You are about to delete untracked files permanently. This action cannot be undone."
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.hdl:"
+msgid "Do you want to delete untracked files?"
+msgstr ""
+
+msgctxt "dlgStdDiscardConfirmUntrackedFiles.tle:"
+msgid "Discard"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.btn:"
+msgid "Confirm"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Feature Prefix"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Main Branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.edt:"
+msgid "Main Branches"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.hdl:"
+msgid "Configure main and feature branches"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.hdl:"
+msgid "Configure main branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.inf:"
+msgid "Set the main branch for your repository and an optional prefix for feature branches."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.inf:"
+msgid "Set the main branch for your repository."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.lbl:"
+msgid "Example: develop, release-.\\*"
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.lbl:"
+msgid "The 'main branch' represents the main development branch of your repository and serves as a foundation for releases. Usually it is named 'develop', 'master' or 'main'.\\n\\nBranches that are used to develop a single new feature, bugfix or other related changes \\(temporarily\\) isolated from the main branch are called 'feature branch' \\(or short 'feature'\\). They typically have a special name prefix, e.g. 'feature/'.\\n\\nNew features will be forked off from a main branch using 'Start'. For an existing feature, new changes from the main branch will be integrated using 'Integrate'. Once you have finished the feature, you can incorporate it into the main branch using 'Finish'.\\n\\nFor extended configuration options, invoke '\\u30d6\\u30e9\\u30f3\\u30c1 \\| Feature \\u306e\\u8a2d\\u5b9a'."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.ttp:"
+msgid "The <b>Feature Prefix</b> is optional. <tt>feature/</tt>is commonly used and compatible with Git-Flow."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfiguration.ttp:"
+msgid "You can configure one or more <b>Main Branches</b> by specifying their names separated by semicolon. To specify patterns instead of singular names, use regular expressions. For example: <tt>main,release-.\\*</tt>."
+msgstr ""
+
+msgctxt "dlgStdFeatureConfigurationSimple.hdl:"
+msgid "'$1' has been configured as main branch and '$2' as feature-prefix."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.btn:"
+msgid "Select"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Create merge commit"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Delete feature branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.chk:"
+msgid "Push results"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.edt:"
+msgid "Merge Message"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.hdl:"
+msgid "Finish feature '$1'"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.inf:"
+msgid "Choose how to finish the feature branch '$1'. This operation will integrate the feature branch into the '$2' branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.rbt:"
+msgid "Create Pull Request"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinish.rbt:"
+msgid "Finish to main branch"
+msgstr ""
+
+msgctxt "dlgStdFeatureFinishFeatureEmpty.fur:"
+msgid "Your feature branch does not contain any new commits. Finishing now will simply remove the branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureFinishFeatureEmpty.hdl:"
+msgid "Feature branch is empty."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "Branch '$1' is ahead of '$2'.\\n\\nConsolidate the '$3'-branch, then invoke Integrate again."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "The feature branch has been rebased onto '$1'.\\n\\nYou may now verify and push the branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.fur:"
+msgid "The local feature branch has been rebased onto the remote branch '$1'.\\n\\nYou may now verify and push the branch, then invoke Integrate again."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Resolve diverged main branch."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Verify integrated main changes."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.hdl:"
+msgid "Verify integrated remote changes."
+msgstr ""
+
+msgctxt "dlgStdFeatureIntegrateProgress.lbl:"
+msgid "Steps"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.btn:"
+msgid "Start"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.edt:"
+msgid "Feature Name"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.hdl:"
+msgid "Start a new feature"
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.inf:"
+msgid "Enter the name of the new feature branch. This operation will fork a new branch from '$1'."
+msgstr ""
+
+msgctxt "dlgStdFeatureStart.lbl:"
+msgid "Resulting Branch: $1"
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.btn:"
+msgid "Switch Anyway"
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.fur:"
+msgid "Your working tree currently has local modifications, and you are not currently on the main branch. Initiating a new feature now will require switching commits, which can potentially fail due to the presence of local changes.\\n\\nThe recommended course of action is either to commit your local changes \\(if they pertain to the current branch\\) or stash them away in order to have a clean working tree before starting a new feature."
+msgstr ""
+
+msgctxt "dlgStdFeatureStartNotOnMainBranchesAndLocalChanges.hdl:"
+msgid "Do you want to switch to a different branch despite having local changes?"
+msgstr ""
+
+msgctxt "dlgStdOutputCommandConflicts.fur:"
+msgid "These conflicts must be resolved before continuing. Select the conflicted files in the Local Files view and use the Conflict Solver to resolve them, then continue the operation."
+msgstr ""
+
+msgctxt "dlgStdOutputCommandConflicts.hdl:"
+msgid "SmartGit encountered conflicts during the Integrate main operation."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.fur:"
+msgid "Commit or stash local changes before cherry-picking."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.fur:"
+msgid "Commit or stash local changes before reverting."
+msgstr ""
+
+msgctxt "dlgStdPickCommitWtDirty.hdl:"
+msgid "The working tree contains local changes."
+msgstr ""
+
+msgctxt "dlgStdRemove.btn:"
+msgid "Delete Local Files"
+msgstr ""
+
+msgctxt "dlgStdRemove.btn:"
+msgid "Keep Local Files"
+msgstr ""
+
+msgctxt "dlgStdRemove.fur:"
+msgid "You can just remove the files from the repository \\(keeping the local files, e.g. to mark them later as ignored\\), or also delete the local files."
+msgstr ""
+
+msgctxt "dlgStdRemove.hdl:"
+msgid "How do you want to remove the files from the repository?"
+msgstr ""
+
 msgctxt "dlgTxtEditor.fileModified.btn:"
 msgid "Keep Content"
 msgstr "保留内容"
@@ -11175,8 +12846,8 @@ msgid "Unless you want to see the old file state, it is recommended to reload."
 msgstr "重新加载将显示最新的文件状态."
 
 msgctxt "dlgTxtEditor.fileModified.hdl:"
-msgid "The file config was changed. Reload it?"
-msgstr "该文件配置已变更. 是否重新加载?"
+msgid "The file $1 was changed. Reload it?"
+msgstr ""
 
 msgctxt "dlgTxtEditor.fileModified.tle:"
 msgid "Editor"
@@ -11283,6 +12954,10 @@ msgid "In case you are encountering strange errors or unexpected dialog popups, 
 msgstr "万一您遇到奇怪的错误或意外的对话框弹出, 可以尝试禁用此配置改由 SmartGit 处理身份验证."
 
 msgctxt "ntmCredentialHelper:"
+msgid "In general this should be fine and is the recommended configuration when working with multiple Git clients. If unexpected credential popups or weird errors occur, try to let SmartGit handle the authentication itself."
+msgstr ""
+
+msgctxt "ntmCredentialHelper:"
 msgid "In general this should be fine and is the recommended configuration when working with multiple Git clients. In case you are encountering strange errors or unexpected dialog popups, try to disable this configuration and let SmartGit handle the authentication itself."
 msgstr ""
 
@@ -11297,6 +12972,18 @@ msgstr "SmartGit 检测到 <b>credential.helper</b> 被配置到了 $1 文件中
 msgctxt "ntmCredentialHelper:"
 msgid "To disable this configuration, open the above config file, locate the <b>\\[credential\\]</b>-section and comment out the <b>helper\\=</b> line using <b>#</b>"
 msgstr "要想禁用此配置项, 请打开以上配置文件, 定位到 <b>\\[credential\\]</b>-选项并使用<b>#</b>注释掉 <b>helper\\=</b>"
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Directory '$1' \\($2\\) has been excluded from file monitoring because it's listed in some .gitignore file."
+msgstr ""
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Sometimes ignored directories are containing tracked files in which case changes to these files might not show up automatically. If this is the case for you, you may disable this optimization by setting system property 'fileMonitor.excludeIgnoredDirectories\\=false'."
+msgstr ""
+
+msgctxt "ntmFileMonitorDirectoriesExcluded:"
+msgid "Usually this does not cause any problems but improves Refreshing performance and reduces required inotify handles."
+msgstr ""
 
 msgctxt "ntmFollowUsOnTwitter:"
 msgid "<link1>Facebook</link1>: news"
@@ -11343,7 +13030,19 @@ msgid "poll for opinions on how to implement new or change existing features"
 msgstr "关于如何实施新功能或更改现有功能的意见调查"
 
 msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Bluesky</link1>: news"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Bluesky</link1>: news, polls, discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
 msgid "<link1>Facebook</link1>: news"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Mastodon</link1>: news"
 msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
@@ -11351,7 +13050,19 @@ msgid "<link1>Mastodon</link1>: news, polls, discussions"
 msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
+msgid "<link1>Reddit</link1>: discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>UserEcho</link1>: feature requests, voting"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
 msgid "<link1>UserEcho</link1>: improvement ideas, discussions"
+msgstr ""
+
+msgctxt "ntmFollowUsOnX:"
+msgid "<link1>X</link1>: news"
 msgstr ""
 
 msgctxt "ntmFollowUsOnX:"
@@ -11382,6 +13093,10 @@ msgctxt "ntmHostingProviderIntegrationNotYetConfigured:"
 msgid "SmartGit provides special support for $1. The integration can be configured in the Preferences."
 msgstr "SmartGit 为 $1 提供特殊支持服务. 可在首选项中配置集成."
 
+msgctxt "ntmLcTypeProblem:"
+msgid "If you experience problems with garbled file names/paths containing non-US-ASCII characters, consider to set the environment variables <tt>LC_ALL</tt>, or both <tt>LC_CTYPE</tt> and <tt>LANG</tt> to a country code which ends with \"<tt>.UTF-8</tt>\"."
+msgstr ""
+
 msgctxt "ntmMarkRepositoriesAsFavorite:"
 msgid "Git repositories marked as 'favorites' will be refreshed and fetched automatically in the background."
 msgstr "标记为收藏的仓库会后台自动刷新"
@@ -11402,6 +13117,10 @@ msgctxt "ntmRepositoryGitCleanup:"
 msgid "The repository '$1' contains a significant amount of loose or even unused 'objects'. Running a cleanup will reduce disk space and increase performance. SmartGit will try to do so, when it is idle."
 msgstr ""
 
+msgctxt "ntmRepositoryRefsReadingManyLoose:"
+msgid "The repository '$1' contains many 'loose' refs which makes refreshing inefficient. Repacking the refs will improve performance."
+msgstr ""
+
 msgctxt "ntmSupportExpired:"
 msgid "To extend your support, please purchase an update license and upgrade to the latest SmartGit version."
 msgstr "想要使用支持服务, 请购买升级授权许可并更新到最新版本."
@@ -11410,9 +13129,23 @@ msgctxt "ntmSupportExpired:"
 msgid "You may continue to use SmartGit, just your support period expired."
 msgstr "您可以继续使用 SmartGit, 只是支持服务已过期."
 
+msgctxt "ntmUpdateCheckChannelSubscribePolls:"
+msgid "Occasionally, you'll be invited to quick polls here in the notification area. Your feedback helps shape SmartGit's future. You can turn this off anytime in the Preferences."
+msgstr ""
+
 msgctxt "ntmUpdateCheckFetchVersionStart:"
 msgid "After the new version has been downloaded successfully, you will be notified again."
 msgstr "After the new version has been downloaded successfully, you will be notified again."
+
+# TODO: Check if the variable range is correct.
+#| msgid "SmartGit 25.1.093 needs to be restarted now for the changes to take effect."
+msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+msgid "$1 needs to be restarted now for the changes to take effect."
+msgstr ""
+
+msgctxt "ntmUpdateCheckFetchVersionSuccess:"
+msgid "SmartGit $1 Preview needs to be restarted now for the changes to take effect."
+msgstr ""
 
 msgctxt "ntmUpdateCheckFetchVersionSuccess:"
 msgid "SmartGit needs to be restarted now for the changes to take effect."
@@ -11434,9 +13167,25 @@ msgctxt "ntmVoteForUs:"
 msgid "vote at <link1>alternativeto.net</link1>"
 msgstr "vote at <link1>alternativeto.net</link1>"
 
+msgctxt "ntmWslWorkaround:"
+msgid "To work around some problems with WSL, please check our documentation."
+msgstr ""
+
+msgctxt "nttCredentialHelper:"
+msgid "External Credential Helper detected"
+msgstr ""
+
 msgctxt "nttCredentialHelper:"
 msgid "External Credentials Helper detected"
 msgstr "检测到外部凭据帮助程序"
+
+msgctxt "nttCredentialHelper:"
+msgid "Let SmartGit handle Authentication"
+msgstr ""
+
+msgctxt "nttFileMonitorDirectoriesExcluded:"
+msgid "Ignored directories are not monitored"
+msgstr ""
 
 msgctxt "nttFollowUsOnTwitter:"
 msgid "Follow SmartGit on Twitter!"
@@ -11462,6 +13211,10 @@ msgctxt "nttGeneral:"
 msgid "Remind me later"
 msgstr "以后再说"
 
+msgctxt "nttGeneral:"
+msgid "Skip this Poll"
+msgstr ""
+
 msgctxt "nttHighMemoryUsage:"
 msgid "Contact Support"
 msgstr "联系支持"
@@ -11477,6 +13230,10 @@ msgstr "$1-integration is not yet configured."
 msgctxt "nttHostingProviderIntegrationNotYetConfigured:"
 msgid "Configure Now"
 msgstr "立即配置"
+
+msgctxt "nttLcTypeProblem:"
+msgid "Experience problems with non-US-ASCII file names?"
+msgstr ""
 
 msgctxt "nttMarkRepositoriesAsFavorite:"
 msgid "Mark repositories as 'favorite' for automatic background refresh."
@@ -11510,6 +13267,18 @@ msgctxt "nttRepositoryGitCleanup:"
 msgid "Run Garbage Collector Now"
 msgstr ""
 
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Do not warn me again for this repository"
+msgstr ""
+
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Many loose refs"
+msgstr ""
+
+msgctxt "nttRepositoryRefsReadingManyLoose:"
+msgid "Repack"
+msgstr ""
+
 msgctxt "nttSupportExpired:"
 msgid "Purchase Update"
 msgstr "购买更新"
@@ -11518,9 +13287,29 @@ msgctxt "nttSupportExpired:"
 msgid "Your support period has expired on $1."
 msgstr "您的支持服务将于 $1 过期."
 
+msgctxt "nttUpdateCheck:"
+msgid "Quick Poll: $1"
+msgstr ""
+
+msgctxt "nttUpdateCheck:"
+msgid "Vote"
+msgstr ""
+
+msgctxt "nttUpdateCheckChannelSubscribePolls:"
+msgid "Turn on"
+msgstr ""
+
+msgctxt "nttUpdateCheckChannelSubscribePolls:"
+msgid "Want to influence SmartGit's development?"
+msgstr ""
+
 msgctxt "nttUpdateCheckFetchVersionStart:"
 msgid "Started downloading version $1 \\($2\\)."
 msgstr "正在下载版本 $1 \\($2\\)."
+
+msgctxt "nttUpdateCheckFetchVersionStart:"
+msgid "Started downloading version $1."
+msgstr ""
 
 msgctxt "nttUpdateCheckFetchVersionSuccess:"
 msgid "Restart SmartGit"
@@ -11542,9 +13331,21 @@ msgctxt "nttVoteForUs:"
 msgid "What do you like in SmartGit?"
 msgstr "您喜欢 SmartGit 哪些功能?"
 
+msgctxt "nttWslWorkaround:"
+msgid "It seems that you're running SmartGit in WSL."
+msgstr ""
+
+msgctxt "nttWslWorkaround:"
+msgid "Open Documentation"
+msgstr ""
+
 msgctxt "pop:"
 msgid "$1 succeeded."
 msgstr "$1 成功。"
+
+msgctxt "pop:"
+msgid "Already up-to-date"
+msgstr ""
 
 msgctxt "pop:"
 msgid "Command $1 has been aborted."
@@ -11588,6 +13389,10 @@ msgstr "选择要重命名的存储。"
 
 msgctxt "pop:"
 msgid "The dropped directory is no Git repository."
+msgstr ""
+
+msgctxt "pop:"
+msgid "The working tree contains local changes."
 msgstr ""
 
 msgctxt "pop:"
@@ -11638,7 +13443,7 @@ msgctxt "ttpBranches:"
 msgid "<b>Incoming</b> from repository <b>$1</b> branch <b>$2</b> to branch <b>$3</b>"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
+msgctxt "ttpBranches:"
 msgid "<b>Last Updated By: </b>$1"
 msgstr ""
 
@@ -11646,12 +13451,12 @@ msgctxt "ttpBranches:"
 msgid "<b>Local Branch:\\t</b>$1"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
+msgctxt "ttpBranches:"
 msgid "<b>On: </b>$1"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
-msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
+msgctxt "ttpBranches:"
+msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>$3</b>"
 msgstr ""
 
 msgctxt "ttpBranches:"
@@ -11728,6 +13533,10 @@ msgstr ""
 
 msgctxt "ttpBranches:"
 msgid "<b>Tracking State:\\t</b>identical"
+msgstr ""
+
+msgctxt "ttpBranches:"
+msgid "<b>Worktree:\\t</b>$1"
 msgstr ""
 
 msgctxt "ttpBranches:"
@@ -11831,6 +13640,10 @@ msgid "<b>Remotes:\\t</b>"
 msgstr ""
 
 msgctxt "ttpRepositories:"
+msgid "<b>Tracked Branch:\\t</b>$1"
+msgstr ""
+
+msgctxt "ttpRepositories:"
 msgid "<b>Tracked Branch:\\t</b>$1<col1>$2</col1>"
 msgstr ""
 
@@ -11892,6 +13705,62 @@ msgstr ""
 
 msgctxt "ttpRepositories:"
 msgid "The remote repository contains new commits."
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "About SmartGit"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Contact Support"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "License Agreement"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open File"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open in Terminal"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Open in VSCode"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "Reveal in Finder"
+msgstr ""
+
+msgctxt "wnd.mni:"
+msgid "SmartGit Website"
+msgstr ""
+
+msgctxt "wnd.mniBisectTryCommit:"
+msgid "Try Commit"
+msgstr ""
+
+msgctxt "wnd.mniFixCaseChange:"
+msgid "Fix Case-Change"
+msgstr ""
+
+msgctxt "wnd.mniIntegrateMain:"
+msgid "Integrate Main"
+msgstr ""
+
+msgctxt "wnd.mniShowInMyHistory:"
+msgid "Show in My History"
+msgstr ""
+
+msgctxt "wnd.mniWindow-maximize:"
+msgid "Zoom"
+msgstr ""
+
+msgctxt "wnd.mniWindowMaximizeRestore:"
+msgid "Maximize View"
 msgstr ""
 
 msgctxt "wndAnnotate.cmb:"
@@ -12053,6 +13922,16 @@ msgstr "文档"
 msgctxt "wndAnnotate.tab:"
 msgid "History of current line"
 msgstr "当前行的历史记录"
+
+# $1: File Name $2 Relative path
+msgctxt "wndAnnotate.tle:"
+msgid "$1 - Blame of $2"
+msgstr ""
+
+# $1: File Name ,$2 Relative path ,$3:CommitID
+msgctxt "wndAnnotate.tle:"
+msgid "$1 - Blame of $2@$3"
+msgstr ""
 
 msgctxt "wndAnnotate.tle:"
 msgid "$1 - Blame"
@@ -12342,6 +14221,11 @@ msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame \\(in progress...\\)"
 msgstr "提交 \\(处理中...\\)"
 
+# [decode] msgid "Blame \(in progress…\)"
+msgctxt "wndDeepgit.lblBlameHeader:"
+msgid "Blame \\(in progress\\u2026\\)"
+msgstr "提交 \\(处理中...\\)"
+
 msgctxt "wndDeepgit.lblBlameHeader:"
 msgid "Blame for"
 msgstr "提交"
@@ -12578,6 +14462,10 @@ msgctxt "wndDeepgit.mniDgFilterSetSelection:"
 msgid "Set Selection as Filter"
 msgstr "将选定内容设置为筛选器"
 
+msgctxt "wndDeepgit.mniDgFollowInsignificantMerges:"
+msgid "Follow Insignificant Merges \\(experimental\\)"
+msgstr ""
+
 msgctxt "wndDeepgit.mniDgFollowRenames:"
 msgid "Follow Renames"
 msgstr "关注重命名"
@@ -12739,7 +14627,16 @@ msgid "Files changed in commit $1"
 msgstr "在 $1 提交中变更的文件"
 
 msgctxt "wndDeepgit.tab:"
+msgid "Files"
+msgstr ""
+
+msgctxt "wndDeepgit.tab:"
 msgid "Navigation \\(initializing...\\)"
+msgstr "导航 \\(初始化...\\)"
+
+# [decode] msgid "Navigation \(initializing…\)"
+msgctxt "wndDeepgit.tab:"
+msgid "Navigation \\(initializing\\u2026\\)"
 msgstr "导航 \\(初始化...\\)"
 
 msgctxt "wndDeepgit.tab:"
@@ -12874,6 +14771,10 @@ msgctxt "wndEditor.mni:"
 msgid "LF \\(Unix, macOS\\)"
 msgstr "LF \\(Unix, macOS 系统\\)"
 
+msgctxt "wndEditor.mniBlockSelection:"
+msgid "Block Selection"
+msgstr ""
+
 msgctxt "wndEditor.mniEdit-undo:"
 msgid "Undo"
 msgstr "撤销"
@@ -12925,6 +14826,10 @@ msgstr "暂存行内变更"
 msgctxt "wndGit.indexEditor.mni:"
 msgid "Stage Line"
 msgstr "暂存线"
+
+msgctxt "wndGit.indexEditor.mni:"
+msgid "Stage Lines"
+msgstr ""
 
 msgctxt "wndGit.indexEditor.mni:"
 msgid "Stage Selection"
@@ -13003,20 +14908,157 @@ msgid "$1 - Index Editor"
 msgstr ""
 
 msgctxt "wndLog.hnt:"
+msgid "No commit matches the filter."
+msgstr ""
+
+msgctxt "wndLog.hnt:"
 msgid "No graph roots selected."
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Add $1 Git repositories to Group '$2'"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Continue in Background"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Continue with Description"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Copy Name <email>"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Drop All Notes"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Explain Commit"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Explain Diff"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "On Manual Intervention"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Reconfigure"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Reword '@ai' and 'WIP' commits"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "Stop"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "generate \\(active\\)"
+msgstr ""
+
+msgctxt "wndLog.mni:"
+msgid "github \\(active\\)"
+msgstr ""
+
+msgctxt "wndLog.mniCopyCommitId:"
+msgid "Copy"
 msgstr ""
 
 msgctxt "wndLog.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr ""
 
+msgctxt "wndLog.mniGitNoteAdd:"
+msgid "Add Note"
+msgstr ""
+
+# [decode] msgid "Graph \(Initializing Subtree-Cache…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Initializing Subtree-Cache\\u2026\\)"
+msgstr ""
+
+# [decode] msgid "Graph \(Loading…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Loading\\u2026\\)"
+msgstr ""
+
+# [decode] msgid "Graph \(Running log…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Running log\\u2026\\)"
+msgstr ""
+
+# [decode] msgid "Graph \(Scanning WT…\)"
+msgctxt "wndLog.tab:"
+msgid "Graph \\(Scanning WT\\u2026\\)"
+msgstr ""
+
+msgctxt "wndLog.tbt:"
+msgid "Hidden toolbar items..."
+msgstr ""
+
 msgctxt "wndLog.tbt:"
 msgid "Refresh information from GitHub."
+msgstr ""
+
+#| msgid "Rewording 1 commits\\u2026"
+msgctxt "wndLog.tbtAi.commitMessageCompose:"
+msgid "Rewording $1 commits\\u2026"
+msgstr ""
+
+msgctxt "wndLog.tbtFlowContext:"
+msgid "Start a new Git-Flow feature."
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Base"
 msgstr ""
 
 msgctxt "wndProject.mni:"
 msgid "Log Selection"
 msgstr "选择日志"
+
+msgctxt "wndProject.mni:"
+msgid "New_key"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "PR_Review"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Review_Tool"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndProject.mni:"
+msgid "Show Rewritten Behind Commits"
+msgstr ""
+
+msgctxt "wndProject.mniCopyCommitId:"
+msgid "Copy"
+msgstr ""
+
+msgctxt "wndProject.mniFixCaseChange:"
+msgid "Fix Case-Change"
+msgstr ""
+
+msgctxt "wndProject.mniOpen:"
+msgid "Open"
+msgstr ""
 
 msgctxt "wndStd.btn:"
 msgid "Compare"
@@ -13047,7 +15089,24 @@ msgid "Commit files: select 1 commit\\nDiff between Commits: select 2 commits"
 msgstr ""
 
 msgctxt "wndStd.hnt:"
+msgid "Filter by repository name or path"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
 msgid "Loading ..."
+msgstr ""
+
+# [decode] msgid "Loading …"
+msgctxt "wndStd.hnt:"
+msgid "Loading \\u2026"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "No files below the selected directory"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "No graph roots selected."
 msgstr ""
 
 msgctxt "wndStd.hnt:"
@@ -13056,6 +15115,14 @@ msgstr ""
 
 msgctxt "wndStd.hnt:"
 msgid "No locally changed files"
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "The repository's\\nreflog is empty."
+msgstr ""
+
+msgctxt "wndStd.hnt:"
+msgid "This repository has\\nno stashes yet."
 msgstr ""
 
 msgctxt "wndStd.lbl:"
@@ -13091,6 +15158,10 @@ msgid "All files, incl. ignored"
 msgstr ""
 
 msgctxt "wndStd.mni:"
+msgid "All my branches"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Apply Stash"
 msgstr ""
 
@@ -13100,6 +15171,38 @@ msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Changed files"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Close Others"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Close to the Right"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Continue in Background"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Continue with Description"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Copy Path"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Don't Show Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Drop All Notes"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Explain Commit"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -13123,11 +15226,23 @@ msgid "Log"
 msgstr ""
 
 msgctxt "wndStd.mni:"
-msgid "On master: SmartGit: automatic stash on Pull."
+msgid "On $1: SmartGit: automatic stash on Pull."
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "On Manual Intervention"
 msgstr ""
 
 msgctxt "wndStd.mni:"
 msgid "Only current branch \\(HEAD\\)"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Open in GitHub"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Open"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -13147,7 +15262,31 @@ msgid "Reset"
 msgstr ""
 
 msgctxt "wndStd.mni:"
+msgid "Reword '@ai' and 'WIP' commits"
+msgstr ""
+
+msgctxt "wndStd.mni:"
 msgid "Save Stash"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Select from GitHub"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show 'My' Pull Requests \\(involving me\\)"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show 'My' and Unassigned Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show All Pull Requests"
+msgstr ""
+
+msgctxt "wndStd.mni:"
+msgid "Show Tags"
 msgstr ""
 
 msgctxt "wndStd.mni:"
@@ -13158,6 +15297,10 @@ msgctxt "wndStd.mni:"
 msgid "Sort by Path"
 msgstr ""
 
+msgctxt "wndStd.mni:"
+msgid "Stop"
+msgstr ""
+
 msgctxt "wndStd.mniBisectTryCommit:"
 msgid "Try Commit"
 msgstr ""
@@ -13166,8 +15309,20 @@ msgctxt "wndStd.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr ""
 
+msgctxt "wndStd.mniGitNoteAdd:"
+msgid "Add Note"
+msgstr ""
+
+msgctxt "wndStd.mniIndexEditor:"
+msgid "Edit in Index Editor"
+msgstr ""
+
 msgctxt "wndStd.mniIntegrateMain:"
 msgid "Integrate Main"
+msgstr ""
+
+msgctxt "wndStd.mniStdCiResultOpenInBrowser:"
+msgid "Open CI Result"
 msgstr ""
 
 msgctxt "wndStd.mniStdOpenSubmodule:"
@@ -13176,6 +15331,18 @@ msgstr ""
 
 msgctxt "wndStd.mniStdOpenSubmoduleFromFile:"
 msgid "Open this Submodule"
+msgstr ""
+
+msgctxt "wndStd.mniStdProviderOpenFileInBrowser:"
+msgid "Open in GitHub"
+msgstr ""
+
+msgctxt "wndStd.mniStdProviderOpenInBrowser:"
+msgid "Open in $1"
+msgstr ""
+
+msgctxt "wndStd.mniStdProviderOpenRefInBrowser:"
+msgid "Open in GitHub"
 msgstr ""
 
 msgctxt "wndStd.mniStdSetModeHistory:"
@@ -13194,13 +15361,33 @@ msgctxt "wndStd.tbr:"
 msgid "Submodule"
 msgstr ""
 
+msgctxt "wndStd.tbt:"
+msgid "History"
+msgstr ""
+
+msgctxt "wndStd.tbt:"
+msgid "Show filter input field."
+msgstr ""
+
+msgctxt "wndStd.tbtFlowFeatureFinish:"
+msgid "Finish the current feature branch."
+msgstr ""
+
 msgctxt "wndStd.tbtFlowFeatureStart:"
 msgid "Start a new feature branch."
+msgstr ""
+
+msgctxt "wndStd.tbtIntegrateMain:"
+msgid "Integrate latest changes from the main branch into the current feature branch."
 msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).lblStatusBarMessage:"
 msgid "Ready"
 msgstr "就绪"
+
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
+msgid "Enter Full Screen"
+msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
 msgid "Full Screen"
@@ -13209,6 +15396,10 @@ msgstr "全屏"
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
 msgid "Maximize"
 msgstr "最大化"
+
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
+msgid "Zoom"
+msgstr ""
 
 msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore:"
 msgid "Restore"
@@ -13718,10 +15909,6 @@ msgstr "个文件"
 msgctxt "wnd(Log|Project|Std|).lbl:"
 msgid "Files"
 msgstr "个文件"
-
-msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
-msgid "Show Rewritten Behind Commits"
-msgstr "在提交后显示重写"
 
 msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "<no entry>"
@@ -14381,6 +16568,10 @@ msgstr "仅显示选定的分支和标签"
 msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Show Only Selected Refs"
 msgstr "仅显示选定的引用"
+
+msgctxt "wnd(Log|Project|Std|).mni:"
+msgid "Show Rewritten Behind Commits"
+msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Show Unchanged Directories"
@@ -15796,10 +17987,6 @@ msgctxt "wnd(Log|Project|Std|).tab:"
 msgid "Repositories"
 msgstr "仓库"
 
-msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
-msgid "History"
-msgstr "历史"
-
 #, fuzzy
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Add Branch"
@@ -15884,6 +18071,10 @@ msgstr "完成"
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Git-Flow"
 msgstr "Git 工作流"
+
+msgctxt "wnd(Log|Project|Std|).tbr:"
+msgid "History"
+msgstr ""
 
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Ignore WS"
@@ -16312,9 +18503,17 @@ msgctxt "wnd(Log|Project|Std|).tle:"
 msgid "$1 \\[$2\\] - Log for $3"
 msgstr ""
 
+msgctxt "wnd(Log|Std|).mniOpen:"
+msgid "Open from Working Tree"
+msgstr ""
+
 #~ msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 #~ msgid "\\[$1\\] - $2"
 #~ msgstr ""
+
+#~ msgctxt "dlgSgAbortRebasingConfirm.fur:"
+#~ msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
+#~ msgstr "您的工作区处于 “变基” 状态。你可以放弃变基; 如果您只想跳过当前的补丁，请使用 分支 \\| 变基 \\| 将 HEAD 变基至。\\n\\n中止将清除任何本地修改 \\(通过调用 “git reset --hard”\\)！"
 
 #~ msgctxt "dlgSgAbortRevertingConfirm.hdl"
 #~ msgid "Do you want to abort the current revert?"
@@ -16328,8 +18527,20 @@ msgstr ""
 #~ msgid "Do you want to delete the branch '$1'?"
 #~ msgstr ""
 
+#~ msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
+#~ msgid "Skip large files \\(\"partial clone\"\\)"
+#~ msgstr "跳过大文件 \\(“部分克隆”\\)"
+
+#~ msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
+#~ msgid "Simple commit \\(one parent, \"squash\"\\)"
+#~ msgstr "简单提交 \\(1个父系, “压缩”\\)"
+
 #~ msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
 #~ msgid "\\[$1\\] - \\[$2\\] - $3"
+#~ msgstr ""
+
+#~ msgctxt "dlgSgErrorUtilsClientException.fur:"
+#~ msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
 #~ msgstr ""
 
 #~ msgctxt "dlgSgFlowHotfixFinish.hdl"
@@ -16352,9 +18563,33 @@ msgstr ""
 #~ msgid "Generate a new API token for $1"
 #~ msgstr ""
 
+#~ msgctxt "dlgSgPushForced.hdl:"
+#~ msgid "Do you want to force-push \\(replace\\) the remote branch?"
+#~ msgstr "你想强制推送 \\(替换\\) 远程分支吗？"
+
+#~ msgctxt "dlgSgRepositorySettings.inf:"
+#~ msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
+#~ msgstr "在这里, 您可以编辑该仓库的 Git 设置. 默认设置可以在首选项中找到."
+
 #~ msgctxt "dlgSgResetAdv.inf"
 #~ msgid "Reset the current branch (HEAD) to the selected commit and optionally update Index and working tree."
 #~ msgstr ""
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
+#~ msgid "Set to $1 \\(\"ours\", $2\\)"
+#~ msgstr "设置为 $1 \\(“我们的”，$2 \\)"
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
+#~ msgid "Set to $1 \\(\"theirs\", $2\\)"
+#~ msgstr "设置为 $1 \\(“他们的”，$2 \\)"
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
+#~ msgid "Set to rebase target \\(\"theirs\", $1\\)"
+#~ msgstr "设置为变基目标 \\(“他们的”，$1\\)"
+
+#~ msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
+#~ msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
+#~ msgstr "设置为变基分支 “$1” \\(“我们的”，$2\\)"
 
 #~ msgctxt "dlgSgRevealCommitLocalOrTracked.tle"
 #~ msgid "Reveal Commit"
@@ -16368,7 +18603,47 @@ msgstr ""
 #~ msgid "Do you want to rollback the selected files to the state of commit $1?"
 #~ msgstr ""
 
+#~ msgctxt "dlgSgSetupStdWnd.fur:"
+#~ msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
+#~ msgstr "对于 \\*初出茅庐的 Git 用户\\* ，我们推荐使用标准窗口。如果您对 SmartGit 的老版本十分熟悉，或许会对标准窗口与自己熟悉的界面 \\*十分不同\\* 感到诧异。若您对旧有体验情有独钟，可以考虑启用 \\*日志图\\* 或 \\*工作区\\* 窗口。"
+
+#~ msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
+#~ msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
+#~ msgstr "完成拉取操作后，您应该手动应用最新的存储，以将本地变更还原到工作区中。"
+
+#~ msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
+#~ msgid "Authentication to the SVN repository '$1' failed with error: $2'"
+#~ msgstr "对 SVN 仓库 “$1” 的身份验证失败，错误：$2"
+
+#~ msgctxt "dlgTxtEditor.fileModified.hdl:"
+#~ msgid "The file config was changed. Reload it?"
+#~ msgstr "该文件配置已变更. 是否重新加载?"
+
+#~ msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
+#~ msgid "<b>Last Updated By: </b>$1"
+#~ msgstr ""
+
+#~ msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
+#~ msgid "<b>On: </b>$1"
+#~ msgstr ""
+
+#~ msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
+#~ msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
+#~ msgstr ""
+
 #, fuzzy
 #~ msgctxt "wndProject.col:"
 #~ msgid "LFS"
 #~ msgstr "LFS"
+
+#~ msgctxt "wndStd.mni:"
+#~ msgid "On master: SmartGit: automatic stash on Pull."
+#~ msgstr ""
+
+#~ msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
+#~ msgid "Show Rewritten Behind Commits"
+#~ msgstr "在提交后显示重写"
+
+#~ msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
+#~ msgid "History"
+#~ msgstr "历史"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -2192,7 +2192,7 @@ msgstr ""
 
 msgctxt "dlgSgAbortRevertingConfirm.tle:"
 msgid "Discard"
-msgstr ""
+msgstr "丢弃"
 
 msgctxt "dlgSgAbout.btn:"
 msgid "Copy Evaluation-ID"
@@ -3451,7 +3451,7 @@ msgstr "将 SVN 主干，标签和分支映射到 Git"
 
 msgctxt "dlgSgClone.chk:"
 msgid "Skip large files \\(\"partial clone\"\\)"
-msgstr ""
+msgstr "跳过大文件 \\(\"部分克隆\"\\)"
 
 msgctxt "dlgSgClone.edt:"
 msgid "Check Out Branch"
@@ -3804,7 +3804,7 @@ msgstr "合并提交 \\(多个父系\\)"
 
 msgctxt "dlgSgCommit.rbt:"
 msgid "Simple commit \\(one parent, \"squash\"\\)"
-msgstr ""
+msgstr "简单提交 \\(1个父系, \"压缩\"\\)"
 
 msgctxt "dlgSgCommit.rbt:"
 msgid "Staged Changes"
@@ -4768,7 +4768,7 @@ msgstr "提交/标签信息"
 
 msgctxt "dlgSgFlowHotfixFinish.hdl:"
 msgid "Finish a hotfix"
-msgstr ""
+msgstr "完成 hotfix"
 
 msgctxt "dlgSgFlowHotfixFinish.hdl:"
 msgid "Finish current hotfix"
@@ -4904,7 +4904,7 @@ msgstr ""
 
 msgctxt "dlgSgFlowReleaseFinish.hdl:"
 msgid "Finish a release"
-msgstr ""
+msgstr "完成 release"
 
 msgctxt "dlgSgFlowReleaseFinish.hdl:"
 msgid "Finish current release"
@@ -5760,7 +5760,7 @@ msgstr ""
 
 msgctxt "dlgSgHostingProviderAdd.hdl:"
 msgid "Configure a new hosting provider account"
-msgstr ""
+msgstr "配置新的主机提供商账户"
 
 msgctxt "dlgSgHostingProviderAdd.inf:"
 msgid "Set or select the options according to your account."
@@ -10372,19 +10372,19 @@ msgstr "打开冲突解决工具"
 
 msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"ours\", $2\\)"
-msgstr ""
+msgstr "设置为 $1 \\(\"我们的\", $2 \\)"
 
 msgctxt "dlgSgResolve.rbt:"
 msgid "Set to $1 \\(\"theirs\", $2\\)"
-msgstr ""
+msgstr "设置为 $1 \\(\"他们的\", $2 \\)"
 
 msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebase target \\(\"theirs\", $1\\)"
-msgstr ""
+msgstr "设置为变基目标 \\(\"他们的\", $1\\)"
 
 msgctxt "dlgSgResolve.rbt:"
 msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
-msgstr ""
+msgstr "设置为变基分支 \"$1\" \\(\"我们的\", $2\\)"
 
 msgctxt "dlgSgResolve.tle:"
 msgid "Resolve"
@@ -10456,7 +10456,7 @@ msgstr ""
 
 msgctxt "dlgSgRevealCommitLocalOrTracked.tle:"
 msgid "Reveal Commit"
-msgstr ""
+msgstr "显示提交"
 
 msgctxt "dlgSgRevertAndCommitConfirmSingle.btn:"
 msgid "Revert && Commit"
@@ -12127,7 +12127,7 @@ msgstr "SVN 认证"
 
 msgctxt "dlgSgSvnClientCertificate.wrn:"
 msgid "Authentication to the SVN repository '$1' failed with error: $2'"
-msgstr ""
+msgstr "对 SVN 仓库 '$1' 的身份验证失败，错误：$2"
 
 msgctxt "dlgSgSvnSslFingerprintChanged.btn:"
 msgid "Accept"
@@ -15046,7 +15046,7 @@ msgstr ""
 
 msgctxt "wndProject.mni:"
 msgid "Show Rewritten Behind Commits"
-msgstr ""
+msgstr "在提交后显示重写"
 
 msgctxt "wndProject.mniCopyCommitId:"
 msgid "Copy"
@@ -15363,7 +15363,7 @@ msgstr ""
 
 msgctxt "wndStd.tbt:"
 msgid "History"
-msgstr ""
+msgstr "历史"
 
 msgctxt "wndStd.tbt:"
 msgid "Show filter input field."
@@ -16571,7 +16571,7 @@ msgstr "仅显示选定的引用"
 
 msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Show Rewritten Behind Commits"
-msgstr ""
+msgstr "在提交后显示重写"
 
 msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Show Unchanged Directories"
@@ -18074,7 +18074,7 @@ msgstr "Git 工作流"
 
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "History"
-msgstr ""
+msgstr "历史"
 
 msgctxt "wnd(Log|Project|Std|).tbr:"
 msgid "Ignore WS"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -733,10 +733,6 @@ msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - 冲突解决工具"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
-msgid "\\[$1\\] - $2"
-msgstr ""
-
 msgctxt "dlgScConflictSolverUnresolvedConflicts.chk"
 msgid "Don't warn me again"
 msgstr "不再显示警告"
@@ -2373,13 +2369,13 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
-msgid "Do you want to delete $1 local branches?"
-msgstr ""
-
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl"
 msgid "Do you want to delete $1 local branches?"
 msgstr "您确定要删除 $1 本地分支吗？"
+
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
+msgid "Do you want to delete $1 local branches?"
+msgstr ""
 
 msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle"
 msgid "Delete"
@@ -2413,13 +2409,13 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.fur:"
 msgid "Your local branch is tracking branch '$1'. Decide whether you also want to delete this branch from the remote repository."
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
-msgid "Do you want to delete the local branch '$1'?"
-msgstr ""
-
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "您确定要删除本地分支 “$1” 吗？"
+
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
+msgid "Do you want to delete the local branch '$1'?"
+msgstr ""
 
 msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle"
 msgid "Delete"
@@ -2437,6 +2433,10 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "删除"
 
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
+msgid "Delete from remote repository '$1'"
+msgstr ""
+
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
 msgstr "从远程 “$1” 删除"
@@ -2444,10 +2444,6 @@ msgstr "从远程 “$1” 删除"
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr "从远程仓库中删除 '$1'"
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
-msgid "Delete from remote repository '$1'"
-msgstr ""
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
@@ -2460,10 +2456,6 @@ msgstr "您要删除分支 “$1” 吗？"
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr "您要删除远程分支 “$1” 吗？"
-
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl"
-msgid "Do you want to delete the branch '$1'?"
-msgstr ""
 
 msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle"
 msgid "Delete"
@@ -3504,10 +3496,6 @@ msgstr ""
 
 msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
 msgid "The right file is not editable because of mixed line-endings."
-msgstr ""
-
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.tle"
-msgid "\\[$1\\] - \\[$2\\] - $3"
 msgstr ""
 
 msgctxt "dlgSgConflictResolverExternalStarted.btn:"
@@ -7515,10 +7503,6 @@ msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.hdl"
-msgid "Generate a new API token for $1"
-msgstr ""
-
 msgctxt "dlgSgProviderGenerateToken.inf"
 msgid "Authenticate at GitLab and grant access to SmartGit."
 msgstr ""
@@ -9727,10 +9711,6 @@ msgstr ""
 
 msgctxt "dlgSgRollbackToCommit.fur"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
-msgstr ""
-
-msgctxt "dlgSgRollbackToCommit.hdl"
-msgid "Do you want to rollback the Index to the state of commit $1?"
 msgstr ""
 
 msgctxt "dlgSgRollbackToCommit.tle"
@@ -16408,10 +16388,6 @@ msgstr ""
 
 #~ msgctxt "dlgSgProviderGenerateToken.hdl"
 #~ msgid "Generate a new API token for $1"
-#~ msgstr ""
-
-#~ msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl"
-#~ msgid "Do you want to drop the local commits of pull request $1?"
 #~ msgstr ""
 
 #~ msgctxt "dlgSgResetAdv.inf"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -101,19 +101,19 @@ msgctxt "dlgCommit.replaceMessage.btn:"
 msgid "Replace"
 msgstr "替换"
 
-msgctxt "dlgCommit.replaceMessage.chk"
+msgctxt "dlgCommit.replaceMessage.chk:"
 msgid "Always replace"
 msgstr "始终替换"
 
-msgctxt "dlgCommit.replaceMessage.fur"
+msgctxt "dlgCommit.replaceMessage.fur:"
 msgid "After replacing you can find the previous message when clicking the history button."
 msgstr "替换后，您可以在单击历史记录按钮时找到上一条消息。"
 
-msgctxt "dlgCommit.replaceMessage.hdl"
+msgctxt "dlgCommit.replaceMessage.hdl:"
 msgid "Replace the existing message?"
 msgstr "是否替换现有消息？"
 
-msgctxt "dlgCommit.replaceMessage.tle"
+msgctxt "dlgCommit.replaceMessage.tle:"
 msgid "Replace Message"
 msgstr "替换消息"
 
@@ -121,11 +121,11 @@ msgctxt "dlgCommitGitHubConfirmEmail.btn:"
 msgid "Confirm Email"
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.fur"
+msgctxt "dlgCommitGitHubConfirmEmail.fur:"
 msgid "If this repository is open-source, you might want to hide your email address, as \\[https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-email-preferences/setting-your-commit-email-address#setting-your-email-address-for-a-single-repository suggested by GitHub\\], and use instead <username>@users.noreply.github.com."
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.hdl"
+msgctxt "dlgCommitGitHubConfirmEmail.hdl:"
 msgid "Commit with default email address $1?"
 msgstr ""
 
@@ -141,7 +141,7 @@ msgctxt "dlgCommitGitHubConfirmEmail.rbt:"
 msgid "Use following email address:"
 msgstr ""
 
-msgctxt "dlgCommitGitHubConfirmEmail.tle"
+msgctxt "dlgCommitGitHubConfirmEmail.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -149,31 +149,31 @@ msgctxt "dlgCommitInvisibleIndex.btn:"
 msgid "Commit"
 msgstr "提交"
 
-msgctxt "dlgCommitInvisibleIndex.fur"
+msgctxt "dlgCommitInvisibleIndex.fur:"
 msgid "Some staged files are not visible at the moment."
 msgstr ""
 
-msgctxt "dlgCommitInvisibleIndex.hdl"
+msgctxt "dlgCommitInvisibleIndex.hdl:"
 msgid "Commit invisible staged files?"
 msgstr ""
 
-msgctxt "dlgCommitInvisibleIndex.tle"
+msgctxt "dlgCommitInvisibleIndex.tle:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.chk"
+msgctxt "dlgCommitView.hiddenOptions.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.fur"
+msgctxt "dlgCommitView.hiddenOptions.fur:"
 msgid "To use the options, they need to remain visible."
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.hdl"
+msgctxt "dlgCommitView.hiddenOptions.hdl:"
 msgid "Hidden options will be treated as unselected."
 msgstr ""
 
-msgctxt "dlgCommitView.hiddenOptions.tle"
+msgctxt "dlgCommitView.hiddenOptions.tle:"
 msgid "Commit"
 msgstr ""
 
@@ -217,27 +217,27 @@ msgctxt "dlgDgAbout.tab:"
 msgid "Licensee"
 msgstr "授权信息"
 
-msgctxt "dlgDgAbout.tle"
+msgctxt "dlgDgAbout.tle:"
 msgid "About DeepGit"
 msgstr "关于 DeepGit"
 
-msgctxt "dlgDgClientException.hdl"
+msgctxt "dlgDgClientException.hdl:"
 msgid "Executing a command has failed."
 msgstr ""
 
-msgctxt "dlgDgClientException.tle"
+msgctxt "dlgDgClientException.tle:"
 msgid "Command Failed"
 msgstr ""
 
-msgctxt "dlgDgRefMapperGroupConfig.hdl"
+msgctxt "dlgDgRefMapperGroupConfig.hdl:"
 msgid "Configure patterns for grouping tags of this repository"
 msgstr "配置此仓库的标记分组模式"
 
-msgctxt "dlgDgRefMapperGroupConfig.inf"
+msgctxt "dlgDgRefMapperGroupConfig.inf:"
 msgid "Tags, branches and other refs matched by this configuration will be displayed in the Navigation graph."
 msgstr "标签, 分支以及与此配置匹配的其他引用将显示在导航图中."
 
-msgctxt "dlgDgRefMapperGroupConfig.tle"
+msgctxt "dlgDgRefMapperGroupConfig.tle:"
 msgid "Configure Tag-Grouping"
 msgstr "配置标记分组"
 
@@ -245,31 +245,31 @@ msgctxt "dlgDgSetEncoding.edt:"
 msgid "Text File Encoding"
 msgstr "文本文件编码"
 
-msgctxt "dlgDgSetEncoding.hdl"
+msgctxt "dlgDgSetEncoding.hdl:"
 msgid "Configure Encoding"
 msgstr "配置编码"
 
-msgctxt "dlgDgSetEncoding.inf"
+msgctxt "dlgDgSetEncoding.inf:"
 msgid "Specify the encoding which should be used for processing and viewing files. Note, that UTF-8 encoding will be auto-detected, regardless of the configuration here."
 msgstr "指定应用于处理和查看文件的编码。请注意,UTF-8 编码将自动检测到,而不考虑此处的配置。"
 
-msgctxt "dlgDgSetEncoding.tle"
+msgctxt "dlgDgSetEncoding.tle:"
 msgid "Set Encoding"
 msgstr "设置编码"
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.fur"
+msgctxt "dlgDgSetPerspectiveCantSwitch.fur:"
 msgid "In order to inspect available Origins, they have to be evaluated first. Select a line in the Blame view. Then wait until the calculation of possible Origins has finished."
 msgstr "为审查可能的起源, 必须先对它们进行评估. 先在提交视图中选择1行. 然后等待完成查找可能的起源."
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.hdl"
+msgctxt "dlgDgSetPerspectiveCantSwitch.hdl:"
 msgid "Can't switch perspective."
 msgstr "无法切换视角."
 
-msgctxt "dlgDgSetPerspectiveCantSwitch.tle"
+msgctxt "dlgDgSetPerspectiveCantSwitch.tle:"
 msgid "Origins Perspective"
 msgstr "原始视角"
 
-msgctxt "dlgInfo.tle"
+msgctxt "dlgInfo.tle:"
 msgid "Discard"
 msgstr "丢弃"
 
@@ -325,15 +325,15 @@ msgctxt "dlgProgress.tle:"
 msgid "Verifying executables"
 msgstr ""
 
-msgctxt "dlgQBugFileSendingFailed.fur"
+msgctxt "dlgQBugFileSendingFailed.fur:"
 msgid "Maybe you need to configure a proxy or our server is temporarily down.\\nDetails: $1"
 msgstr "也许您需要配置代理才能访问我们服务器或我们的服务器暂时关闭。\\n详情：$1"
 
-msgctxt "dlgQBugFileSendingFailed.hdl"
+msgctxt "dlgQBugFileSendingFailed.hdl:"
 msgid "Could not send the crash logs to $1"
 msgstr "无法将崩溃记录发送到 $1"
 
-msgctxt "dlgQBugFileSendingFailed.tle"
+msgctxt "dlgQBugFileSendingFailed.tle:"
 msgid "Native Crash Logs"
 msgstr "本机崩溃记录"
 
@@ -389,23 +389,23 @@ msgctxt "dlgQBugReportSend.lbl:"
 msgid "What did you do? We often solve a difficult bug after receiving just one good hint!"
 msgstr ""
 
-msgctxt "dlgQBugReportSend.tle"
+msgctxt "dlgQBugReportSend.tle:"
 msgid "Internal Error"
 msgstr "内部错误"
 
-msgctxt "dlgQDockManagerClosedView.chk"
+msgctxt "dlgQDockManagerClosedView.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgQDockManagerClosedView.fur"
+msgctxt "dlgQDockManagerClosedView.fur:"
 msgid "To reopen it again, use the corresponding menu item from the Window menu."
 msgstr "要再次重新打开，请使用窗口菜单中的相应菜单项。"
 
-msgctxt "dlgQDockManagerClosedView.hdl"
+msgctxt "dlgQDockManagerClosedView.hdl:"
 msgid "You've closed the view '$1'."
 msgstr "您已经关闭了视图 $1。"
 
-msgctxt "dlgQDockManagerClosedView.tle"
+msgctxt "dlgQDockManagerClosedView.tle:"
 msgid "Closed View"
 msgstr "关闭视图"
 
@@ -413,15 +413,15 @@ msgctxt "dlgQFileSaveAcceptFilterOverwrite.btn:"
 msgid "Overwrite"
 msgstr "覆盖"
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.fur:"
 msgid "To save to a different file, click 'Cancel'."
 msgstr "要保存到其他文件，请单击 “取消”。"
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.hdl:"
 msgid "The file $1 already exists. Do you want to overwrite it?"
 msgstr "文件 $1 已存在。你确定覆盖吗？"
 
-msgctxt "dlgQFileSaveAcceptFilterOverwrite.tle"
+msgctxt "dlgQFileSaveAcceptFilterOverwrite.tle:"
 msgid "Overwrite File"
 msgstr "覆盖文件"
 
@@ -441,23 +441,23 @@ msgctxt "dlgQFrameManagerExit.fur:"
 msgid "There are unsaved changes which would be lost when exiting now!"
 msgstr ""
 
-msgctxt "dlgQFrameManagerExit.hdl"
+msgctxt "dlgQFrameManagerExit.hdl:"
 msgid "Do you really want to exit SmartGit?"
 msgstr "是否确定要退出 SmartGit ？"
 
-msgctxt "dlgQFrameManagerExit.tle"
+msgctxt "dlgQFrameManagerExit.tle:"
 msgid "Exit"
 msgstr "退出"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.fur"
+msgctxt "dlgQIntegerInputProviderInvalidValue.fur:"
 msgid "Port must be in the range from $1 to $2."
 msgstr "端口必须在 $1 到 $2 的范围内。"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.hdl"
+msgctxt "dlgQIntegerInputProviderInvalidValue.hdl:"
 msgid "The text in field '$1' is not valid."
 msgstr "字段 “$1” 中的文本无效。"
 
-msgctxt "dlgQIntegerInputProviderInvalidValue.tle"
+msgctxt "dlgQIntegerInputProviderInvalidValue.tle:"
 msgid "Input Validation"
 msgstr "输入验证"
 
@@ -497,7 +497,7 @@ msgctxt "dlgQProxyConfigure.rbt:"
 msgid "Use following proxy"
 msgstr "使用以下代理"
 
-msgctxt "dlgQProxyConfigure.tle"
+msgctxt "dlgQProxyConfigure.tle:"
 msgid "Configure Proxy"
 msgstr "设置代理"
 
@@ -509,15 +509,15 @@ msgctxt "dlgQProxyConnectionFailed.btn:"
 msgid "Retry"
 msgstr "重试"
 
-msgctxt "dlgQProxyConnectionFailed.fur"
+msgctxt "dlgQProxyConnectionFailed.fur:"
 msgid "Details: syntevo.com"
 msgstr "详情：syntevo.com"
 
-msgctxt "dlgQProxyConnectionFailed.hdl"
+msgctxt "dlgQProxyConnectionFailed.hdl:"
 msgid "Could not connect to $1."
 msgstr "无法连接到 $1。"
 
-msgctxt "dlgQProxyConnectionFailed.tle"
+msgctxt "dlgQProxyConnectionFailed.tle:"
 msgid "Connection Failed"
 msgstr "连接失败"
 
@@ -537,27 +537,27 @@ msgctxt "dlgQUpdateCheckForNewVersion.btn:"
 msgid "Skip"
 msgstr "跳过"
 
-msgctxt "dlgQUpdateCheckForNewVersion.hdl"
+msgctxt "dlgQUpdateCheckForNewVersion.hdl:"
 msgid "SmartGit needs to check for updates"
 msgstr "SmartGit 需要检查更新"
 
-msgctxt "dlgQUpdateCheckForNewVersion.inf"
+msgctxt "dlgQUpdateCheckForNewVersion.inf:"
 msgid "If necessary, please configure the proxy and retry."
 msgstr "如果需要，请配置代理并重试。"
 
-msgctxt "dlgQUpdateCheckForNewVersion.tle"
+msgctxt "dlgQUpdateCheckForNewVersion.tle:"
 msgid "Check for New Version"
 msgstr "检查新版本"
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.fur"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.fur:"
 msgid "Details: Failed to connect to '$1'."
 msgstr "详细信息：无法连接到 “$1”。"
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.hdl"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.hdl:"
 msgid "Checking for new versions has failed."
 msgstr "检查新版本失败。"
 
-msgctxt "dlgQUpdateCheckForNewVersionFailed.tle"
+msgctxt "dlgQUpdateCheckForNewVersionFailed.tle:"
 msgid "Check for New Version"
 msgstr "检查新版本"
 
@@ -565,27 +565,27 @@ msgctxt "dlgQUpdateCheckLatestBuild.btn:"
 msgid "Get Latest Build"
 msgstr "确认"
 
-msgctxt "dlgQUpdateCheckLatestBuild.fur"
+msgctxt "dlgQUpdateCheckLatestBuild.fur:"
 msgid "Only use the latest build if requested by the support team."
 msgstr "仅在支持团队要求时使用最新版本。"
 
-msgctxt "dlgQUpdateCheckLatestBuild.hdl"
+msgctxt "dlgQUpdateCheckLatestBuild.hdl:"
 msgid "Do you want to download the latest build?"
 msgstr "您确定要下载最新编译版本吗？"
 
-msgctxt "dlgQUpdateCheckLatestBuild.tle"
+msgctxt "dlgQUpdateCheckLatestBuild.tle:"
 msgid "Check for Latest Build"
 msgstr "检查最新编译版本"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.fur:"
 msgid "Details: $1"
 msgstr "详细信息：$1"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.hdl"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.hdl:"
 msgid "Initializing upgrade failed."
 msgstr "初始化升级失败。"
 
-msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.tle"
+msgctxt "dlgQUpdateCheckLatestBuildFetchFailed.tle:"
 msgid "Check for Latest Build"
 msgstr "检查最新编译版本"
 
@@ -593,39 +593,39 @@ msgctxt "dlgQUpdateCheckNewVersion.btn:"
 msgid "Download"
 msgstr "下载"
 
-msgctxt "dlgQUpdateCheckNewVersion.fur"
+msgctxt "dlgQUpdateCheckNewVersion.fur:"
 msgid "It's recommended to update to the new version."
 msgstr "建议更新到新版"
 
-msgctxt "dlgQUpdateCheckNewVersion.hdl"
+msgctxt "dlgQUpdateCheckNewVersion.hdl:"
 msgid "A new version of SmartGit is available."
 msgstr "发现版本更新"
 
-msgctxt "dlgQUpdateCheckNewVersion.tle"
+msgctxt "dlgQUpdateCheckNewVersion.tle:"
 msgid "Check for New Version"
 msgstr "检测更新"
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.fur"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.fur:"
 msgid "You are already using the latest build."
 msgstr "您已经在使用最新编译版本。"
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.hdl"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.hdl:"
 msgid "No newer build found."
 msgstr "未找到需要更新的编译版本"
 
-msgctxt "dlgQUpdateCheckNoNewerLatestBuild.tle"
+msgctxt "dlgQUpdateCheckNoNewerLatestBuild.tle:"
 msgid "Check for Latest Build"
 msgstr "检查最新编译版本"
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.fur"
+msgctxt "dlgQUpdateCheckNowNewerVersion.fur:"
 msgid "You are already using the latest version."
 msgstr "当前版本已是最新"
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.hdl"
+msgctxt "dlgQUpdateCheckNowNewerVersion.hdl:"
 msgid "No newer version found."
 msgstr "未找到需要更新的版本"
 
-msgctxt "dlgQUpdateCheckNowNewerVersion.tle"
+msgctxt "dlgQUpdateCheckNowNewerVersion.tle:"
 msgid "Check for New Version"
 msgstr "检查新版本"
 
@@ -653,15 +653,15 @@ msgctxt "dlgRewriteTextFiles.edt:"
 msgid "Line-Endings"
 msgstr "行尾序列"
 
-msgctxt "dlgRewriteTextFiles.hdl"
+msgctxt "dlgRewriteTextFiles.hdl:"
 msgid "Rewrite text files with selected line-endings"
 msgstr "用选定的行尾序列重写文本文件"
 
-msgctxt "dlgRewriteTextFiles.inf"
+msgctxt "dlgRewriteTextFiles.inf:"
 msgid "Select the line-endings that should be used to write the text files."
 msgstr "选择应用于写入文本文件的行尾序列。"
 
-msgctxt "dlgRewriteTextFiles.tle"
+msgctxt "dlgRewriteTextFiles.tle:"
 msgid "Fix Line-Endings"
 msgstr "修复行尾序列"
 
@@ -669,15 +669,15 @@ msgctxt "dlgScAboutUpdateInstallation.btn:"
 msgid "Upgrade Installation"
 msgstr "安装升级"
 
-msgctxt "dlgScAboutUpdateInstallation.fur"
+msgctxt "dlgScAboutUpdateInstallation.fur:"
 msgid "This will take a few moments and has to restart SmartGit."
 msgstr "这将需要些时间，必须重新启动 SmartGit。"
 
-msgctxt "dlgScAboutUpdateInstallation.hdl"
+msgctxt "dlgScAboutUpdateInstallation.hdl:"
 msgid "Do you want to upgrade the installation directory to version $1?"
 msgstr "是否要将安装目录升级到版本 $1？"
 
-msgctxt "dlgScAboutUpdateInstallation.tle"
+msgctxt "dlgScAboutUpdateInstallation.tle:"
 msgid "Upgrade Installation"
 msgstr "升级安装"
 
@@ -693,59 +693,59 @@ msgctxt "dlgScApplicationStarterRestart.btn:"
 msgid "Restart"
 msgstr "重新启动"
 
-msgctxt "dlgScApplicationStarterRestart.fur"
+msgctxt "dlgScApplicationStarterRestart.fur:"
 msgid "The downloaded program update should be applied now."
 msgstr "下载的程序在重启后生效。"
 
-msgctxt "dlgScApplicationStarterRestart.hdl"
+msgctxt "dlgScApplicationStarterRestart.hdl:"
 msgid "SmartGit requires a restart."
 msgstr "SmartGit 需要重新启动。"
 
-msgctxt "dlgScApplicationStarterRestart.tle"
+msgctxt "dlgScApplicationStarterRestart.tle:"
 msgid "Restart"
 msgstr "重新启动"
 
-msgctxt "dlgScConflictSolverAdd.hdl"
+msgctxt "dlgScConflictSolverAdd.hdl:"
 msgid "Add conflict solver"
 msgstr "添加冲突解决方案"
 
-msgctxt "dlgScConflictSolverAdd.tle"
+msgctxt "dlgScConflictSolverAdd.tle:"
 msgid "Add"
 msgstr "添加"
 
-msgctxt "dlgScConflictSolverEdit.hdl"
+msgctxt "dlgScConflictSolverEdit.hdl:"
 msgid "Edit conflict solver"
 msgstr "变基冲突解决方案"
 
-msgctxt "dlgScConflictSolverEdit.tle"
+msgctxt "dlgScConflictSolverEdit.tle:"
 msgid "Edit"
 msgstr "编辑"
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.fur"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.fur:"
 msgid "The merge file content contains mixed \\(inconsistent\\) line-endings. If these line-endings are intentionally mixed, be sure to not overwrite them while saving this file."
 msgstr "合并文件内容包含混合不一致的行尾序列. 如果这些行尾序列有意混合, 保存此文件时请确保不要覆盖它们."
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.hdl:"
 msgid "The file contains mixed \\(inconsistent\\) line-endings."
 msgstr "文件包含混合不一致的行尾序列."
 
-msgctxt "dlgScConflictSolverInconsistentLineEndings.tle"
+msgctxt "dlgScConflictSolverInconsistentLineEndings.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - 冲突解决工具"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.chk"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.chk:"
 msgid "Don't warn me again"
 msgstr "不再显示警告"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.fur"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.fur:"
 msgid "Not all conflicts have been resolved."
 msgstr "并非所有冲突都已得到解决。"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.hdl"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.hdl:"
 msgid "Do you want to close the Conflict Solver?"
 msgstr "你想关闭冲突解决工具吗？"
 
-msgctxt "dlgScConflictSolverUnresolvedConflicts.tle"
+msgctxt "dlgScConflictSolverUnresolvedConflicts.tle:"
 msgid "Unresolved Conflicts"
 msgstr "未解决的冲突"
 
@@ -761,7 +761,7 @@ msgctxt "dlgScConflictSolver(Add|Edit).edt:"
 msgid "File Pattern"
 msgstr "文件模式"
 
-msgctxt "dlgScConflictSolver(Add|Edit).inf"
+msgctxt "dlgScConflictSolver(Add|Edit).inf:"
 msgid "Define the file pattern \\(e.g. \\*.txt\\) and select the merge tool which should be used to resolve conflicting files matching this pattern."
 msgstr "定义文件模式 \\(例如：\\*.txt\\) 并选择合并工具，该工具用于解决与此模式匹配的冲突文件。"
 
@@ -841,15 +841,15 @@ msgctxt "dlgScCustomizeAccelerators.edt:"
 msgid "Accelerator"
 msgstr "快捷键"
 
-msgctxt "dlgScCustomizeAccelerators.hdl"
+msgctxt "dlgScCustomizeAccelerators.hdl:"
 msgid "Customize Accelerators"
 msgstr "自定义加速器"
 
-msgctxt "dlgScCustomizeAccelerators.inf"
+msgctxt "dlgScCustomizeAccelerators.inf:"
 msgid "Double click on the menu item for which the accelerator should be changed, then press the accelerator keys and click the Assign button."
 msgstr "双击要更改的快捷键菜单项，然后按加速器键并单击 “分配” 按钮。"
 
-msgctxt "dlgScCustomizeAccelerators.tle"
+msgctxt "dlgScCustomizeAccelerators.tle:"
 msgid "Customize"
 msgstr "自定义"
 
@@ -901,7 +901,7 @@ msgctxt "dlgScCustomizeToolBar.mni:"
 msgid "Remove"
 msgstr ""
 
-msgctxt "dlgScCustomizeToolBar.tle"
+msgctxt "dlgScCustomizeToolBar.tle:"
 msgid "Configure Toolbar"
 msgstr "配置工具栏"
 
@@ -921,15 +921,15 @@ msgctxt "dlgScDevOpsCredentials.edt:"
 msgid "User Name"
 msgstr "用户名"
 
-msgctxt "dlgScDevOpsCredentials.hdl"
+msgctxt "dlgScDevOpsCredentials.hdl:"
 msgid "Login to '$1'"
 msgstr "登录 “$1”"
 
-msgctxt "dlgScDevOpsCredentials.inf"
+msgctxt "dlgScDevOpsCredentials.inf:"
 msgid "Provide the user name and password for authenticating to JIRA."
 msgstr "提供用于向 JIRA 进行身份验证的用户名和密码。"
 
-msgctxt "dlgScDevOpsCredentials.tle"
+msgctxt "dlgScDevOpsCredentials.tle:"
 msgid "Login to JIRA"
 msgstr "登录到 JIRA"
 
@@ -953,15 +953,15 @@ msgctxt "dlgScDevOpsSslClientCertificate.edt:"
 msgid "Passphrase"
 msgstr "密码"
 
-msgctxt "dlgScDevOpsSslClientCertificate.hdl"
+msgctxt "dlgScDevOpsSslClientCertificate.hdl:"
 msgid "Select the client certificate for $1"
 msgstr "选择 $1 的客户端证书"
 
-msgctxt "dlgScDevOpsSslClientCertificate.inf"
+msgctxt "dlgScDevOpsSslClientCertificate.inf:"
 msgid "Select the client certificate file for authenticating to JIRA."
 msgstr "选择用于向 JIRA 进行身份验证的客户端证书文件。"
 
-msgctxt "dlgScDevOpsSslClientCertificate.tle"
+msgctxt "dlgScDevOpsSslClientCertificate.tle:"
 msgid "JIRA Client Certificate"
 msgstr "JIRA 客户证书"
 
@@ -997,7 +997,7 @@ msgctxt "dlgScDevOpsSslFingerprintNew.lbl:"
 msgid "When in doubt, contact your server administrator."
 msgstr "如有疑问，请与你的服务器管理员联系。"
 
-msgctxt "dlgScDevOpsSslFingerprintNew.tle"
+msgctxt "dlgScDevOpsSslFingerprintNew.tle:"
 msgid "SSL Authentication"
 msgstr "SSL 身份验证"
 
@@ -1021,7 +1021,7 @@ msgctxt "dlgScDialogAssertionHandler.lbl:"
 msgid "SmartGit has crashed due to insufficient system memory"
 msgstr "SmartGit 由于系统内存不足而崩溃"
 
-msgctxt "dlgScDialogAssertionHandler.tle"
+msgctxt "dlgScDialogAssertionHandler.tle:"
 msgid "Native Crash Logs"
 msgstr "本机崩溃记录"
 
@@ -1037,7 +1037,7 @@ msgctxt "dlgScDialogAssertionHandlerLinkageError.lbl:"
 msgid "SmartGit has detected inconsistencies within its installation files \\(JAR files\\), what has most likely been caused by a faulty installation.\\n\\nPlease uninstall SmartGit completely, make sure there are no more installation files left \\(especially JAR files\\), then reinstall.\\n\\nIf the problem persists, send following log file as an attachment to smartgit@syntevo.com."
 msgstr "SmartGit 已检测到其安装文件 \\(JAR 文件\\) 中的不一致，这很可能是由安装错误引起的。\\n\\n请完全卸载 SmartGit，确保没有剩余的安装文件 \\(尤其是 JAR 文件\\) ，然后重新安装。\\n\\n如果问题仍然存在，请将以下记录文件作为附件发送到 smartgit@syntevo.com。"
 
-msgctxt "dlgScDialogAssertionHandlerLinkageError.tle"
+msgctxt "dlgScDialogAssertionHandlerLinkageError.tle:"
 msgid "Internal Error"
 msgstr "内部错误"
 
@@ -1045,15 +1045,15 @@ msgctxt "dlgScDialogAssertionHandlerOutOfMemory.btn:"
 msgid "Force Exit"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.fur:"
 msgid "It is strongly recommended to restart SmartGit.\\n\\nTo increase the maximum memory limit edit $1, increase the value of the -Xmx option, for example to -Xmx1024m \\(or add it if not yet existing\\) and restart SmartGit."
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.hdl"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.hdl:"
 msgid "SmartGit ran out of memory!"
 msgstr ""
 
-msgctxt "dlgScDialogAssertionHandlerOutOfMemory.tle"
+msgctxt "dlgScDialogAssertionHandlerOutOfMemory.tle:"
 msgid "Out Of Memory"
 msgstr ""
 
@@ -1065,27 +1065,27 @@ msgctxt "dlgScEvaluationReminderContinue.btn:"
 msgid "Register"
 msgstr "注册"
 
-msgctxt "dlgScEvaluationReminderContinue.fur"
+msgctxt "dlgScEvaluationReminderContinue.fur:"
 msgid "To use SmartGit in a commercial environment, you will have to \\[$1 purchase a license\\].\\n\\nFor \\[$2 certain uses\\] we grant free licenses."
 msgstr "在商业环境中使用 SmartGit，您必须 \\[$1 购买许可证 \\]。\\n\\n对于 \\[$2 某些用途 \\]，我们授予免费许可证。"
 
-msgctxt "dlgScEvaluationReminderContinue.hdl"
+msgctxt "dlgScEvaluationReminderContinue.hdl:"
 msgid "Your SmartGit evaluation ends in $1 days."
 msgstr "您的 SmartGit 试用将在 $1 天后结束。"
 
-msgctxt "dlgScEvaluationReminderContinue.tle"
+msgctxt "dlgScEvaluationReminderContinue.tle:"
 msgid "Evaluation"
 msgstr "试用"
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.hdl:"
 msgid "Cannot run program \"$1\": $2"
 msgstr "无法运行 \"$1\": $2"
 
-msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle"
+msgctxt "dlgScExternalFileStarterCommandInvocationFailed.tle:"
 msgid "\\[$1\\] - Conflict Solver"
 msgstr "\\[$1\\] - 冲突解决工具"
 
-msgctxt "dlgScFileComparatorAdd.hdl"
+msgctxt "dlgScFileComparatorAdd.hdl:"
 msgid "Add external diff tool"
 msgstr "添加外部差异工具"
 
@@ -1101,11 +1101,11 @@ msgctxt "dlgScFileComparatorAdd.mni:"
 msgid "Base Title"
 msgstr "基准标题"
 
-msgctxt "dlgScFileComparatorAdd.tle"
+msgctxt "dlgScFileComparatorAdd.tle:"
 msgid "Add"
 msgstr "添加"
 
-msgctxt "dlgScFileComparatorEdit.hdl"
+msgctxt "dlgScFileComparatorEdit.hdl:"
 msgid "Edit external diff tool"
 msgstr "编辑外部差异工具"
 
@@ -1121,7 +1121,7 @@ msgctxt "dlgScFileComparatorEdit.mni:"
 msgid "Base Title"
 msgstr "基准标题"
 
-msgctxt "dlgScFileComparatorEdit.tle"
+msgctxt "dlgScFileComparatorEdit.tle:"
 msgid "Edit"
 msgstr "编辑"
 
@@ -1137,7 +1137,7 @@ msgctxt "dlgScFileComparator(Add|Edit).edt:"
 msgid "File Pattern"
 msgstr "文件模式"
 
-msgctxt "dlgScFileComparator(Add|Edit).inf"
+msgctxt "dlgScFileComparator(Add|Edit).inf:"
 msgid "Define the file pattern \\(e.g. \\*.png\\) and select the compare command which should be used to compare files matching the file pattern."
 msgstr "定义文件模式 \\(例如：\\*.png\\) 并选择比较命令，该命令应用于比较与文件模式匹配的文件。"
 
@@ -1201,15 +1201,15 @@ msgctxt "dlgScFileCompareFileChanged.btn:"
 msgid "Save"
 msgstr "保存"
 
-msgctxt "dlgScFileCompareFileChanged.fur"
+msgctxt "dlgScFileCompareFileChanged.fur:"
 msgid "Your changes will be lost, if you don't save them."
 msgstr "如果您不保存更改，您的更改将会丢失。"
 
-msgctxt "dlgScFileCompareFileChanged.hdl"
+msgctxt "dlgScFileCompareFileChanged.hdl:"
 msgid "Do you want to save your changes?"
 msgstr "你确定要保存更改吗？"
 
-msgctxt "dlgScFileCompareFileChanged.tle"
+msgctxt "dlgScFileCompareFileChanged.tle:"
 msgid "File Changed"
 msgstr "文件已更改"
 
@@ -1229,15 +1229,15 @@ msgctxt "dlgScFileCompareSaveAll.chk:"
 msgid "Right file"
 msgstr "右侧文件"
 
-msgctxt "dlgScFileCompareSaveAll.hdl"
+msgctxt "dlgScFileCompareSaveAll.hdl:"
 msgid "Save file changes"
 msgstr "保存文件变更"
 
-msgctxt "dlgScFileCompareSaveAll.inf"
+msgctxt "dlgScFileCompareSaveAll.inf:"
 msgid "Decide which file content to save."
 msgstr "确定要保存的文件内容."
 
-msgctxt "dlgScFileCompareSaveAll.tle"
+msgctxt "dlgScFileCompareSaveAll.tle:"
 msgid "Save Changes"
 msgstr "保存变更"
 
@@ -1245,11 +1245,11 @@ msgctxt "dlgScFilePatternsEdit.edt:"
 msgid "File Pattern"
 msgstr "文件模式"
 
-msgctxt "dlgScFilePatternsEdit.hdl"
+msgctxt "dlgScFilePatternsEdit.hdl:"
 msgid "Language: $1"
 msgstr "语言：$1"
 
-msgctxt "dlgScFilePatternsEdit.inf"
+msgctxt "dlgScFilePatternsEdit.inf:"
 msgid "File patterns are used to determine file language, which is used for syntax coloring."
 msgstr "文件模式用于确定文件语言，该文件用于语法着色。"
 
@@ -1257,7 +1257,7 @@ msgctxt "dlgScFilePatternsEdit.lbl:"
 msgid "Valid wildcards are ?\\u00a0\\(one arbitrary character\\) and \\*\\u00a0\\(any number of arbitrary characters\\). Separate multiple patterns by comma. Example:\\u00a0\\*.txt,\\u00a0\\*.html"
 msgstr "有效的通配符是 ?\\u00a0\\(一个任意字符\\)和\\*\\u00a0\\(任意数量的任意字符\\)。用逗号分隔多个模式。例如：\\u00a0\\*.txt,\\u00a0\\*.html。"
 
-msgctxt "dlgScFilePatternsEdit.tle"
+msgctxt "dlgScFilePatternsEdit.tle:"
 msgid "File Patterns"
 msgstr "文件模式"
 
@@ -1265,7 +1265,7 @@ msgctxt "dlgScFindAction.edt:"
 msgid "Action name"
 msgstr "命令"
 
-msgctxt "dlgScFindAction.tle"
+msgctxt "dlgScFindAction.tle:"
 msgid "Find Command"
 msgstr "查找命令"
 
@@ -1285,15 +1285,15 @@ msgctxt "dlgScHostKeyVerifier.edt:"
 msgid "Server"
 msgstr "服务器"
 
-msgctxt "dlgScHostKeyVerifier.fur"
+msgctxt "dlgScHostKeyVerifier.fur:"
 msgid "If you are unsure, contact your administrator."
 msgstr "如果您不确定，请与管理员联系。"
 
-msgctxt "dlgScHostKeyVerifier.hdl"
+msgctxt "dlgScHostKeyVerifier.hdl:"
 msgid "Please confirm the SSH server fingerprint."
 msgstr "请确认 SSH 服务器指纹。"
 
-msgctxt "dlgScHostKeyVerifier.tle"
+msgctxt "dlgScHostKeyVerifier.tle:"
 msgid "SSH Server Verification"
 msgstr "SSH 服务器验证"
 
@@ -1329,11 +1329,11 @@ msgctxt "dlgScJiraCommitMessageSelect.col:"
 msgid "Summary"
 msgstr "摘要"
 
-msgctxt "dlgScJiraCommitMessageSelect.hdl"
+msgctxt "dlgScJiraCommitMessageSelect.hdl:"
 msgid "Select commit message by JIRA issue"
 msgstr "按 JIRA 问题选择提交消息"
 
-msgctxt "dlgScJiraCommitMessageSelect.inf"
+msgctxt "dlgScJiraCommitMessageSelect.inf:"
 msgid "The selected issue summary will be used as commit message."
 msgstr "选定的问题摘要将用作提交消息。"
 
@@ -1349,7 +1349,7 @@ msgctxt "dlgScJiraCommitMessageSelect.lbl:"
 msgid "Query Configuration"
 msgstr "查询配置"
 
-msgctxt "dlgScJiraCommitMessageSelect.tle"
+msgctxt "dlgScJiraCommitMessageSelect.tle:"
 msgid "Select Issue"
 msgstr "选择问题"
 
@@ -1377,15 +1377,15 @@ msgctxt "dlgScJiraResolveIssue.edt:"
 msgid "Summary"
 msgstr "摘要"
 
-msgctxt "dlgScJiraResolveIssue.hdl"
+msgctxt "dlgScJiraResolveIssue.hdl:"
 msgid "Resolve issue $1"
 msgstr "解决问题 $1"
 
-msgctxt "dlgScJiraResolveIssue.inf"
+msgctxt "dlgScJiraResolveIssue.inf:"
 msgid "Select whether to resolve this issue and for which version to mark as resolved."
 msgstr "选择是否解决此问题以及要标记为已解决的版本。"
 
-msgctxt "dlgScJiraResolveIssue.tle"
+msgctxt "dlgScJiraResolveIssue.tle:"
 msgid "Resolve JIRA Issue"
 msgstr "解决 JIRA 问题"
 
@@ -1401,11 +1401,11 @@ msgctxt "dlgScMasterPasswordChange.edt:"
 msgid "Retype New Master Password"
 msgstr "再次输入"
 
-msgctxt "dlgScMasterPasswordChange.hdl"
+msgctxt "dlgScMasterPasswordChange.hdl:"
 msgid "Change or reset the master password"
 msgstr "更改或重置主密码"
 
-msgctxt "dlgScMasterPasswordChange.inf"
+msgctxt "dlgScMasterPasswordChange.inf:"
 msgid "To change the master password, enter the current one. To go without a master password, leave the new field blank."
 msgstr "要更改主密码，请输入当前密码。要没有主密码，请将字段留空。"
 
@@ -1421,7 +1421,7 @@ msgctxt "dlgScMasterPasswordChange.rbt:"
 msgid "Set new master password"
 msgstr "设置新的主密码"
 
-msgctxt "dlgScMasterPasswordChange.tle"
+msgctxt "dlgScMasterPasswordChange.tle:"
 msgid "Change Master Password"
 msgstr "更改主密码"
 
@@ -1433,11 +1433,11 @@ msgctxt "dlgScMasterPasswordCreate.edt:"
 msgid "Retype Again"
 msgstr "重新输入"
 
-msgctxt "dlgScMasterPasswordCreate.hdl"
+msgctxt "dlgScMasterPasswordCreate.hdl:"
 msgid "Configure the master password for the encrypted password store"
 msgstr "配置加密密码存储的主密码"
 
-msgctxt "dlgScMasterPasswordCreate.inf"
+msgctxt "dlgScMasterPasswordCreate.inf:"
 msgid "The master password is used to protect passwords and passphrases which are used to authenticate with servers."
 msgstr "主密码用于保护用于向服务器进行身份验证的密码和口令。"
 
@@ -1457,7 +1457,7 @@ msgctxt "dlgScMasterPasswordCreate.rbt:"
 msgid "Use the following master password"
 msgstr "使用以下主密码"
 
-msgctxt "dlgScMasterPasswordCreate.tle"
+msgctxt "dlgScMasterPasswordCreate.tle:"
 msgid "Master Password"
 msgstr "主密码"
 
@@ -1465,39 +1465,39 @@ msgctxt "dlgScMasterPasswordEnter.edt:"
 msgid "Master Password"
 msgstr "主密码"
 
-msgctxt "dlgScMasterPasswordEnter.hdl"
+msgctxt "dlgScMasterPasswordEnter.hdl:"
 msgid "Enter the master password"
 msgstr "输入主密码"
 
-msgctxt "dlgScMasterPasswordEnter.inf"
+msgctxt "dlgScMasterPasswordEnter.inf:"
 msgid "A stored password or passphrase has been requested from the password store."
 msgstr "已从密码库中申请了存储的密码或口令。"
 
-msgctxt "dlgScMasterPasswordEnter.tle"
+msgctxt "dlgScMasterPasswordEnter.tle:"
 msgid "Passwords"
 msgstr "密码"
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.fur"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.fur:"
 msgid "The process could not be started."
 msgstr "无法启动进程."
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.hdl"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr "更新程序启动失败."
 
-msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.tle"
+msgctxt "dlgScNotificationUpdateCheckHandlerUpdateFailure.tle:"
 msgid "SmartGit Installation Update"
 msgstr "SmartGit 安装更新"
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.fur"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.fur:"
 msgid "Be sure to remember it, otherwise you won't be able to access your stored passwords anymore."
 msgstr "请务必记住它，否则您将无法再访问您存储的密码。"
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.hdl"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.hdl:"
 msgid "The master password has been changed."
 msgstr "主密码已更改。"
 
-msgctxt "dlgScPasswordMasterChangeSuccessfulChange.tle"
+msgctxt "dlgScPasswordMasterChangeSuccessfulChange.tle:"
 msgid "Change Master Password"
 msgstr "更改主密码"
 
@@ -1505,15 +1505,15 @@ msgctxt "dlgScPropertiesReset.btn:"
 msgid "Reset"
 msgstr "重置"
 
-msgctxt "dlgScPropertiesReset.fur"
+msgctxt "dlgScPropertiesReset.fur:"
 msgid "The new values will be active after restarting SmartGit."
 msgstr "新值只有在重新启动 SmartGit 后才会激活。"
 
-msgctxt "dlgScPropertiesReset.hdl"
+msgctxt "dlgScPropertiesReset.hdl:"
 msgid "Do you want to reset $1 system properties to their defaults?"
 msgstr "是否要将系统属性 $1 重置为默认值？"
 
-msgctxt "dlgScPropertiesReset.tle"
+msgctxt "dlgScPropertiesReset.tle:"
 msgid "Reset Properties"
 msgstr "重置属性"
 
@@ -1521,11 +1521,11 @@ msgctxt "dlgScPropertyEdit.edt:"
 msgid "Value"
 msgstr "值"
 
-msgctxt "dlgScPropertyEdit.hdl"
+msgctxt "dlgScPropertyEdit.hdl:"
 msgid "Edit low-level property value"
 msgstr "编辑低级属性值"
 
-msgctxt "dlgScPropertyEdit.inf"
+msgctxt "dlgScPropertyEdit.inf:"
 msgid "Set the value for property '$1'"
 msgstr "设置属性 “$1” 的值"
 
@@ -1537,7 +1537,7 @@ msgctxt "dlgScPropertyEdit.rbt:"
 msgid "true"
 msgstr "真"
 
-msgctxt "dlgScPropertyEdit.tle"
+msgctxt "dlgScPropertyEdit.tle:"
 msgid "Edit Property"
 msgstr "编辑属性"
 
@@ -1577,7 +1577,7 @@ msgctxt "dlgScRegisterFormLicenseConfirmDetails.edt:"
 msgid "User Count"
 msgstr "用户计数"
 
-msgctxt "dlgScRegisterFormLicenseConfirmDetails.tle"
+msgctxt "dlgScRegisterFormLicenseConfirmDetails.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit 许可证"
 
@@ -1585,27 +1585,27 @@ msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.btn:"
 msgid "Purchase Update"
 msgstr "购买更新"
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.fur"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.fur:"
 msgid "You may use an older SmartGit version or purchase an update license."
 msgstr "您可以使用旧的 SmartGit 版本或购买更新许可证。"
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.hdl"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.hdl:"
 msgid "The free update period for this license does not cover this version."
 msgstr "此许可证的免费更新期不包括此版本。"
 
-msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.tle"
+msgctxt "dlgScRegisterFreeUpdatesExpiredLicense.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit 许可证"
 
-msgctxt "dlgScRegisterRequestRejected.fur"
+msgctxt "dlgScRegisterRequestRejected.fur:"
 msgid "The license server rejected the request. Please manually register the latest license file you've got by email or try again later."
 msgstr "许可证服务器拒绝了该请求。请手动注册你通过电子邮件得到的最新许可文件，或稍后再试。"
 
-msgctxt "dlgScRegisterRequestRejected.hdl"
+msgctxt "dlgScRegisterRequestRejected.hdl:"
 msgid "Failed to update license file."
 msgstr "更新许可文件失败。"
 
-msgctxt "dlgScRegisterRequestRejected.tle"
+msgctxt "dlgScRegisterRequestRejected.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit 许可证"
 
@@ -1633,15 +1633,15 @@ msgctxt "dlgScSetupLicense.edt:"
 msgid "License Server URL"
 msgstr ""
 
-msgctxt "dlgScSetupLicense.hdl"
+msgctxt "dlgScSetupLicense.hdl:"
 msgid "Register license file"
 msgstr "注册许可证文件"
 
-msgctxt "dlgScSetupLicense.inf"
+msgctxt "dlgScSetupLicense.inf:"
 msgid "Please provide your SmartGit license file you've received by email after purchase."
 msgstr "请提供您在购买后通过电子邮件收到的 SmartGit 许可文件。"
 
-msgctxt "dlgScSetupLicense.tle"
+msgctxt "dlgScSetupLicense.tle:"
 msgid "SmartGit License"
 msgstr "SmartGit 许可证"
 
@@ -1653,19 +1653,19 @@ msgctxt "dlgScSpellCheckDictionaryAdd.err:"
 msgid "Please select a dictionary file."
 msgstr ""
 
-msgctxt "dlgScSpellCheckDictionaryAdd.hdl"
+msgctxt "dlgScSpellCheckDictionaryAdd.hdl:"
 msgid "Add spell checker dictionary"
 msgstr "添加拼写检查字典"
 
-msgctxt "dlgScSpellCheckDictionaryAdd.tle"
+msgctxt "dlgScSpellCheckDictionaryAdd.tle:"
 msgid "Add"
 msgstr "添加"
 
-msgctxt "dlgScSpellCheckDictionaryEdit.hdl"
+msgctxt "dlgScSpellCheckDictionaryEdit.hdl:"
 msgid "Edit spell checker dictionary"
 msgstr "编辑拼写检查字典"
 
-msgctxt "dlgScSpellCheckDictionaryEdit.tle"
+msgctxt "dlgScSpellCheckDictionaryEdit.tle:"
 msgid "Edit"
 msgstr "编辑"
 
@@ -1677,7 +1677,7 @@ msgctxt "dlgScSpellCheckDictionary(Add|Edit).edt:"
 msgid "Name"
 msgstr "名称"
 
-msgctxt "dlgScSpellCheckDictionary(Add|Edit).inf"
+msgctxt "dlgScSpellCheckDictionary(Add|Edit).inf:"
 msgid "Specify the MySpell dictionary file to use, e.g. \\*.dic from Mozilla Firefox' or Thunderbird's \"dictionary\" directory\\). The name is used when switching between different dictionaries."
 msgstr "指定拼写字典文件 \\(例如:\\*.dic 来自 Mozilla Firefox 或 Thunderbird 的 “词典” 目录\\). 该名称用来切换不同的字典。"
 
@@ -1705,7 +1705,7 @@ msgctxt "dlgScSslFingerprint.lbl:"
 msgid "This might indicate a security problem! When in doubt, contact your server administrator."
 msgstr "这可能表示存在安全问题！ 如有疑问，请与服务器管理员联系。"
 
-msgctxt "dlgScSslFingerprint.tle"
+msgctxt "dlgScSslFingerprint.tle:"
 msgid "Server Fingerprint"
 msgstr "服务器指纹"
 
@@ -1713,15 +1713,15 @@ msgctxt "dlgScTextFinderFindFromEnd.btn:"
 msgid "Find from End"
 msgstr "从后向前查找"
 
-msgctxt "dlgScTextFinderFindFromEnd.fur"
+msgctxt "dlgScTextFinderFindFromEnd.fur:"
 msgid "No occurrences have been found until the beginning of the document."
 msgstr "从文档开头未找到结果."
 
-msgctxt "dlgScTextFinderFindFromEnd.hdl"
+msgctxt "dlgScTextFinderFindFromEnd.hdl:"
 msgid "Do you want to continue from the end of the document?"
 msgstr "是否从文档末尾继续?"
 
-msgctxt "dlgScTextFinderFindFromEnd.tle"
+msgctxt "dlgScTextFinderFindFromEnd.tle:"
 msgid "Find Text"
 msgstr "查找文件"
 
@@ -1729,23 +1729,23 @@ msgctxt "dlgScTextFinderFindFromStart.btn:"
 msgid "Find from Beginning"
 msgstr "从头查找"
 
-msgctxt "dlgScTextFinderFindFromStart.fur"
+msgctxt "dlgScTextFinderFindFromStart.fur:"
 msgid "No occurrences have been found until the end of the document."
 msgstr "直到文档底部无法查找更多文本"
 
-msgctxt "dlgScTextFinderFindFromStart.hdl"
+msgctxt "dlgScTextFinderFindFromStart.hdl:"
 msgid "Do you want to continue from the beginning of the document?"
 msgstr "您想从文档的开头继续查找吗？"
 
-msgctxt "dlgScTextFinderFindFromStart.tle"
+msgctxt "dlgScTextFinderFindFromStart.tle:"
 msgid "Find Text"
 msgstr "查找文本"
 
-msgctxt "dlgScTextFinderNothingFound.hdl"
+msgctxt "dlgScTextFinderNothingFound.hdl:"
 msgid "No \\(more\\) occurrences have been found."
 msgstr "没有找到 \\(更多\\) 文本。"
 
-msgctxt "dlgScTextFinderNothingFound.tle"
+msgctxt "dlgScTextFinderNothingFound.tle:"
 msgid "Find Text"
 msgstr "查找文本"
 
@@ -1753,11 +1753,11 @@ msgctxt "dlgScTextMultiComponentGoToLine.edt:"
 msgid "Line Number"
 msgstr "行号"
 
-msgctxt "dlgScTextMultiComponentGoToLine.tle"
+msgctxt "dlgScTextMultiComponentGoToLine.tle:"
 msgid "Go to Line"
 msgstr "转到行"
 
-msgctxt "dlgScTextMultiComponentSyntaxHighlightingSelection.tle"
+msgctxt "dlgScTextMultiComponentSyntaxHighlightingSelection.tle:"
 msgid "Select Syntax-Highlighting"
 msgstr "选择语法-高亮显示"
 
@@ -1869,43 +1869,43 @@ msgctxt "dlgScTextSettings.tab:"
 msgid "General"
 msgstr "常规"
 
-msgctxt "dlgScTextSettings.tle"
+msgctxt "dlgScTextSettings.tle:"
 msgid "Settings"
 msgstr "设置"
 
-msgctxt "dlgScUpdateInstallationResumeFailure.fur"
+msgctxt "dlgScUpdateInstallationResumeFailure.fur:"
 msgid "The process could not be started."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationResumeFailure.hdl"
+msgctxt "dlgScUpdateInstallationResumeFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationResumeFailure.tle"
+msgctxt "dlgScUpdateInstallationResumeFailure.tle:"
 msgid "Upgrade"
 msgstr ""
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.fur"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.fur:"
 msgid "The process could not be started."
 msgstr "进程无法启动."
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.hdl"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.hdl:"
 msgid "Launching updater directly failed."
 msgstr "更新程序启动失败."
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle"
+msgctxt "dlgScUpdateInstallationUpdateManuallyFailure.tle:"
 msgid "SmartGit Installation Update"
 msgstr "SmartGit 安装更新"
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.fur:"
 msgid "Please get rid of '$1' manually and retry the upgrade."
 msgstr "请手动删除 '$1' 并重试."
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.hdl"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.hdl:"
 msgid "Clearing updater directory failed."
 msgstr "清除更新程序目录失败."
 
-msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.tle"
+msgctxt "dlgScUpdateInstallationUpdateManuallyInfo.tle:"
 msgid "SmartGit Installation Update"
 msgstr "SmartGit 安装更新"
 
@@ -1913,15 +1913,15 @@ msgctxt "dlgScUpdateInstallationUpgrade.btn:"
 msgid "Upgrade Now"
 msgstr "立即升级"
 
-msgctxt "dlgScUpdateInstallationUpgrade.fur"
+msgctxt "dlgScUpdateInstallationUpgrade.fur:"
 msgid "The new version $1 has been downloaded which needs to be installed."
 msgstr "新版本 $1 已经下载，需要安装。"
 
-msgctxt "dlgScUpdateInstallationUpgrade.hdl"
+msgctxt "dlgScUpdateInstallationUpgrade.hdl:"
 msgid "Do you want to upgrade SmartGit now?"
 msgstr "是否要立即升级 SmartGit？"
 
-msgctxt "dlgScUpdateInstallationUpgrade.tle"
+msgctxt "dlgScUpdateInstallationUpgrade.tle:"
 msgid "Upgrade SmartGit"
 msgstr "升级 SmartGit"
 
@@ -1929,11 +1929,11 @@ msgctxt "dlgSelectDiff.col:"
 msgid "Command"
 msgstr "命令"
 
-msgctxt "dlgSelectDiff.hdl"
+msgctxt "dlgSelectDiff.hdl:"
 msgid "Select the diff tool"
 msgstr "选择比较工具"
 
-msgctxt "dlgSelectDiff.inf"
+msgctxt "dlgSelectDiff.inf:"
 msgid "Select which matching diff tool should be used."
 msgstr "选择应使用的匹配比较工具。"
 
@@ -1945,7 +1945,7 @@ msgctxt "dlgSelectDiff.lbl:"
 msgid "Diff tool:"
 msgstr ""
 
-msgctxt "dlgSelectDiff.tle"
+msgctxt "dlgSelectDiff.tle:"
 msgid "File Compare"
 msgstr "文件比较"
 
@@ -1953,15 +1953,15 @@ msgctxt "dlgSgAbortBisectingConfirm.btn:"
 msgid "Abort Bisect"
 msgstr "中止二分"
 
-msgctxt "dlgSgAbortBisectingConfirm.fur"
+msgctxt "dlgSgAbortBisectingConfirm.fur:"
 msgid "Your working tree is in 'bisecting' state. You may abort it to get out of this state.\\n\\nAborting will checkout the branch or commit before starting bisect."
 msgstr "您的工作区处于 “二分” 状态。您可以中止它以退出此状态。\\n\\n在开始二分之前，将检查分支或提交。"
 
-msgctxt "dlgSgAbortBisectingConfirm.hdl"
+msgctxt "dlgSgAbortBisectingConfirm.hdl:"
 msgid "Do you want to reset your working tree?"
 msgstr "是否要重置工作区？"
 
-msgctxt "dlgSgAbortBisectingConfirm.tle"
+msgctxt "dlgSgAbortBisectingConfirm.tle:"
 msgid "Abort"
 msgstr "中止"
 
@@ -1969,15 +1969,15 @@ msgctxt "dlgSgAbortCherryPickingConfirm.btn:"
 msgid "Abort Cherry-Pick"
 msgstr "中止摘取"
 
-msgctxt "dlgSgAbortCherryPickingConfirm.fur"
+msgctxt "dlgSgAbortCherryPickingConfirm.fur:"
 msgid "Your working tree is in 'cherry-picking' state. You may abort it to get out of this state and freshly start over with the cherry-picking afterwards.\\n\\nAborting will clean any local modification \\(by invoking 'git cherry-pick --abort'\\)!"
 msgstr "您的工作区处于 “摘取” 状态。你可以中止它以摆脱这种状态，然后重新开始摘取。\\n\\n中止将清理任何本地修改 \\(通过调用 “git reset --hard”\\)！"
 
-msgctxt "dlgSgAbortCherryPickingConfirm.hdl"
+msgctxt "dlgSgAbortCherryPickingConfirm.hdl:"
 msgid "Do you want to abort the current cherry-pick?"
 msgstr "您想重置您的工作区吗？"
 
-msgctxt "dlgSgAbortCherryPickingConfirm.tle"
+msgctxt "dlgSgAbortCherryPickingConfirm.tle:"
 msgid "Abort"
 msgstr "中止"
 
@@ -1985,15 +1985,15 @@ msgctxt "dlgSgAbortMergingConfirm.btn:"
 msgid "Abort Merge"
 msgstr "中止合并"
 
-msgctxt "dlgSgAbortMergingConfirm.fur"
+msgctxt "dlgSgAbortMergingConfirm.fur:"
 msgid "Your working tree is in 'merging' state. You may abort it to get out of this state and freshly start over with the merge afterwards.\\n\\nAborting will try to reconstruct the pre-merge state \\(by invoking 'git merge --abort'\\)!"
 msgstr "您的工作区处于 “合并” 状态。您可以中止它以退出此状态，然后重新开始合并。\\n\\n中止将尝试重建合并前状态 \\(通过调用 “git merge --abort”\\)！"
 
-msgctxt "dlgSgAbortMergingConfirm.hdl"
+msgctxt "dlgSgAbortMergingConfirm.hdl:"
 msgid "Do you want to abort the current merge?"
 msgstr "您想中止当前的合并吗？"
 
-msgctxt "dlgSgAbortMergingConfirm.tle"
+msgctxt "dlgSgAbortMergingConfirm.tle:"
 msgid "Abort"
 msgstr "丢弃"
 
@@ -2001,15 +2001,15 @@ msgctxt "dlgSgAbortRebasingConfirm.btn:"
 msgid "Abort Rebase"
 msgstr "中止变基"
 
-msgctxt "dlgSgAbortRebasingConfirm.fur"
+msgctxt "dlgSgAbortRebasingConfirm.fur:"
 msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase instead.\\n\\nAborting will clean any local modification \\(by invoking 'git rebase --abort'\\)!"
 msgstr "您的工作区处于 “变基” 状态。你可以放弃变基; 如果您只想跳过当前的补丁，请使用 分支 \\| 变基 \\| 将 HEAD 变基至。\\n\\n中止将清除任何本地修改 \\(通过调用 “git reset --hard”\\)！"
 
-msgctxt "dlgSgAbortRebasingConfirm.hdl"
+msgctxt "dlgSgAbortRebasingConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
 msgstr "您想中止变基吗？"
 
-msgctxt "dlgSgAbortRebasingConfirm.tle"
+msgctxt "dlgSgAbortRebasingConfirm.tle:"
 msgid "Abort"
 msgstr "丢弃"
 
@@ -2021,7 +2021,7 @@ msgctxt "dlgSgAbortRevertingConfirm.btn:"
 msgid "Abort Revert"
 msgstr "中止还原"
 
-msgctxt "dlgSgAbortRevertingConfirm.fur"
+msgctxt "dlgSgAbortRevertingConfirm.fur:"
 msgid "Your working tree is in 'reverting' state. You may abort it to get out of this state and freshly start over with the revert afterwards.\\n\\nAborting will clean any local modification \\(by invoking 'git reset --hard'\\)!"
 msgstr "您的工作区处于 “还原” 状态。您可以中止它以退出此状态，然后重新开始还原。\\n\\n中止将清除任何本地修改 \\(通过调用 “git reset --hard”\\)!"
 
@@ -2105,31 +2105,31 @@ msgctxt "dlgSgAbout.tab:"
 msgid "Licensee"
 msgstr "授权信息"
 
-msgctxt "dlgSgAbout.tle"
+msgctxt "dlgSgAbout.tle:"
 msgid "About SmartGit"
 msgstr "关于 SmartGit"
 
-msgctxt "dlgSgApplicationAlreadyRunning.fur"
+msgctxt "dlgSgApplicationAlreadyRunning.fur:"
 msgid "Instead of running separate instances you can open multiple project windows in SmartGit.\\n\\nIf you are sure that no SmartGit instance is running any more you should delete the lock file\\n$1"
 msgstr ""
 
-msgctxt "dlgSgApplicationAlreadyRunning.hdl"
+msgctxt "dlgSgApplicationAlreadyRunning.hdl:"
 msgid "It seems that SmartGit is already running."
 msgstr ""
 
-msgctxt "dlgSgApplicationAlreadyRunning.tle"
+msgctxt "dlgSgApplicationAlreadyRunning.tle:"
 msgid "SmartGit"
 msgstr ""
 
-msgctxt "dlgSgApplicationUpgradeError.fur"
+msgctxt "dlgSgApplicationUpgradeError.fur:"
 msgid "The process could not be started."
 msgstr "进程无法启动."
 
-msgctxt "dlgSgApplicationUpgradeError.hdl"
+msgctxt "dlgSgApplicationUpgradeError.hdl:"
 msgid "Launching updater directly failed."
 msgstr "更新程序启动失败."
 
-msgctxt "dlgSgApplicationUpgradeError.tle"
+msgctxt "dlgSgApplicationUpgradeError.tle:"
 msgid "Upgrade"
 msgstr "更新"
 
@@ -2137,15 +2137,15 @@ msgctxt "dlgSgAuthenticationRemoveAllCredentials.btn:"
 msgid "Remove All"
 msgstr "移除所有"
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.fur"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.fur:"
 msgid "You will have to re-enter all authentication details."
 msgstr "您必须重新输入所有身份验证详细信息。"
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.hdl"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.hdl:"
 msgid "Do you want to remove all known credentials?"
 msgstr "您确定要删除所有已知凭据吗？"
 
-msgctxt "dlgSgAuthenticationRemoveAllCredentials.tle"
+msgctxt "dlgSgAuthenticationRemoveAllCredentials.tle:"
 msgid "Remove All"
 msgstr "移除所有"
 
@@ -2153,7 +2153,7 @@ msgctxt "dlgSgAuthenticationShowPassword.edt:"
 msgid "Password"
 msgstr "密码"
 
-msgctxt "dlgSgAuthenticationShowPassword.tle"
+msgctxt "dlgSgAuthenticationShowPassword.tle:"
 msgid "Password for $1"
 msgstr "$1 的密码"
 
@@ -2165,11 +2165,11 @@ msgctxt "dlgSgAzureGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgAzureGenerateToken.hdl"
+msgctxt "dlgSgAzureGenerateToken.hdl:"
 msgid "Enter the generated code"
 msgstr ""
 
-msgctxt "dlgSgAzureGenerateToken.inf"
+msgctxt "dlgSgAzureGenerateToken.inf:"
 msgid "Authenticate at Azure DevOps and enter the generated token."
 msgstr ""
 
@@ -2177,15 +2177,15 @@ msgctxt "dlgSgAzureGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at Azure DevOps and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgAzureGenerateToken.tle"
+msgctxt "dlgSgAzureGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr ""
 
-msgctxt "dlgSgAzureRefreshFailed.hdl"
+msgctxt "dlgSgAzureRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr ""
 
-msgctxt "dlgSgAzureRefreshFailed.tle"
+msgctxt "dlgSgAzureRefreshFailed.tle:"
 msgid "Azure DevOps"
 msgstr ""
 
@@ -2197,15 +2197,15 @@ msgctxt "dlgSgBisectResult.btn:"
 msgid "Leave Bisect"
 msgstr "离开二分"
 
-msgctxt "dlgSgBisectResult.fur"
+msgctxt "dlgSgBisectResult.fur:"
 msgid "$1"
 msgstr "$1"
 
-msgctxt "dlgSgBisectResult.hdl"
+msgctxt "dlgSgBisectResult.hdl:"
 msgid "Bisect has determined the first bad commit."
 msgstr "二分决定了第一次错误的提交。"
 
-msgctxt "dlgSgBisectResult.tle"
+msgctxt "dlgSgBisectResult.tle:"
 msgid "Bisect Finished"
 msgstr "完成二分"
 
@@ -2217,15 +2217,15 @@ msgctxt "dlgSgBisectStartConfirm.btn:"
 msgid "Start Bisect"
 msgstr "开始二分"
 
-msgctxt "dlgSgBisectStartConfirm.fur"
+msgctxt "dlgSgBisectStartConfirm.fur:"
 msgid "You need to mark 1 commit as good and 1 commit as bad before Git can start the binary search."
 msgstr "在 Git 开始二进制搜索之前，你需要将 1 个提交标记为正常，1 个提交为损坏。"
 
-msgctxt "dlgSgBisectStartConfirm.hdl"
+msgctxt "dlgSgBisectStartConfirm.hdl:"
 msgid "Should the bisect be started with a bad commit?"
 msgstr "是否应该以错误的提交开始？"
 
-msgctxt "dlgSgBisectStartConfirm.tle"
+msgctxt "dlgSgBisectStartConfirm.tle:"
 msgid "Start Bisect"
 msgstr "开始二分"
 
@@ -2237,11 +2237,11 @@ msgctxt "dlgSgBitbucketGenerateToken.edt:"
 msgid "Link"
 msgstr "链接"
 
-msgctxt "dlgSgBitbucketGenerateToken.hdl"
+msgctxt "dlgSgBitbucketGenerateToken.hdl:"
 msgid "Enter the generated code"
 msgstr "输入生成的代码"
 
-msgctxt "dlgSgBitbucketGenerateToken.inf"
+msgctxt "dlgSgBitbucketGenerateToken.inf:"
 msgid "Authenticate at Bitbucket and enter the generated token"
 msgstr "在 Bitbucket 进行身份验证并输入生成的令牌"
 
@@ -2249,15 +2249,15 @@ msgctxt "dlgSgBitbucketGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at Bitbucket and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr "您的浏览器应该已自动打开，请使用 Bitbucket 上的首选账户进行身份验证并授予对 SmartGit 的访问权限。如果没有发生这种情况，请手动打开以下链接："
 
-msgctxt "dlgSgBitbucketGenerateToken.tle"
+msgctxt "dlgSgBitbucketGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr "请求访问令牌"
 
-msgctxt "dlgSgBitbucketRefreshFailed.hdl"
+msgctxt "dlgSgBitbucketRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr ""
 
-msgctxt "dlgSgBitbucketRefreshFailed.tle"
+msgctxt "dlgSgBitbucketRefreshFailed.tle:"
 msgid "Bitbucket"
 msgstr ""
 
@@ -2305,11 +2305,11 @@ msgctxt "dlgSgBranchAddCheckout.hdl:"
 msgid "Create new branch at current branch \\(HEAD\\)"
 msgstr ""
 
-msgctxt "dlgSgBranchAddCheckout.inf"
+msgctxt "dlgSgBranchAddCheckout.inf:"
 msgid "Enter the name of the local branch to create."
 msgstr "输入要创建的本地分支的名称。"
 
-msgctxt "dlgSgBranchAddCheckout.tle"
+msgctxt "dlgSgBranchAddCheckout.tle:"
 msgid "Add Branch"
 msgstr "创建分支"
 
@@ -2317,27 +2317,27 @@ msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.btn:"
 msgid "Overwrite"
 msgstr "覆盖"
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr "单击 “取消” 以选择其他分支名称。"
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.hdl:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr "分支 “$1” 已经存在。你想覆盖吗？"
 
-msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.tle"
+msgctxt "dlgSgBranchAddCheckoutOverwriteExisting.tle:"
 msgid "Add Branch"
 msgstr "创建分支"
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.fur"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.fur:"
 msgid "By default, SmartGit disallows to delete the current branch. To skip this restriction, switch to a different branch or set the low-level property 'branch.delete.allowToDeleteCurrentBranch'."
 msgstr "默认情况下，SmartGit 不允许删除当前分支。 要跳过此限制，请设置低级属性 “branch.delete.allowToDeleteCurrentBranch”。"
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.hdl"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.hdl:"
 msgid "You can't delete the current branch."
 msgstr "您无法删除当前分支。"
 
-msgctxt "dlgSgBranchDeleteCurrentNotPossible.tle"
+msgctxt "dlgSgBranchDeleteCurrentNotPossible.tle:"
 msgid "Delete"
 msgstr "删除"
 
@@ -2369,7 +2369,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr "您确定要删除 $1 本地分支吗？"
 
@@ -2377,7 +2377,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.hdl:"
 msgid "Do you want to delete $1 local branches?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle"
+msgctxt "dlgSgBranchDeleteLocalConfirmMultiple.tle:"
 msgid "Delete"
 msgstr "删除"
 
@@ -2409,7 +2409,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.fur:"
 msgid "Your local branch is tracking branch '$1'. Decide whether you also want to delete this branch from the remote repository."
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr "您确定要删除本地分支 “$1” 吗？"
 
@@ -2417,7 +2417,7 @@ msgctxt "dlgSgBranchDeleteLocalConfirmSingle.hdl:"
 msgid "Do you want to delete the local branch '$1'?"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle"
+msgctxt "dlgSgBranchDeleteLocalConfirmSingle.tle:"
 msgid "Delete"
 msgstr "删除"
 
@@ -2425,7 +2425,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.btn:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.tle"
+msgctxt "dlgSgBranchDeleteRemoteConfirmMultiple.tle:"
 msgid "Delete"
 msgstr ""
 
@@ -2433,7 +2433,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "删除"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr ""
 
@@ -2445,7 +2445,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.chk:"
 msgid "Delete from remote repository '$1'"
 msgstr "从远程仓库中删除 '$1'"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.fur:"
 msgid "If you don't delete the branch from the remote repository, it may come back with the next fetch."
 msgstr "您只能从本地远程分支列表中删除分支，但这分支可能会在下一次获取中恢复。"
 
@@ -2457,7 +2457,7 @@ msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.hdl:"
 msgid "Do you want to delete the remote branch '$1'?"
 msgstr "您要删除远程分支 “$1” 吗？"
 
-msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle"
+msgctxt "dlgSgBranchDeleteRemoteConfirmSingle.tle:"
 msgid "Delete"
 msgstr "删除"
 
@@ -2465,15 +2465,15 @@ msgctxt "dlgSgBranchTrackingResetConfirm.btn:"
 msgid "Stop Tracking"
 msgstr "停止跟踪"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.fur"
+msgctxt "dlgSgBranchTrackingResetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "必要的配置将在 .git/config 文件中执行。"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.hdl"
+msgctxt "dlgSgBranchTrackingResetConfirm.hdl:"
 msgid "Should branch '$1' stop tracking '$2'?"
 msgstr "分支 '$1' 是否应该停止跟踪 '$2'？"
 
-msgctxt "dlgSgBranchTrackingResetConfirm.tle"
+msgctxt "dlgSgBranchTrackingResetConfirm.tle:"
 msgid "Stop Tracking"
 msgstr "停止跟踪"
 
@@ -2481,15 +2481,15 @@ msgctxt "dlgSgBranchTrackingSetConfirm.btn:"
 msgid "Configure"
 msgstr "配置"
 
-msgctxt "dlgSgBranchTrackingSetConfirm.fur"
+msgctxt "dlgSgBranchTrackingSetConfirm.fur:"
 msgid "The necessary configuration will be performed in the .git/config file."
 msgstr "必要的配置将在 .git/config 文件中执行。"
 
-msgctxt "dlgSgBranchTrackingSetConfirm.hdl"
+msgctxt "dlgSgBranchTrackingSetConfirm.hdl:"
 msgid "Do you want to configure '$1' to track '$2'?"
 msgstr "你想配置 '$1' 跟踪 '$2' 吗？"
 
-msgctxt "dlgSgBranchTrackingSetConfirm.tle"
+msgctxt "dlgSgBranchTrackingSetConfirm.tle:"
 msgid "Set Tracked Branch"
 msgstr "设置跟踪分支"
 
@@ -2509,11 +2509,11 @@ msgctxt "dlgSgBugReportSettings.err:"
 msgid "Sending 'crash footprints' is required for preview builds, because their main purposes is to get as much as possible bugs reported and fixed before release."
 msgstr "预览版本需要发送 “崩溃追踪”，因为它们的主要目的是尽可能多地获取在发布之前报告和修复的错误。"
 
-msgctxt "dlgSgBugReportSettings.hdl"
+msgctxt "dlgSgBugReportSettings.hdl:"
 msgid "Crash Reporting"
 msgstr "崩溃报告"
 
-msgctxt "dlgSgBugReportSettings.inf"
+msgctxt "dlgSgBugReportSettings.inf:"
 msgid "Please help to improve SmartGit's quality by automatically sending 'crash footprints'."
 msgstr "请通过自动发送不包含任何敏感信息的 “崩溃追踪” 来帮助提高 SmartGit 的质量。您可以稍后在偏好设置中更改此选项。"
 
@@ -2525,7 +2525,7 @@ msgctxt "dlgSgBugReportSettings.lbl:"
 msgid "Sent data contains \\*no potentially sensitive information\\* like user names, email addresses, file contents, file paths or server names."
 msgstr ""
 
-msgctxt "dlgSgBugReportSettings.tle"
+msgctxt "dlgSgBugReportSettings.tle:"
 msgid "SmartGit"
 msgstr "SmartGit"
 
@@ -2537,15 +2537,15 @@ msgctxt "dlgSgCheckout.btn:"
 msgid "Check Out"
 msgstr "检出"
 
-msgctxt "dlgSgCheckout.hdl"
+msgctxt "dlgSgCheckout.hdl:"
 msgid "Check out a commit"
 msgstr "检出提交"
 
-msgctxt "dlgSgCheckout.inf"
+msgctxt "dlgSgCheckout.inf:"
 msgid "Select the commit to check out. This allows to switch \\(back\\) the working tree to any commit."
 msgstr "选择要检出的提交. 允许将工作区切换到任何提交."
 
-msgctxt "dlgSgCheckout.tle"
+msgctxt "dlgSgCheckout.tle:"
 msgid "Check Out"
 msgstr "检出"
 
@@ -2557,15 +2557,15 @@ msgctxt "dlgSgCheckoutFastForwardMerge.btn:"
 msgid "Just Checkout"
 msgstr "仅检出"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.fur"
+msgctxt "dlgSgCheckoutFastForwardMerge.fur:"
 msgid "Fast-forward-merging automatically moves the branch forward to the tracked remote branch."
 msgstr "快进合并会自动将分支向前移动到跟踪的远程分支。"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.hdl"
+msgctxt "dlgSgCheckoutFastForwardMerge.hdl:"
 msgid "Do you want to fast-forward-merge remote changes after checking out '$1'?"
 msgstr "检出 “$1” 后，您想要快进合并远程变更吗？"
 
-msgctxt "dlgSgCheckoutFastForwardMerge.tle"
+msgctxt "dlgSgCheckoutFastForwardMerge.tle:"
 msgid "Check Out"
 msgstr "检出"
 
@@ -2573,19 +2573,19 @@ msgctxt "dlgSgCheckoutLocalBranchConfirm.btn:"
 msgid "Checkout"
 msgstr "检出"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.chk"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.fur"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.fur:"
 msgid "This will make '$1' your current branch."
 msgstr "这将使 “$1” 成为您当前的分支。"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.hdl:"
 msgid "Do you want to checkout the branch '$1'?"
 msgstr "你想检出 “$1” 分支吗?"
 
-msgctxt "dlgSgCheckoutLocalBranchConfirm.tle"
+msgctxt "dlgSgCheckoutLocalBranchConfirm.tle:"
 msgid "Check Out"
 msgstr "检出"
 
@@ -2617,7 +2617,7 @@ msgctxt "dlgSgCheckoutTarget.hdl:"
 msgid "Checkout remote branch"
 msgstr "检出远程分支"
 
-msgctxt "dlgSgCheckoutTarget.inf"
+msgctxt "dlgSgCheckoutTarget.inf:"
 msgid "Create and checkout a new local branch for the selected commit"
 msgstr "当检出提交而不是本地分支的时候需要小心：在该提交之后的提交很容易丢失。"
 
@@ -2637,7 +2637,7 @@ msgctxt "dlgSgCheckoutTarget.rbt:"
 msgid "Don't create local branch \\(just work read-only\\)"
 msgstr "不创建本地分支 \\(只是以只读方式工作\\)"
 
-msgctxt "dlgSgCheckoutTarget.tle"
+msgctxt "dlgSgCheckoutTarget.tle:"
 msgid "Check Out"
 msgstr "检出"
 
@@ -2665,15 +2665,15 @@ msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.btn:"
 msgid "Overwrite"
 msgstr "覆盖"
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different branch name."
 msgstr "单击 “取消” 以选择其他分支名称。"
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.hdl:"
 msgid "The branch '$1' already exists. Do you want to overwrite it?"
 msgstr "分支 “$1” 已经存在。您想覆盖吗？"
 
-msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.tle"
+msgctxt "dlgSgCheckoutTargetAlreadyExistsOverwrite.tle:"
 msgid "Check Out"
 msgstr "检出"
 
@@ -2681,7 +2681,7 @@ msgctxt "dlgSgCherryPickConfigurationFile.btn:"
 msgid "Cherry-Pick"
 msgstr "摘取"
 
-msgctxt "dlgSgCherryPickConfigurationFile.fur"
+msgctxt "dlgSgCherryPickConfigurationFile.fur:"
 msgid "Only changes of these files will be cherry-picked \\(without committing\\)."
 msgstr "只有这些文件的变更才会被摘取 \\(不提交\\)。"
 
@@ -2693,7 +2693,7 @@ msgctxt "dlgSgCherryPickConfigurationFile.hdl:"
 msgid "Do you want to cherry-pick changes of '$1'?"
 msgstr "你想要摘取 $1 文件的变更？"
 
-msgctxt "dlgSgCherryPickConfigurationFile.tle"
+msgctxt "dlgSgCherryPickConfigurationFile.tle:"
 msgid "Cherry-Pick"
 msgstr "摘取"
 
@@ -2705,35 +2705,35 @@ msgctxt "dlgSgCherryPickConfirmation.btn:"
 msgid "Cherry-Pick"
 msgstr "摘取"
 
-msgctxt "dlgSgCherryPickConfirmation.chk"
+msgctxt "dlgSgCherryPickConfirmation.chk:"
 msgid "Append source commit ID to commit message"
 msgstr "将源 SHA 附加到提交消息"
 
-msgctxt "dlgSgCherryPickConfirmation.fur"
+msgctxt "dlgSgCherryPickConfirmation.fur:"
 msgid "This will cherry-pick the selected commit into the Working Tree."
 msgstr "选中的提交将会被摘取到工作区中"
 
-msgctxt "dlgSgCherryPickConfirmation.hdl"
+msgctxt "dlgSgCherryPickConfirmation.hdl:"
 msgid "Do you want to cherry-pick?"
 msgstr "你想要摘取提交吗？"
 
-msgctxt "dlgSgCherryPickConfirmation.tle"
+msgctxt "dlgSgCherryPickConfirmation.tle:"
 msgid "Cherry-Pick"
 msgstr "摘取"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.chk"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.fur"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.fur:"
 msgid "You may need to resolve the conflicts before proceeding."
 msgstr "您可能需要在继续之前解决冲突。"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.hdl"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.hdl:"
 msgid "Cherry-picking failed because of conflicts."
 msgstr "由于冲突，摘取失败。"
 
-msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.tle"
+msgctxt "dlgSgCherryPickFailedBecauseOfConflicts.tle:"
 msgid "Cherry Pick"
 msgstr "摘取"
 
@@ -2741,15 +2741,15 @@ msgctxt "dlgSgCherryPickUnpushedCommits.btn:"
 msgid "Cherry-Pick"
 msgstr "摘取"
 
-msgctxt "dlgSgCherryPickUnpushedCommits.fur"
+msgctxt "dlgSgCherryPickUnpushedCommits.fur:"
 msgid "At least one of the selected commits has not been pushed yet, hence cherry-pick is only local and won't be translated to SVN \\(mergeinfo\\)."
 msgstr "存在选定的提交尚未推送，因此摘取只是本地的，不会转换为 SVN \\(合并信息\\)。"
 
-msgctxt "dlgSgCherryPickUnpushedCommits.hdl"
+msgctxt "dlgSgCherryPickUnpushedCommits.hdl:"
 msgid "Do you want to cherry-pick unpushed commits?"
 msgstr "你想要摘取未推送的提交吗？"
 
-msgctxt "dlgSgCherryPickUnpushedCommits.tle"
+msgctxt "dlgSgCherryPickUnpushedCommits.tle:"
 msgid "Cherry-Pick"
 msgstr "摘取"
 
@@ -2769,11 +2769,11 @@ msgctxt "dlgSgClean.edt:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgClean.hdl"
+msgctxt "dlgSgClean.hdl:"
 msgid "Delete unversioned files"
 msgstr "删除未跟踪的文件"
 
-msgctxt "dlgSgClean.inf"
+msgctxt "dlgSgClean.inf:"
 msgid "Select which unversioned files should be deleted."
 msgstr "选择应删除哪些未跟踪的文件。"
 
@@ -2797,7 +2797,7 @@ msgctxt "dlgSgClean.rbt:"
 msgid "Untracked"
 msgstr ""
 
-msgctxt "dlgSgClean.tle"
+msgctxt "dlgSgClean.tle:"
 msgid "Clean Working Tree"
 msgstr "清理工作区"
 
@@ -2805,27 +2805,27 @@ msgctxt "dlgSgCleanDeleteFiles.btn:"
 msgid "Delete Files"
 msgstr ""
 
-msgctxt "dlgSgCleanDeleteFiles.fur"
+msgctxt "dlgSgCleanDeleteFiles.fur:"
 msgid "Git reported following files and directories to be deleted:"
 msgstr ""
 
-msgctxt "dlgSgCleanDeleteFiles.hdl"
+msgctxt "dlgSgCleanDeleteFiles.hdl:"
 msgid "Do you want to delete these files?"
 msgstr ""
 
-msgctxt "dlgSgCleanDeleteFiles.tle"
+msgctxt "dlgSgCleanDeleteFiles.tle:"
 msgid "Clean Working Tree"
 msgstr ""
 
-msgctxt "dlgSgCleanNoFilesFound.fur"
+msgctxt "dlgSgCleanNoFilesFound.fur:"
 msgid "Your repository only seems to contain tracked files."
 msgstr ""
 
-msgctxt "dlgSgCleanNoFilesFound.hdl"
+msgctxt "dlgSgCleanNoFilesFound.hdl:"
 msgid "No files found to be deleted."
 msgstr ""
 
-msgctxt "dlgSgCleanNoFilesFound.tle"
+msgctxt "dlgSgCleanNoFilesFound.tle:"
 msgid "Clean Working Tree"
 msgstr ""
 
@@ -2858,7 +2858,7 @@ msgctxt "dlgSgClone.chk:"
 msgid "Map SVN trunk, tags and branches to Git"
 msgstr "将 SVN 主干，标签和分支映射到 Git"
 
-msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\""
+msgctxt "dlgSgClone.chk\"Skip large files \\(\\\"partial clone\\\"\\)\":"
 msgid "Skip large files \\(\"partial clone\"\\)"
 msgstr "跳过大文件 \\(“部分克隆”\\)"
 
@@ -3006,7 +3006,7 @@ msgctxt "dlgSgClone.rbt:"
 msgid "Remote repository"
 msgstr "远程仓库"
 
-msgctxt "dlgSgClone.tle"
+msgctxt "dlgSgClone.tle:"
 msgid "Clone"
 msgstr "克隆"
 
@@ -3022,15 +3022,15 @@ msgctxt "dlgSgClone.ttpPartialWarning:"
 msgid "This functionality depends on the capabilities of your server."
 msgstr ""
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.fur"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.fur:"
 msgid "Please select an empty, local directory for the new repository."
 msgstr ""
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.hdl"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.hdl:"
 msgid "The selected directory is a Git repository."
 msgstr ""
 
-msgctxt "dlgSgCloneDirectoryIsGitRepository.tle"
+msgctxt "dlgSgCloneDirectoryIsGitRepository.tle:"
 msgid "Input Validation"
 msgstr ""
 
@@ -3042,15 +3042,15 @@ msgctxt "dlgSgCloneRepositoryType.btn:"
 msgid "SVN"
 msgstr "SVN"
 
-msgctxt "dlgSgCloneRepositoryType.fur"
+msgctxt "dlgSgCloneRepositoryType.fur:"
 msgid "The specified URL protocol is ambiguous and may refer to different types of repositories."
 msgstr "指定的 URL 协议不明确，可能引用不同类型的仓库。"
 
-msgctxt "dlgSgCloneRepositoryType.hdl"
+msgctxt "dlgSgCloneRepositoryType.hdl:"
 msgid "Select the type of repository you are going to clone."
 msgstr "选择要克隆的仓库类型。"
 
-msgctxt "dlgSgCloneRepositoryType.tle"
+msgctxt "dlgSgCloneRepositoryType.tle:"
 msgid "Clone"
 msgstr "克隆"
 
@@ -3062,11 +3062,11 @@ msgctxt "dlgSgCloneSetCredentialHelper.btn:"
 msgid "Set SmartGit as Credential-Helper"
 msgstr ""
 
-msgctxt "dlgSgCloneSetCredentialHelper.fur"
+msgctxt "dlgSgCloneSetCredentialHelper.fur:"
 msgid "If selected, SmartGit will be set as `credential.helper` in the `.git\\\\/config` of newly cloned repositories that are cloned directly from a configured Hosting Provider. Executing remote Git commands \\(e.g. \\*pull\\* or \\*push\\*\\) in the terminal or a shell script will then use the credentials known to SmartGit.\\n\\nThis repository setting will only affect new clones and takes precedence over any `credential.helper` configuration in your user `~\\\\/.gitconfig`.\\n\\nFor already cloned repositories the setting \\*Use SmartGit as credential helper\\* can be changed in \\*Repository \\| Settings\\*.\\n\\n\\*When to select?\\*\\nIf you solely use SmartGit as your GUI client and you use Git from the command line, we suggest selecting this option. It will simplify the authentication process when accessing platforms like GitHub.\\n\\n\\*When not to set?\\*\\nIf you also use other GUI clients, adding this configuration may disrupt the authentication of these tools and should be avoided.\\n\\nIf you do not use Git on command line or other GUI clients, selecting this option serves no purpose and is not recommended."
 msgstr ""
 
-msgctxt "dlgSgCloneSetCredentialHelper.hdl"
+msgctxt "dlgSgCloneSetCredentialHelper.hdl:"
 msgid "Do you want to configure SmartGit as credential helper?"
 msgstr ""
 
@@ -3074,19 +3074,19 @@ msgctxt "dlgSgCloneSetCredentialHelper.mni:"
 msgid "Copy"
 msgstr ""
 
-msgctxt "dlgSgCloneSetCredentialHelper.tle"
+msgctxt "dlgSgCloneSetCredentialHelper.tle:"
 msgid "Clone"
 msgstr ""
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.fur"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.fur:"
 msgid "SmartGit now continues to fetch all other revisions in the background. You may safely start working with the repository now; only log-related operations will be affected by this intermediate state.\\n\\nOnce SmartGit has finished the background part of the clone, it will let you know in the notifications area \\(status bar\\) and you can complete the clone there."
 msgstr "SmartGit 现在继续在后台获取所有其他修订版。 您现在可以安全地开始使用仓库; 只有与记录相关的操作才会受到此中间状态的影响。\\n\\n一旦 SmartGit 完成了克隆的后台部分，它会在通知区域 \\(状态栏\\) 中通知您，您可以在那里完成克隆。"
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.hdl"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.hdl:"
 msgid "HEAD revision has been successfully cloned."
 msgstr "已成功克隆 HEAD 修订版。"
 
-msgctxt "dlgSgCloneSvnDetachedHeadSuccess.tle"
+msgctxt "dlgSgCloneSvnDetachedHeadSuccess.tle:"
 msgid "Clone"
 msgstr "克隆"
 
@@ -3150,11 +3150,11 @@ msgctxt "dlgSgCommit.err:"
 msgid "Select at least one file to commit."
 msgstr ""
 
-msgctxt "dlgSgCommit.hdl"
+msgctxt "dlgSgCommit.hdl:"
 msgid "Commit local or staged changes"
 msgstr "提交本地或暂存的变更"
 
-msgctxt "dlgSgCommit.inf"
+msgctxt "dlgSgCommit.inf:"
 msgid "Select the files you want to commit and provide a commit message."
 msgstr "选择要提交的文件并提供提交消息。"
 
@@ -3194,7 +3194,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Merge commit \\(multiple parents\\)"
 msgstr "合并提交 \\(多个父系\\)"
 
-msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\""
+msgctxt "dlgSgCommit.rbt\"Simple commit \\(one parent, \\\"squash\\\"\\)\":"
 msgid "Simple commit \\(one parent, \"squash\"\\)"
 msgstr "简单提交 \\(1个父系, “压缩”\\)"
 
@@ -3202,7 +3202,7 @@ msgctxt "dlgSgCommit.rbt:"
 msgid "Staged Changes"
 msgstr "暂存的修改"
 
-msgctxt "dlgSgCommit.tle"
+msgctxt "dlgSgCommit.tle:"
 msgid "Commit"
 msgstr "提交"
 
@@ -3218,27 +3218,27 @@ msgctxt "dlgSgCommitAmendAlreadyPushedCommit.btn:"
 msgid "Amend"
 msgstr "修改"
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.fur"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.fur:"
 msgid "If you amend a pushed commit, you will need to force-push it later. This might overwrite other users' changes."
 msgstr "如果修改已推送的提交，你需要稍后强制推送它。这可能会覆盖其他用户的变更。"
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.hdl"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.hdl:"
 msgid "Do you want to amend an already pushed commit?"
 msgstr "你确定要修改已推送的提交吗？"
 
-msgctxt "dlgSgCommitAmendAlreadyPushedCommit.tle"
+msgctxt "dlgSgCommitAmendAlreadyPushedCommit.tle:"
 msgid "Commit"
 msgstr "提交"
 
-msgctxt "dlgSgCommitCantAmend.fur"
+msgctxt "dlgSgCommitCantAmend.fur:"
 msgid "Can't modify an already pushed commit. If you know what you are doing and want to enable it, select the option 'Allow modifying pushed commits' in the preferences."
 msgstr "无法修订已推送的提交. 如果你了解风险并想要启用, 请在设置中选择 '允许修改推送的提交'."
 
-msgctxt "dlgSgCommitCantAmend.hdl"
+msgctxt "dlgSgCommitCantAmend.hdl:"
 msgid "Can't amend commit."
 msgstr "无法修订提交."
 
-msgctxt "dlgSgCommitCantAmend.tle"
+msgctxt "dlgSgCommitCantAmend.tle:"
 msgid "Commit"
 msgstr "提交"
 
@@ -3250,15 +3250,15 @@ msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.btn:"
 msgid "Create Commit"
 msgstr "创建提交"
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.fur"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.fur:"
 msgid "The repository is in 'rebasing' state. Instead of creating an additional commit as part of your rebased commits, you will usually just want continue the rebase."
 msgstr "仓库处于 “变基” 状态。 您通常只想继续使用变基，而不是在重新提交的提交中创建额外的提交。"
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.hdl"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.hdl:"
 msgid "Do you want to continue the rebase or create an additional commit?"
 msgstr "您想继续使用变基还是创建额外的提交？"
 
-msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.tle"
+msgctxt "dlgSgCommitContinueRebaseOrCreateAdditionalCommit.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -3266,15 +3266,15 @@ msgctxt "dlgSgCommitDirectlyTo.btn:"
 msgid "Commit Anyway"
 msgstr "强制提交"
 
-msgctxt "dlgSgCommitDirectlyTo.fur"
+msgctxt "dlgSgCommitDirectlyTo.fur:"
 msgid "You have Git-Flow configured and committing to the Git-Flow master branch should not happen directly but only with the help of the Git-Flow commands and merging.\\n\\nIf in doubt, please contact your administrator."
 msgstr "你配置了 Git-Flow, 不应该直接提交到 Git-Flow master 分支, 只能通过 Git-Flow 命令和合并操作.\\n\\n如有疑问, 请联系仓库管理员."
 
-msgctxt "dlgSgCommitDirectlyTo.hdl"
+msgctxt "dlgSgCommitDirectlyTo.hdl:"
 msgid "Do you want to commit directly to 'master'?"
 msgstr "确定要直接提交到 'master'?"
 
-msgctxt "dlgSgCommitDirectlyTo.tle"
+msgctxt "dlgSgCommitDirectlyTo.tle:"
 msgid "Commit"
 msgstr "提交"
 
@@ -3294,27 +3294,27 @@ msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.chk:"
 msgid "Include untracked files"
 msgstr ""
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.fur"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.fur:"
 msgid "No file is staged yet. To commit all \\(visible\\) working tree changes, click Commit All. To stage individual changes, click Cancel."
 msgstr "至今没有文件被暂存。 要暂存个别变更，请单击 “取消”。 否则，所有工作区变更将被暂存和提交。"
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.hdl"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.hdl:"
 msgid "Do you want to commit all \\(visible\\) working tree changes?"
 msgstr "您想要提交所有工作区的变更吗？"
 
-msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.tle"
+msgctxt "dlgSgCommitIndexAllWorkingTreeChanges.tle:"
 msgid "Commit"
 msgstr "提交"
 
-msgctxt "dlgSgCommitIndexNoFilesFound.fur"
+msgctxt "dlgSgCommitIndexNoFilesFound.fur:"
 msgid "There is nothing to commit."
 msgstr "找不到暂存文件或本地变更的文件。"
 
-msgctxt "dlgSgCommitIndexNoFilesFound.hdl"
+msgctxt "dlgSgCommitIndexNoFilesFound.hdl:"
 msgid "There is nothing to commit."
 msgstr "没有需要提交的。"
 
-msgctxt "dlgSgCommitIndexNoFilesFound.tle"
+msgctxt "dlgSgCommitIndexNoFilesFound.tle:"
 msgid "Commit"
 msgstr "提交"
 
@@ -3326,27 +3326,27 @@ msgctxt "dlgSgCommitMessageContainsComments.btn:"
 msgid "Strip Comments"
 msgstr ""
 
-msgctxt "dlgSgCommitMessageContainsComments.fur"
+msgctxt "dlgSgCommitMessageContainsComments.fur:"
 msgid "The commit message contains lines starting with # which Git would treat as comment \\(and thus strip from the message\\).\\n\\nFor advanced comment-handling you may consider to use Git's config option 'core.commentChar'.\\n\\nIf you always want to keep or strip comment lines, you can configure this in the Preferences."
 msgstr ""
 
-msgctxt "dlgSgCommitMessageContainsComments.hdl"
+msgctxt "dlgSgCommitMessageContainsComments.hdl:"
 msgid "Should comment lines be committed as-is?"
 msgstr ""
 
-msgctxt "dlgSgCommitMessageContainsComments.tle"
+msgctxt "dlgSgCommitMessageContainsComments.tle:"
 msgid "Commit"
 msgstr ""
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.fur"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.fur:"
 msgid "Neither staged files nor locally changed files were found."
 msgstr "找不到暂存或本地变更的文件。"
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.hdl"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.hdl:"
 msgid "There is nothing to commit."
 msgstr "没有东西需要提交"
 
-msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.tle"
+msgctxt "dlgSgCommitNoFilesFoundNotAllowEmpty.tle:"
 msgid "Commit"
 msgstr "提交"
 
@@ -3362,7 +3362,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.chk:"
 msgid "Add 'fixup!' prefix for easier automatic squashing using Interactive Rebase"
 msgstr "创建 “修复！” 前缀,以便使用交互式变基轻松自动压缩"
 
-msgctxt "dlgSgCommitSelectMessageFromLog.hdl"
+msgctxt "dlgSgCommitSelectMessageFromLog.hdl:"
 msgid "Select a commit"
 msgstr "选择一个提交"
 
@@ -3370,7 +3370,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.hnt:"
 msgid "No repository selected."
 msgstr ""
 
-msgctxt "dlgSgCommitSelectMessageFromLog.inf"
+msgctxt "dlgSgCommitSelectMessageFromLog.inf:"
 msgid "Choose the commit whose message should be used."
 msgstr "选择应使用其消息的提交。"
 
@@ -3430,7 +3430,7 @@ msgctxt "dlgSgCommitSelectMessageFromLog.tbt:"
 msgid "Interpret the search pattern as regular expression."
 msgstr ""
 
-msgctxt "dlgSgCommitSelectMessageFromLog.tle"
+msgctxt "dlgSgCommitSelectMessageFromLog.tle:"
 msgid "Select Commit Message"
 msgstr "选择提交消息"
 
@@ -3442,15 +3442,15 @@ msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.btn:"
 msgid "Commit File"
 msgstr "提交文件"
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.fur"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.fur:"
 msgid "You either can commit the single selected file or all \\(visible\\) changed files."
 msgstr "您可以提交单个选定文件，也可以提交所有已变更的文件。"
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.hdl"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.hdl:"
 msgid "What do you want to commit?"
 msgstr "您想提交什么？"
 
-msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.tle"
+msgctxt "dlgSgCommitSingleOrAllWorkingTreeChanges.tle:"
 msgid "Commit"
 msgstr "提交"
 
@@ -3458,15 +3458,15 @@ msgctxt "dlgSgCommitToDetachedHead.btn:"
 msgid "Commit Anyway"
 msgstr "总是提交"
 
-msgctxt "dlgSgCommitToDetachedHead.fur"
+msgctxt "dlgSgCommitToDetachedHead.fur:"
 msgid "The repository HEAD currently does not point to a branch, but directly refers to a commit \\(SHA\\). When committing, the newly created commit will only be reachable by its SHA and hence may get lost easily.\\n\\nInstead of committing now, you should first create a branch for your current HEAD and commit afterwards."
 msgstr "仓库 HEAD 当前不指向分支，而是直接引用提交 \\(SHA\\)。提交时，新创建的提交只能通过其 SHA 访问，因此可能很容易丢失。\\n\\n现在，您应该首先为当前 HEAD 创建新分支，然后再提交。"
 
-msgctxt "dlgSgCommitToDetachedHead.hdl"
+msgctxt "dlgSgCommitToDetachedHead.hdl:"
 msgid "Do you want to commit to a detached HEAD?"
 msgstr "你想提交独立的 HEAD 吗？"
 
-msgctxt "dlgSgCommitToDetachedHead.tle"
+msgctxt "dlgSgCommitToDetachedHead.tle:"
 msgid "Commit"
 msgstr "提交"
 
@@ -3478,23 +3478,23 @@ msgctxt "dlgSgCompareTwoFiles.btn:"
 msgid "Compare with Repository"
 msgstr "与仓库比较"
 
-msgctxt "dlgSgCompareTwoFiles.fur"
+msgctxt "dlgSgCompareTwoFiles.fur:"
 msgid "The files can be compared to their repository content or to each other."
 msgstr "这些文件可以与它们的仓库内容或相互比较。"
 
-msgctxt "dlgSgCompareTwoFiles.hdl"
+msgctxt "dlgSgCompareTwoFiles.hdl:"
 msgid "Should the selected two files be compared with each other?"
 msgstr "所选的两个文件是否应相互比较？"
 
-msgctxt "dlgSgCompareTwoFiles.tle"
+msgctxt "dlgSgCompareTwoFiles.tle:"
 msgid "Compare"
 msgstr "比较"
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.fur"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.fur:"
 msgid "To prevent overwriting intentional mixed line-endings, editing and saving is disabled."
 msgstr ""
 
-msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl"
+msgctxt "dlgSgCompareTwoFilesFrameMixedLineEndingsRight.hdl:"
 msgid "The right file is not editable because of mixed line-endings."
 msgstr ""
 
@@ -3502,15 +3502,15 @@ msgctxt "dlgSgConflictResolverExternalStarted.btn:"
 msgid "Mark Resolved"
 msgstr "标记已解决"
 
-msgctxt "dlgSgConflictResolverExternalStarted.fur"
+msgctxt "dlgSgConflictResolverExternalStarted.fur:"
 msgid "The external conflict solver has been started. After you have resolved the conflict, you may now mark the file as resolved."
 msgstr "外部冲突解决工具已启动. 解决完冲突, 就可以将文件标记为已解决了."
 
-msgctxt "dlgSgConflictResolverExternalStarted.hdl"
+msgctxt "dlgSgConflictResolverExternalStarted.hdl:"
 msgid "Do you want to mark the file as resolved?"
 msgstr "是否标记为已解决?"
 
-msgctxt "dlgSgConflictResolverExternalStarted.tle"
+msgctxt "dlgSgConflictResolverExternalStarted.tle:"
 msgid "External Conflict Solver"
 msgstr "外部冲突解决工具"
 
@@ -3522,15 +3522,15 @@ msgctxt "dlgSgConflictSolverMarkResolved.btn:"
 msgid "Mark Resolved"
 msgstr "标记已解决"
 
-msgctxt "dlgSgConflictSolverMarkResolved.fur"
+msgctxt "dlgSgConflictSolverMarkResolved.fur:"
 msgid "To complete a conflict resolution, the file needs to be marked as resolved \\(git stage\\). Until marked as resolved, the file remains in conflicted state and you can try other conflict resolutions."
 msgstr "要完成冲突解决，需要将文件标记为已解决 \\(Git 阶段\\)。在标记为已解决之前，文件将保持冲突状态，您可以尝试其他冲突解决方案。"
 
-msgctxt "dlgSgConflictSolverMarkResolved.hdl"
+msgctxt "dlgSgConflictSolverMarkResolved.hdl:"
 msgid "Do you want to mark the file as resolved?"
 msgstr "您是否要将该文件标记为已解决？"
 
-msgctxt "dlgSgConflictSolverMarkResolved.tle"
+msgctxt "dlgSgConflictSolverMarkResolved.tle:"
 msgid "Mark Resolved"
 msgstr "标记已解决"
 
@@ -3542,15 +3542,15 @@ msgctxt "dlgSgConflictSolverStageForCommit.btn:"
 msgid "Stage"
 msgstr "暂存"
 
-msgctxt "dlgSgConflictSolverStageForCommit.fur"
+msgctxt "dlgSgConflictSolverStageForCommit.fur:"
 msgid "Staging is necessary to resolve the file's conflict status."
 msgstr "暂存是解决文件冲突状态所必需的。"
 
-msgctxt "dlgSgConflictSolverStageForCommit.hdl"
+msgctxt "dlgSgConflictSolverStageForCommit.hdl:"
 msgid "Do you want to stage the file for commit now?"
 msgstr "您想现在提交暂存文件吗？"
 
-msgctxt "dlgSgConflictSolverStageForCommit.tle"
+msgctxt "dlgSgConflictSolverStageForCommit.tle:"
 msgid "Stage for Commit"
 msgstr "提交暂存"
 
@@ -3614,7 +3614,7 @@ msgctxt "dlgSgCustomizeProjectUi.tab:"
 msgid "Toolbar"
 msgstr "工具栏"
 
-msgctxt "dlgSgCustomizeProjectUi.tle"
+msgctxt "dlgSgCustomizeProjectUi.tle:"
 msgid "Customize"
 msgstr "自定义"
 
@@ -3626,23 +3626,23 @@ msgctxt "dlgSgDeleteDirTrash.btn:"
 msgid "Move to Trash"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.fur"
+msgctxt "dlgSgDeleteDirTrash.fur:"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.hdl"
+msgctxt "dlgSgDeleteDirTrash.hdl:"
 msgid "Do you want to delete '$1' recursively?"
 msgstr ""
 
-msgctxt "dlgSgDeleteDirTrash.tle"
+msgctxt "dlgSgDeleteDirTrash.tle:"
 msgid "Delete"
 msgstr ""
 
-msgctxt "dlgSgDeleteFileTrash.hdl"
+msgctxt "dlgSgDeleteFileTrash.hdl:"
 msgid "Do you want to delete '$1'?"
 msgstr "确定要删除 “$1” 吗？"
 
-msgctxt "dlgSgDeleteFilesTrash.hdl"
+msgctxt "dlgSgDeleteFilesTrash.hdl:"
 msgid "Do you want to delete the $1 selected files?"
 msgstr "您确定要删除所选的 $1 文件吗？"
 
@@ -3666,11 +3666,11 @@ msgctxt "dlgSgDiscard.edt:"
 msgid "Revert to"
 msgstr "还原"
 
-msgctxt "dlgSgDiscard.hdl"
+msgctxt "dlgSgDiscard.hdl:"
 msgid "Discard local or staged changes"
 msgstr "丢弃本地或暂存的变更"
 
-msgctxt "dlgSgDiscard.inf"
+msgctxt "dlgSgDiscard.inf:"
 msgid "Select the files for which changes should be discarded and whether to set them back to Index or HEAD state."
 msgstr "选择应丢弃变更的文件以及是否将其设置回索引或 HEAD 状态。"
 
@@ -3710,39 +3710,39 @@ msgctxt "dlgSgDiscard.rbt:"
 msgid "Index"
 msgstr "索引"
 
-msgctxt "dlgSgDiscard.tle"
+msgctxt "dlgSgDiscard.tle:"
 msgid "Discard"
 msgstr "丢弃"
 
-msgctxt "dlgSgDiscardNoFilesFound.fur"
+msgctxt "dlgSgDiscardNoFilesFound.fur:"
 msgid "Neither staged files nor locally changed files were found."
 msgstr "找不到暂存文件或本地变更的文件。"
 
-msgctxt "dlgSgDiscardNoFilesFound.hdl"
+msgctxt "dlgSgDiscardNoFilesFound.hdl:"
 msgid "There is nothing to discard."
 msgstr "没有什么可以丢弃的。"
 
-msgctxt "dlgSgDiscardNoFilesFound.tle"
+msgctxt "dlgSgDiscardNoFilesFound.tle:"
 msgid "Discard"
 msgstr "丢弃"
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.fur"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.fur:"
 msgid "You have selected to discard only the Index changes of one or more files. However, at least one of the files is also modified in the working tree. It is not possible to discard only Index changes in this case.\\n\\nIf you actually want to discard the working tree changes, select the file in the working tree table."
 msgstr ""
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.hdl"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.hdl:"
 msgid "Discarding Index changes is not possible."
 msgstr ""
 
-msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle"
+msgctxt "dlgSgDiscardNotApplicableForIndexFiles.tle:"
 msgid "Discard"
 msgstr ""
 
-msgctxt "dlgSgDiscardRevertToHead.hdl"
+msgctxt "dlgSgDiscardRevertToHead.hdl:"
 msgid "Do you want to reset $1 files back to their HEAD state?"
 msgstr "您确定要将 $1 文件重置为 HEAD 状态吗？"
 
-msgctxt "dlgSgDiscardRevertToIndex.hdl"
+msgctxt "dlgSgDiscardRevertToIndex.hdl:"
 msgid "Do you want to reset $1 files back to their Index state?"
 msgstr "您确定要将 $1 文件重置为其索引状态吗？"
 
@@ -3750,15 +3750,15 @@ msgctxt "dlgSgDiscardRevertTo(Head|Index).btn:"
 msgid "Discard"
 msgstr "丢弃"
 
-msgctxt "dlgSgDiscardRevertTo(Head|Index).fur"
+msgctxt "dlgSgDiscardRevertTo(Head|Index).fur:"
 msgid "The content might be hard to restore!"
 msgstr "内容可能很难还原！"
 
-msgctxt "dlgSgDiscardRevertTo(Head|Index).tle"
+msgctxt "dlgSgDiscardRevertTo(Head|Index).tle:"
 msgid "Discard"
 msgstr "丢弃"
 
-msgctxt "dlgSgErrorUtilsClientException.fur"
+msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "Server returned HTTP response code: 400 for URL: https://gitlab.com/oauth/token"
 msgstr ""
 
@@ -3782,11 +3782,11 @@ msgctxt "dlgSgErrorUtilsClientException.fur:"
 msgid "svn: $1"
 msgstr "svn: $1"
 
-msgctxt "dlgSgErrorUtilsClientException.hdl"
+msgctxt "dlgSgErrorUtilsClientException.hdl:"
 msgid "Executing a command has failed."
 msgstr "执行命令失败。"
 
-msgctxt "dlgSgErrorUtilsClientException.tle"
+msgctxt "dlgSgErrorUtilsClientException.tle:"
 msgid "Command Failed"
 msgstr "命令失败"
 
@@ -3794,19 +3794,19 @@ msgctxt "dlgSgExitConfirmation.btn:"
 msgid "Exit Now"
 msgstr "立即退出"
 
-msgctxt "dlgSgExitConfirmation.chk"
+msgctxt "dlgSgExitConfirmation.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgExitConfirmation.fur"
+msgctxt "dlgSgExitConfirmation.fur:"
 msgid "By closing the last window you will exit SmartGit."
 msgstr "关闭所有窗口后退出 SmartGit。"
 
-msgctxt "dlgSgExitConfirmation.hdl"
+msgctxt "dlgSgExitConfirmation.hdl:"
 msgid "Do you want to exit SmartGit now?"
 msgstr "你想立即退出 SmartGit 吗？"
 
-msgctxt "dlgSgExitConfirmation.tle"
+msgctxt "dlgSgExitConfirmation.tle:"
 msgid "Exit"
 msgstr "退出"
 
@@ -3814,19 +3814,19 @@ msgctxt "dlgSgFileCompareConflictSolverNoTextFile.btn:"
 msgid "Force Opening"
 msgstr ""
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.hdl:"
 msgid "Could not open Conflict Solver for '$1', because it seems to be no text file."
 msgstr ""
 
-msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle"
+msgctxt "dlgSgFileCompareConflictSolverNoTextFile.tle:"
 msgid "Conflict Solver"
 msgstr ""
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.hdl"
+msgctxt "dlgSgFileCompareInvokerFailedIO.hdl:"
 msgid "'$1' could not be invoked."
 msgstr ""
 
-msgctxt "dlgSgFileCompareInvokerFailedIO.tle"
+msgctxt "dlgSgFileCompareInvokerFailedIO.tle:"
 msgid "Open"
 msgstr ""
 
@@ -3834,19 +3834,19 @@ msgctxt "dlgSgFileCompareNoChanges.btn:"
 msgid "Open"
 msgstr "打开"
 
-msgctxt "dlgSgFileCompareNoChanges.chk"
+msgctxt "dlgSgFileCompareNoChanges.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgFileCompareNoChanges.fur"
+msgctxt "dlgSgFileCompareNoChanges.fur:"
 msgid "Both file contents are byte-wise equal.\\nTo see the file contents anyway, click 'Open'."
 msgstr "两个文件内容按字节顺序相等。\\n要查看文件内容，请单击 “打开” 。"
 
-msgctxt "dlgSgFileCompareNoChanges.hdl"
+msgctxt "dlgSgFileCompareNoChanges.hdl:"
 msgid "Open the file compare though no changes will be shown?"
 msgstr "打开文件将显示比较尽管没有变化？"
 
-msgctxt "dlgSgFileCompareNoChanges.tle"
+msgctxt "dlgSgFileCompareNoChanges.tle:"
 msgid "File Compare"
 msgstr "文件比较"
 
@@ -3854,7 +3854,7 @@ msgctxt "dlgSgFindObject.edt:"
 msgid "Repository Path, Commit ID or Ref"
 msgstr "仓库路径、提交 ID 或引用"
 
-msgctxt "dlgSgFindObject.tle"
+msgctxt "dlgSgFindObject.tle:"
 msgid "Find Object"
 msgstr "查找对象"
 
@@ -3862,15 +3862,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.btn:"
 msgid "Fast-Forward"
 msgstr "快进"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.fur:"
 msgid "The local branch '$1' is behind its tracked branch '$2'. You may fast-forward now or do it manually later, e.g. by checking out the branch '$3'."
 msgstr "本地分支 “$1” 位于其跟踪分支 “$2” 的后面。您可以现在快进，也可以稍后手动前进，例如签出分支 $3 。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.hdl:"
 msgid "Should branch '$1' be fast-forwarded to '$2'?"
 msgstr "分支 “$1” 是否应快速转发到 “$2”？"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerFastForward.tle:"
 msgid "Start Feature"
 msgstr "开始 feature"
 
@@ -3878,15 +3878,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.btn:"
 msgid "Replace"
 msgstr "替换"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.fur:"
 msgid "The local branch '$1' seems to contain more recent but rewritten commits of remote branch '$2'.\\n\\nIf you are not sure whether the local branch is actually more recent than the remote branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr "本地分支 “$1” 似乎包含远程分支 “$2” 的更新但已重写的提交。\\n\\n如果您不确定本地分支是否实际比远程分支更新，则最好取消此操作并更详细地审查本地和远程变更。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.hdl:"
 msgid "Should branch '$1' replace remote branch '$2'?"
 msgstr "分支 “$1” 是否应替换远程分支 “$2”？"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerReplaceRemote.tle:"
 msgid "Finish Feature"
 msgstr "完成 feature"
 
@@ -3894,15 +3894,15 @@ msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.btn:"
 msgid "Reset"
 msgstr "重置"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.fur:"
 msgid "The remote branch '$1' seems to contain more recent but rewritten commits of local branch '$2'.\\n\\nIf you are not sure whether the remote branch is actually more recent than the local branch, you should better cancel this operation and investigate local and remote changes in more detail."
 msgstr "远程分支 '$1' 似乎包含更近期但被重写的本地分支 '$2' 的提交。\\r\\n如果您不确定远程分支是否实际上比本地分支更新，您应该取消此操作并进行审查本地和远程变更更详细。"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.hdl:"
 msgid "Should branch '$1' be reset to remote branch '$2'?"
 msgstr "分支 '$1' 是否应重置为远程分支 '$2' ？"
 
-msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.tle"
+msgctxt "dlgSgFlowBranchDivergedHandlerResetToRemote.tle:"
 msgid "Finish Feature"
 msgstr "完成 Feature"
 
@@ -3954,11 +3954,11 @@ msgctxt "dlgSgFlowConfigure.edt:"
 msgid "Version Tags"
 msgstr "版本标签"
 
-msgctxt "dlgSgFlowConfigure.hdl"
+msgctxt "dlgSgFlowConfigure.hdl:"
 msgid "Configure the branch naming scheme"
 msgstr "配置分支命名方案"
 
-msgctxt "dlgSgFlowConfigure.inf"
+msgctxt "dlgSgFlowConfigure.inf:"
 msgid "Configure how your feature, release and hotfix branches should be named."
 msgstr "配置应如何命名 feature、release 和 hotfix 分支。"
 
@@ -3974,7 +3974,7 @@ msgctxt "dlgSgFlowConfigure.rbt:"
 msgid "Light \\(just feature branches\\)"
 msgstr "轻量 \\(只有 feature 分支\\)"
 
-msgctxt "dlgSgFlowConfigure.tle"
+msgctxt "dlgSgFlowConfigure.tle:"
 msgid "Configure Git-Flow"
 msgstr "配置 Git 工作流"
 
@@ -3986,15 +3986,15 @@ msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.btn:"
 msgid "Switch-Off Git-Flow"
 msgstr "关闭 Git 工作流"
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.fur"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.fur:"
 msgid "Git-Flow is already configured for this repository. You may change the Git-Flow configuration or switch-off the Git-Flow features. In both cases, the file ~/.git/config will be modified accordingly."
 msgstr "已经为此仓库配置了 Git 工作流。您可以更改 Git 工作流配置或关闭 Git 工作流功能。在这两种情况下，文件 ~/.git/config 都将被相应地修改。"
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.hdl"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.hdl:"
 msgid "Do you want to change or switch-off the Git-Flow configuration?"
 msgstr "您想更改或关闭 Git 工作流配置吗？"
 
-msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.tle"
+msgctxt "dlgSgFlowConfigureChangeOrSwitchOff.tle:"
 msgid "Configure Git-Flow"
 msgstr "配置 Git 工作流"
 
@@ -4022,7 +4022,7 @@ msgctxt "dlgSgFlowFeatureFinish.edt:"
 msgid "Commit Message"
 msgstr "提交消息"
 
-msgctxt "dlgSgFlowFeatureFinish.hdl"
+msgctxt "dlgSgFlowFeatureFinish.hdl:"
 msgid "Finish current feature"
 msgstr "完成当前 feature"
 
@@ -4054,7 +4054,7 @@ msgctxt "dlgSgFlowFeatureFinish.rbt:"
 msgid "Rebase onto '$1'"
 msgstr "变基至 “$1”"
 
-msgctxt "dlgSgFlowFeatureFinish.tle"
+msgctxt "dlgSgFlowFeatureFinish.tle:"
 msgid "Finish Feature"
 msgstr "完成 Feature"
 
@@ -4078,11 +4078,11 @@ msgctxt "dlgSgFlowFeatureStart.err:"
 msgid "Invalid feature name: The name must not end with a slash or dot."
 msgstr "无效的 feature 名称：名称不能以斜线或点结尾。"
 
-msgctxt "dlgSgFlowFeatureStart.hdl"
+msgctxt "dlgSgFlowFeatureStart.hdl:"
 msgid "Start a new feature"
 msgstr "开始新 feature"
 
-msgctxt "dlgSgFlowFeatureStart.inf"
+msgctxt "dlgSgFlowFeatureStart.inf:"
 msgid "Enter the name of the new feature branch. This operation will fork a new branch from the '$1' branch."
 msgstr "输入新 feature 分支的名称。此操作将从 $1 分支派生出新的分支。"
 
@@ -4090,7 +4090,7 @@ msgctxt "dlgSgFlowFeatureStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "结果分支：$1"
 
-msgctxt "dlgSgFlowFeatureStart.tle"
+msgctxt "dlgSgFlowFeatureStart.tle:"
 msgid "Start Feature"
 msgstr "开始 Feature"
 
@@ -4158,7 +4158,7 @@ msgctxt "dlgSgFlowHotfixFinish.inf:"
 msgid "Choose how to finish the hotfix branch '$1'."
 msgstr "选择如何完成 hotfix 分支 “$1”。"
 
-msgctxt "dlgSgFlowHotfixFinish.tle"
+msgctxt "dlgSgFlowHotfixFinish.tle:"
 msgid "Finish Hotfix"
 msgstr "完成 Hotfix"
 
@@ -4182,11 +4182,11 @@ msgctxt "dlgSgFlowHotfixStart.edt:"
 msgid "Hotfix Name"
 msgstr "修补程序名称"
 
-msgctxt "dlgSgFlowHotfixStart.hdl"
+msgctxt "dlgSgFlowHotfixStart.hdl:"
 msgid "Start a new hotfix"
 msgstr "启动新的修补程序"
 
-msgctxt "dlgSgFlowHotfixStart.inf"
+msgctxt "dlgSgFlowHotfixStart.inf:"
 msgid "Enter the name of the new hotfix branch. This operation will fork a new branch from the '$1' branch."
 msgstr "输入新修补程序分支的名称。 此操作将从 '$1' 分支中分叉出新分支。"
 
@@ -4194,7 +4194,7 @@ msgctxt "dlgSgFlowHotfixStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "结果分支：$1"
 
-msgctxt "dlgSgFlowHotfixStart.tle"
+msgctxt "dlgSgFlowHotfixStart.tle:"
 msgid "Start Hotfix"
 msgstr "启动修补程序"
 
@@ -4206,7 +4206,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.chk:"
 msgid "Fetch latest '$1' commits from remote repository"
 msgstr "从远程仓库获取最新的 “$1” 提交"
 
-msgctxt "dlgSgFlowIntegrateDevelop.hdl"
+msgctxt "dlgSgFlowIntegrateDevelop.hdl:"
 msgid "Integrate commits from '$1'"
 msgstr "整合来自 “$1” 的提交"
 
@@ -4230,7 +4230,7 @@ msgctxt "dlgSgFlowIntegrateDevelop.rbt:"
 msgid "Rebase current feature onto '$1'"
 msgstr "将当前 feature 变基至 “$1”"
 
-msgctxt "dlgSgFlowIntegrateDevelop.tle"
+msgctxt "dlgSgFlowIntegrateDevelop.tle:"
 msgid "Integrate Develop"
 msgstr "整合开发"
 
@@ -4290,7 +4290,7 @@ msgctxt "dlgSgFlowReleaseFinish.inf:"
 msgid "Choose how to finish the release branch '$1'."
 msgstr "选择如何完成 release 分支 “$1”。"
 
-msgctxt "dlgSgFlowReleaseFinish.tle"
+msgctxt "dlgSgFlowReleaseFinish.tle:"
 msgid "Finish Release"
 msgstr "完成 release"
 
@@ -4314,11 +4314,11 @@ msgctxt "dlgSgFlowReleaseStart.edt:"
 msgid "Release Name"
 msgstr "发布分支名称"
 
-msgctxt "dlgSgFlowReleaseStart.hdl"
+msgctxt "dlgSgFlowReleaseStart.hdl:"
 msgid "Start a new release"
 msgstr "开始新版本"
 
-msgctxt "dlgSgFlowReleaseStart.inf"
+msgctxt "dlgSgFlowReleaseStart.inf:"
 msgid "Enter the name of the new release branch. This operation will fork a new branch from the '$1' branch."
 msgstr "输入新发布分支的名称。 此操作将从 '$1' 分支中分叉一个新分支。"
 
@@ -4326,7 +4326,7 @@ msgctxt "dlgSgFlowReleaseStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "结果分支：$1"
 
-msgctxt "dlgSgFlowReleaseStart.tle"
+msgctxt "dlgSgFlowReleaseStart.tle:"
 msgid "Start Release"
 msgstr "开始发布"
 
@@ -4350,11 +4350,11 @@ msgctxt "dlgSgFlowSupportStart.edt:"
 msgid "Support Name"
 msgstr "支持名称"
 
-msgctxt "dlgSgFlowSupportStart.hdl"
+msgctxt "dlgSgFlowSupportStart.hdl:"
 msgid "Start a new support"
 msgstr "Start a new support"
 
-msgctxt "dlgSgFlowSupportStart.inf"
+msgctxt "dlgSgFlowSupportStart.inf:"
 msgid "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 msgstr "Enter the name of the new support branch. This operation will fork a new branch from the '$1' branch."
 
@@ -4362,7 +4362,7 @@ msgctxt "dlgSgFlowSupportStart.lbl:"
 msgid "Resulting Branch: $1"
 msgstr "正在生成分支: $1"
 
-msgctxt "dlgSgFlowSupportStart.tle"
+msgctxt "dlgSgFlowSupportStart.tle:"
 msgid "Start Support"
 msgstr "开始支持服务"
 
@@ -4382,15 +4382,15 @@ msgctxt "dlgSgGarbageCollector.chk:"
 msgid "Optimize repository more aggressively \\(may take a while\\)"
 msgstr "更积极地优化仓库 \\(可能需要点时间\\)"
 
-msgctxt "dlgSgGarbageCollector.hdl"
+msgctxt "dlgSgGarbageCollector.hdl:"
 msgid "Run Garbage Collector"
 msgstr "运行垃圾回收"
 
-msgctxt "dlgSgGarbageCollector.inf"
+msgctxt "dlgSgGarbageCollector.inf:"
 msgid "Running the Git garbage collector will prune unreachable objects and optimize the local repository in order to reduce disk space and increase performance."
 msgstr "运行 Git 垃圾回收器将删除不可访问的对象并优化本地仓库，以减少磁盘空间并提高性能。"
 
-msgctxt "dlgSgGarbageCollector.tle"
+msgctxt "dlgSgGarbageCollector.tle:"
 msgid "Run Garbage Collector"
 msgstr "运行垃圾回收"
 
@@ -4398,15 +4398,15 @@ msgctxt "dlgSgGarbageCollectorDeleteAllStashes.btn:"
 msgid "Delete Stashes"
 msgstr "删除贮藏"
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.fur"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.fur:"
 msgid "Expiring the reflog now will also delete all stashes."
 msgstr "立即失效 reflog 并删除所有的贮藏."
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.hdl"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.hdl:"
 msgid "Do you want to also delete all stashes?"
 msgstr "确定要删除所有贮藏吗?"
 
-msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle"
+msgctxt "dlgSgGarbageCollectorDeleteAllStashes.tle:"
 msgid "Run Garbage Collector"
 msgstr "运行垃圾回收"
 
@@ -4430,11 +4430,11 @@ msgctxt "dlgSgGitHubGenerateToken.edt:"
 msgid "Password"
 msgstr "密码"
 
-msgctxt "dlgSgGitHubGenerateToken.hdl"
+msgctxt "dlgSgGitHubGenerateToken.hdl:"
 msgid "Generate a new API token for GitHub"
 msgstr "为 GitHub 生成新的 API 令牌"
 
-msgctxt "dlgSgGitHubGenerateToken.inf"
+msgctxt "dlgSgGitHubGenerateToken.inf:"
 msgid "Authenticate at GitHub and grant access to SmartGit."
 msgstr "使用 OAuth 或提供凭据在 GitHub 进行身份验证。"
 
@@ -4450,7 +4450,7 @@ msgctxt "dlgSgGitHubGenerateToken.rbt:"
 msgid "Authenticate with your GitHub account and password"
 msgstr "使用您的 GitHub 账户和密码进行身份验证"
 
-msgctxt "dlgSgGitHubGenerateToken.tle"
+msgctxt "dlgSgGitHubGenerateToken.tle:"
 msgid "Generate API Token"
 msgstr "生成 API 令牌"
 
@@ -4470,15 +4470,15 @@ msgctxt "dlgSgGitHubPullRequestCreate.edt:"
 msgid "Title and Description"
 msgstr "标题和描述"
 
-msgctxt "dlgSgGitHubPullRequestCreate.hdl"
+msgctxt "dlgSgGitHubPullRequestCreate.hdl:"
 msgid "Create a Pull Request"
 msgstr "创建拉取请求"
 
-msgctxt "dlgSgGitHubPullRequestCreate.inf"
+msgctxt "dlgSgGitHubPullRequestCreate.inf:"
 msgid "Send pull request to another repository or branch."
 msgstr "将拉取请求发送到其他仓库或分支。"
 
-msgctxt "dlgSgGitHubPullRequestCreate.tle"
+msgctxt "dlgSgGitHubPullRequestCreate.tle:"
 msgid "Create Pull Request"
 msgstr "创建拉取请求"
 
@@ -4494,11 +4494,11 @@ msgctxt "dlgSgGitHubPullRequestMerge.edt:"
 msgid "Commit Message"
 msgstr "提交消息"
 
-msgctxt "dlgSgGitHubPullRequestMerge.hdl"
+msgctxt "dlgSgGitHubPullRequestMerge.hdl:"
 msgid "Merge a Pull Request"
 msgstr "合并请求"
 
-msgctxt "dlgSgGitHubPullRequestMerge.inf"
+msgctxt "dlgSgGitHubPullRequestMerge.inf:"
 msgid "Choose how to merge the selected Pull Request."
 msgstr "选择如何合并选定的请求。"
 
@@ -4526,7 +4526,7 @@ msgctxt "dlgSgGitHubPullRequestMerge.rbt:"
 msgid "Merge to Local Repository"
 msgstr "合并到本地仓库"
 
-msgctxt "dlgSgGitHubPullRequestMerge.tle"
+msgctxt "dlgSgGitHubPullRequestMerge.tle:"
 msgid "Merge Pull Request"
 msgstr "合并拉取请求"
 
@@ -4542,11 +4542,11 @@ msgctxt "dlgSgGitLabGenerateToken.edt:"
 msgid "Token"
 msgstr "令牌"
 
-msgctxt "dlgSgGitLabGenerateToken.hdl"
+msgctxt "dlgSgGitLabGenerateToken.hdl:"
 msgid "Generate a new API token for GitLab"
 msgstr "输入生成的令牌"
 
-msgctxt "dlgSgGitLabGenerateToken.inf"
+msgctxt "dlgSgGitLabGenerateToken.inf:"
 msgid "Paste the OAuth code from your browser."
 msgstr "在 Gitlab 验证并输入生成的令牌。"
 
@@ -4554,7 +4554,7 @@ msgctxt "dlgSgGitLabGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at GitLab and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr "您的浏览器应该已自动打开，允许您使用您在 Gitlab 的首选账户进行身份验证，并授予对 SmartGit 的访问权限。如果没有发生这种情况，请手动打开以下链接："
 
-msgctxt "dlgSgGitLabGenerateToken.tle"
+msgctxt "dlgSgGitLabGenerateToken.tle:"
 msgid "Request Access Token"
 msgstr "请求访问令牌"
 
@@ -4570,39 +4570,39 @@ msgctxt "dlgSgGitLabMergeRequestCreate.edt:"
 msgid "Title and Description"
 msgstr "标题和描述"
 
-msgctxt "dlgSgGitLabMergeRequestCreate.hdl"
+msgctxt "dlgSgGitLabMergeRequestCreate.hdl:"
 msgid "Create a Merge Request"
 msgstr "创建合并请求"
 
-msgctxt "dlgSgGitLabMergeRequestCreate.inf"
+msgctxt "dlgSgGitLabMergeRequestCreate.inf:"
 msgid "Send merge request to another repository or branch."
 msgstr "将合并请求发送到其他仓库或分支。"
 
-msgctxt "dlgSgGitLabMergeRequestCreate.tle"
+msgctxt "dlgSgGitLabMergeRequestCreate.tle:"
 msgid "Create Merge Request"
 msgstr "创建合并请求"
 
-msgctxt "dlgSgGitLabRefreshFailed.fur"
+msgctxt "dlgSgGitLabRefreshFailed.fur:"
 msgid "Your SmartGit Hosting Provider configuration for GitLab is probably invalid.\\n\\nReview your settings in the Preferences."
 msgstr ""
 
-msgctxt "dlgSgGitLabRefreshFailed.hdl"
+msgctxt "dlgSgGitLabRefreshFailed.hdl:"
 msgid "Refresh failed."
 msgstr ""
 
-msgctxt "dlgSgGitLabRefreshFailed.tle"
+msgctxt "dlgSgGitLabRefreshFailed.tle:"
 msgid "GitLab"
 msgstr ""
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.fur"
+msgctxt "dlgSgGitLabSettingsInvalidToken.fur:"
 msgid "Use a Personal Access Token from your GitLab account."
 msgstr "使用您的 Gitlab 账户中的个人访问令牌。"
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.hdl"
+msgctxt "dlgSgGitLabSettingsInvalidToken.hdl:"
 msgid "Please enter a Personal Access Token for your GitLab account."
 msgstr "请为您的 Gitlab 账户输入个人访问令牌。"
 
-msgctxt "dlgSgGitLabSettingsInvalidToken.tle"
+msgctxt "dlgSgGitLabSettingsInvalidToken.tle:"
 msgid "Input Validation"
 msgstr "输入验证"
 
@@ -4614,31 +4614,31 @@ msgctxt "dlgSgHeadMessageListenerReplaceMessage.btn:"
 msgid "Replace This Time"
 msgstr "这次更换"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.chk"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.chk:"
 msgid "Never replace if a message is already entered"
 msgstr "如果已输入消息，请勿更换"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.fur"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.fur:"
 msgid "If the commit message input field is empty, the HEAD commit's message will be re-used automatically."
 msgstr "如果提交消息输入字段为空，则将自动重用 HEAD 提交的消息。"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.hdl"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.hdl:"
 msgid "Replace entered commit message with the HEAD commit's message?"
 msgstr "用 HEAD 提交的消息替换输入的提交消息？"
 
-msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle"
+msgctxt "dlgSgHeadMessageListenerReplaceMessage.tle:"
 msgid "Commit"
 msgstr "提交"
 
-msgctxt "dlgSgHistoryCommitCantBeModified.fur"
+msgctxt "dlgSgHistoryCommitCantBeModified.fur:"
 msgid "At least one of the affected commits is not part of your HEAD's first-parent history."
 msgstr ""
 
-msgctxt "dlgSgHistoryCommitCantBeModified.hdl"
+msgctxt "dlgSgHistoryCommitCantBeModified.hdl:"
 msgid "At least one selected commit can't be modified."
 msgstr ""
 
-msgctxt "dlgSgHistoryCommitCantBeModified.tle"
+msgctxt "dlgSgHistoryCommitCantBeModified.tle:"
 msgid "Modify Commit"
 msgstr ""
 
@@ -4670,15 +4670,15 @@ msgctxt "dlgSgHistoryEditAuthor.edt:"
 msgid "User Name"
 msgstr "用户名"
 
-msgctxt "dlgSgHistoryEditAuthor.hdl"
+msgctxt "dlgSgHistoryEditAuthor.hdl:"
 msgid "Edit commit author"
 msgstr "编辑提交作者"
 
-msgctxt "dlgSgHistoryEditAuthor.inf"
+msgctxt "dlgSgHistoryEditAuthor.inf:"
 msgid "Enter the new commit author and its email address."
 msgstr "输入新的提交作者及其电子邮件地址。"
 
-msgctxt "dlgSgHistoryEditAuthor.tle"
+msgctxt "dlgSgHistoryEditAuthor.tle:"
 msgid "Edit Author"
 msgstr "编辑作者"
 
@@ -4702,11 +4702,11 @@ msgctxt "dlgSgHistoryEditMessage.edt:"
 msgid "Commit Message"
 msgstr "提交消息"
 
-msgctxt "dlgSgHistoryEditMessage.hdl"
+msgctxt "dlgSgHistoryEditMessage.hdl:"
 msgid "Edit commit message"
 msgstr "修改提交消息"
 
-msgctxt "dlgSgHistoryEditMessage.inf"
+msgctxt "dlgSgHistoryEditMessage.inf:"
 msgid "Enter the new commit message."
 msgstr "输入新的提交消息。"
 
@@ -4742,7 +4742,7 @@ msgctxt "dlgSgHistoryEditMessage.mni:"
 msgid "Rewrap"
 msgstr ""
 
-msgctxt "dlgSgHistoryEditMessage.tle"
+msgctxt "dlgSgHistoryEditMessage.tle:"
 msgid "Edit Message"
 msgstr "修改提交消息"
 
@@ -4750,19 +4750,19 @@ msgctxt "dlgSgHistoryModifyConfirm.btn:"
 msgid "Modify"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifyConfirm.chk"
+msgctxt "dlgSgHistoryModifyConfirm.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifyConfirm.fur"
+msgctxt "dlgSgHistoryModifyConfirm.fur:"
 msgid "This allows you to step by step walk from the selected commit to HEAD and modify them by amend-committing."
 msgstr ""
 
-msgctxt "dlgSgHistoryModifyConfirm.hdl"
+msgctxt "dlgSgHistoryModifyConfirm.hdl:"
 msgid "Do you want to modify the commits?"
 msgstr ""
 
-msgctxt "dlgSgHistoryModifyConfirm.tle"
+msgctxt "dlgSgHistoryModifyConfirm.tle:"
 msgid "Modify Commit"
 msgstr ""
 
@@ -4774,15 +4774,15 @@ msgctxt "dlgSgHistoryModifySplitConfirm.btn:"
 msgid "Split"
 msgstr "拆分"
 
-msgctxt "dlgSgHistoryModifySplitConfirm.fur"
+msgctxt "dlgSgHistoryModifySplitConfirm.fur:"
 msgid "'Modify' will stop after the commit.\\n\\n'Split' will put the changes into the Index. You may discard some changes that should go into the second commit.\\n\\nAfter you've done the changes, process the remaining commits by continuing the rebase."
 msgstr "提交后，修改将停止。\\n\\n 拆分 会将变更放入索引中。您可以放弃应该进入第二次提交的一些变更。\\n\\n完成变更后，通过继续变基处理剩余的提交。"
 
-msgctxt "dlgSgHistoryModifySplitConfirm.hdl"
+msgctxt "dlgSgHistoryModifySplitConfirm.hdl:"
 msgid "Do you want to modify or split commit $1?"
 msgstr "你想修改或拆分提交 $1 吗？"
 
-msgctxt "dlgSgHistoryModifySplitConfirm.tle"
+msgctxt "dlgSgHistoryModifySplitConfirm.tle:"
 msgid "Modify or Split Commit"
 msgstr "修改或拆分提交"
 
@@ -4790,15 +4790,15 @@ msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.btn:"
 msgid "Force Push"
 msgstr "强制推送"
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr "推送到远程分支不是快进，所以必须强制推送。远程分支中的提交将丢失。"
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.hdl:"
 msgid "Do you want to replace the remote branch by commit $1?"
 msgstr "是否要用提交 $1 替换远程分支？"
 
-msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.tle"
+msgctxt "dlgSgHistoryPushCommitsReplaceRemoteBranch.tle:"
 msgid "Push Up To"
 msgstr "推送到"
 
@@ -4806,15 +4806,15 @@ msgctxt "dlgSgHistoryPushCommitsUpToCommit.btn:"
 msgid "Push"
 msgstr "推送"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.fur:"
 msgid "All commits up to the selected commit will be pushed to the remote repository."
 msgstr "对所选提交的所有提交都将被推送到远程仓库。"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.hdl:"
 msgid "Do you want to push changes up to commit $1?"
 msgstr "是否要将变更向上推送到提交 $1？"
 
-msgctxt "dlgSgHistoryPushCommitsUpToCommit.tle"
+msgctxt "dlgSgHistoryPushCommitsUpToCommit.tle:"
 msgid "Push Up To"
 msgstr "推送到"
 
@@ -4822,11 +4822,11 @@ msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.btn:"
 msgid "Modify Pushed Commits"
 msgstr "修改已推送的提交"
 
-msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.fur"
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.fur:"
 msgid "Commits which are already pushed are known to other users and may have been used by them to build theirs commits upon. When modifying such commits, these users may run into unexpected conflicts later."
 msgstr "已推送的提交对于其他用户是已知的，并且可能已被他们用于构建他们的提交。修改此类提交时，这些用户可能会在以后遇到意外冲突。"
 
-msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl"
+msgctxt "dlgSgHistoryPushedCommitsModifyPushedCommits.hdl:"
 msgid "Do you want to modify commits which are already pushed?"
 msgstr "你想修改已推送的提交吗？"
 
@@ -4862,19 +4862,19 @@ msgctxt "dlgSgHistorySplitConfirm.btn:"
 msgid "Split"
 msgstr "拆分"
 
-msgctxt "dlgSgHistorySplitConfirm.chk"
+msgctxt "dlgSgHistorySplitConfirm.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgHistorySplitConfirm.fur"
+msgctxt "dlgSgHistorySplitConfirm.fur:"
 msgid "This will put the commit's changes into the Index. Unstage those changes that should go into a second commit, then commit the staged changes. Commit the remaining changes in a second \\(or third\\) commit.\\n\\nAfter you are done, process the remaining commits by continuing the rebase."
 msgstr "这会将提交的变更添加到索引中. 取消应进行第二次提交的变更, 然后提交阶段性的变更. 在第二（或第三）次提交中提交其余变更.\\n\\n完成后, 通过继续重新变基来处理剩余的提交."
 
-msgctxt "dlgSgHistorySplitConfirm.hdl"
+msgctxt "dlgSgHistorySplitConfirm.hdl:"
 msgid "Do you want to split the selected commit into multiple commits?"
 msgstr "是否要将所选提交拆分为多个提交?"
 
-msgctxt "dlgSgHistorySplitConfirm.tle"
+msgctxt "dlgSgHistorySplitConfirm.tle:"
 msgid "Split Commit"
 msgstr "拆分提交"
 
@@ -4902,11 +4902,11 @@ msgctxt "dlgSgHistorySquash.edt:"
 msgid "Commit Message"
 msgstr "提交消息"
 
-msgctxt "dlgSgHistorySquash.hdl"
+msgctxt "dlgSgHistorySquash.hdl:"
 msgid "Squash multiple commits"
 msgstr "压缩多个提交"
 
-msgctxt "dlgSgHistorySquash.inf"
+msgctxt "dlgSgHistorySquash.inf:"
 msgid "The selected commits will be replaced by one squashed commit containing all changes of the individual commits."
 msgstr "所选提交将被替换为1个压缩提交，该提交包含各个提交的所有变更。"
 
@@ -4918,7 +4918,7 @@ msgctxt "dlgSgHistorySquash.mni:"
 msgid "Log"
 msgstr "日志"
 
-msgctxt "dlgSgHistorySquash.tle"
+msgctxt "dlgSgHistorySquash.tle:"
 msgid "Squash Commits"
 msgstr "压缩提交"
 
@@ -5070,7 +5070,7 @@ msgctxt "dlgSgHostingProviderAdd.lbl:"
 msgid "You can review Azure DevOps applications in the Authorizations section located at the bottom left of your \\[https://aex.dev.azure.com/me profile\\]."
 msgstr ""
 
-msgctxt "dlgSgHostingProviderAdd.tle"
+msgctxt "dlgSgHostingProviderAdd.tle:"
 msgid "Add Hosting Provider"
 msgstr "添加主机提供商"
 
@@ -5174,11 +5174,11 @@ msgctxt "dlgSgHostingProviderEdit.err:"
 msgid "The provided SSL client certificate path is invalid."
 msgstr "提供的 SSL 客户端证书路径无效."
 
-msgctxt "dlgSgHostingProviderEdit.hdl"
+msgctxt "dlgSgHostingProviderEdit.hdl:"
 msgid "Configure $1 account"
 msgstr "配置 $1 账户"
 
-msgctxt "dlgSgHostingProviderEdit.inf"
+msgctxt "dlgSgHostingProviderEdit.inf:"
 msgid "Please specify your credentials to connect to $1."
 msgstr "请指定您的凭据以连接到 $1。"
 
@@ -5282,7 +5282,7 @@ msgctxt "dlgSgHostingProviderSelectRepository.mni:"
 msgid "Repository"
 msgstr "仓库"
 
-msgctxt "dlgSgHostingProviderSelectRepository.tle"
+msgctxt "dlgSgHostingProviderSelectRepository.tle:"
 msgid "GitHub Projects"
 msgstr "GitHub 项目"
 
@@ -5290,15 +5290,15 @@ msgctxt "dlgSgHostingProvider(Add|Edit).lbl:"
 msgid "Optional SSL configuration"
 msgstr "可选的 SSL 配置"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.fur:"
 msgid "The OAuth-access token could not be requested. Most likely your $1 configuration has changed and SmartGit's stored OAuth credentials are invalid.\\n\\nTo resolve, recreate the $2 hosting provider in the Preferences.\\n\\nDetails:\\n\\n$3"
 msgstr "无法请求 OAuth 访问令牌。很可能您的 $1 配置已更改且 SmartGit 存储的 OAuth 凭据无效。\\n\\n要解析，请在偏好设置中重新创建 $2 主机提供商。\\n\\n详细信息：\\n\\n $3"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.hdl:"
 msgid "$1 OAuth-authentication failed"
 msgstr "$1 OAuth 身份验证失败"
 
-msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.tle"
+msgctxt "dlgSgHttpPasswordAuthenticationFailedCause1.tle:"
 msgid "HTTP authentication"
 msgstr "HTTP 身份验证"
 
@@ -5318,15 +5318,15 @@ msgctxt "dlgSgHttpPasswordCredentials.edt:"
 msgid "User Name"
 msgstr "用户名"
 
-msgctxt "dlgSgHttpPasswordCredentials.hdl"
+msgctxt "dlgSgHttpPasswordCredentials.hdl:"
 msgid "Login to '$1'"
 msgstr "登录到 “$1”"
 
-msgctxt "dlgSgHttpPasswordCredentials.inf"
+msgctxt "dlgSgHttpPasswordCredentials.inf:"
 msgid "Provide the user name and password for authenticating to the repository."
 msgstr "提供用于对仓库进行身份验证的用户名和密码。"
 
-msgctxt "dlgSgHttpPasswordCredentials.tle"
+msgctxt "dlgSgHttpPasswordCredentials.tle:"
 msgid "Login"
 msgstr "登录"
 
@@ -5334,15 +5334,15 @@ msgctxt "dlgSgIgnoreChanged.btn:"
 msgid "Discard Changes"
 msgstr "放弃变更"
 
-msgctxt "dlgSgIgnoreChanged.fur"
+msgctxt "dlgSgIgnoreChanged.fur:"
 msgid "The changes will be discarded when proceeding!"
 msgstr "继续操作时，变更将被丢弃！"
 
-msgctxt "dlgSgIgnoreChanged.hdl"
+msgctxt "dlgSgIgnoreChanged.hdl:"
 msgid "Are you sure to remove changed files?"
 msgstr "您确定要删除已变更的文档？"
 
-msgctxt "dlgSgIgnoreChanged.tle"
+msgctxt "dlgSgIgnoreChanged.tle:"
 msgid "Ignore"
 msgstr "忽略"
 
@@ -5366,15 +5366,15 @@ msgctxt "dlgSgIgnoreDirectoryConfirm.edt:"
 msgid "Ignore File"
 msgstr "忽略文件"
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.fur"
+msgctxt "dlgSgIgnoreDirectoryConfirm.fur:"
 msgid "The directory name will be added to the ignore file. If the ignore file does not exist, it will be created."
 msgstr "目录名称将添加到忽略文件中。如果忽略文件不存在，则将自动创建。"
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.hdl"
+msgctxt "dlgSgIgnoreDirectoryConfirm.hdl:"
 msgid "Do you want to ignore directory '$1'?"
 msgstr "你想忽略目录 “$1” 吗？"
 
-msgctxt "dlgSgIgnoreDirectoryConfirm.tle"
+msgctxt "dlgSgIgnoreDirectoryConfirm.tle:"
 msgid "Ignore"
 msgstr "忽略"
 
@@ -5382,11 +5382,11 @@ msgctxt "dlgSgIgnoreEdit.btn:"
 msgid "Edit"
 msgstr "修改"
 
-msgctxt "dlgSgIgnoreEdit.hdl"
+msgctxt "dlgSgIgnoreEdit.hdl:"
 msgid "Edit Git ignore file"
 msgstr "修改 Git 忽略文件"
 
-msgctxt "dlgSgIgnoreEdit.inf"
+msgctxt "dlgSgIgnoreEdit.inf:"
 msgid "Select the Git ignore file to edit."
 msgstr "选择要修改的 Git 忽略文件"
 
@@ -5398,7 +5398,7 @@ msgctxt "dlgSgIgnoreEdit.mni:"
 msgid "Reveal"
 msgstr "显示"
 
-msgctxt "dlgSgIgnoreEdit.tle"
+msgctxt "dlgSgIgnoreEdit.tle:"
 msgid "Edit Ignore File"
 msgstr "修改忽略文件"
 
@@ -5430,11 +5430,11 @@ msgctxt "dlgSgIgnoreFile.err:"
 msgid "The pattern must match all selected file names. For instance, '$1' is not matched."
 msgstr "模式必须匹配所有选定的文件名。例如，“$1” 不匹配。"
 
-msgctxt "dlgSgIgnoreFile.hdl"
+msgctxt "dlgSgIgnoreFile.hdl:"
 msgid "Mark files to be ignored"
 msgstr "标记要忽略的文件"
 
-msgctxt "dlgSgIgnoreFile.inf"
+msgctxt "dlgSgIgnoreFile.inf:"
 msgid "Choose whether to ignore only the selected file or all files matching the specified pattern. Tracked files will be removed \\(stopped from tracking\\)."
 msgstr "选择是仅忽略所选文件还是忽略与指定模式匹配的所有文件。跟踪的文件将被删除 \\(停止跟踪\\)。"
 
@@ -5450,7 +5450,7 @@ msgctxt "dlgSgIgnoreFile.rbt:"
 msgid "Ignore explicitly \\(e.g. 'Makefile'\\)"
 msgstr "明确忽略 \\(例如 Makefile \\)："
 
-msgctxt "dlgSgIgnoreFile.tle"
+msgctxt "dlgSgIgnoreFile.tle:"
 msgid "Ignore"
 msgstr "忽略"
 
@@ -5458,11 +5458,11 @@ msgctxt "dlgSgIgnoreFile.wrn:"
 msgid "Because of performance reasons it is recommended to ignore by pattern - if possible."
 msgstr ""
 
-msgctxt "dlgSgIndexEditorMixedLineEndings.fur"
+msgctxt "dlgSgIndexEditorMixedLineEndings.fur:"
 msgid "At least one of the file contents contains mixed \\(inconsistent\\) line-endings. To prevent overwriting intentional mixed line-endings, editing and saving is disabled."
 msgstr ""
 
-msgctxt "dlgSgIndexEditorMixedLineEndings.hdl"
+msgctxt "dlgSgIndexEditorMixedLineEndings.hdl:"
 msgid "The file is not editable because of mixed line-endings."
 msgstr ""
 
@@ -5474,15 +5474,15 @@ msgctxt "dlgSgIndexEditorSaveOrDiscard.btn:"
 msgid "Save"
 msgstr "保存"
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.fur"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.fur:"
 msgid "Your changes will be lost, if you don't save them now."
 msgstr "如果您现在不保存变更，则变更将丢失。"
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.hdl"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.hdl:"
 msgid "Do you want to save your changes?"
 msgstr "要保存变更吗？"
 
-msgctxt "dlgSgIndexEditorSaveOrDiscard.tle"
+msgctxt "dlgSgIndexEditorSaveOrDiscard.tle:"
 msgid "Close"
 msgstr "关闭"
 
@@ -5494,27 +5494,27 @@ msgctxt "dlgSgJournalDoubleClick.btn:"
 msgid "Open Log"
 msgstr "打开日志"
 
-msgctxt "dlgSgJournalDoubleClick.fur"
+msgctxt "dlgSgJournalDoubleClick.fur:"
 msgid "Select either to check out '$1' or to open the Log for the selected commit."
 msgstr "选择以检出 '$1' 或打开所选提交的日志."
 
-msgctxt "dlgSgJournalDoubleClick.hdl"
+msgctxt "dlgSgJournalDoubleClick.hdl:"
 msgid "Do you want to check out '$1'?"
 msgstr "确定要检出 '$1' 吗?"
 
-msgctxt "dlgSgJournalDoubleClick.tle"
+msgctxt "dlgSgJournalDoubleClick.tle:"
 msgid "Journal"
 msgstr "日志视图"
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.fur"
+msgctxt "dlgSgJournalFormCommitCantBeModified.fur:"
 msgid "Not part of your head's first-parent history"
 msgstr "不是您 HEAD 主要父系历史的一部分"
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.hdl"
+msgctxt "dlgSgJournalFormCommitCantBeModified.hdl:"
 msgid "At least one selected commit can't be modified."
 msgstr "至少有一个选定的提交无法修改。"
 
-msgctxt "dlgSgJournalFormCommitCantBeModified.tle"
+msgctxt "dlgSgJournalFormCommitCantBeModified.tle:"
 msgid "Edit Author"
 msgstr "编辑作者"
 
@@ -5522,15 +5522,15 @@ msgctxt "dlgSgLfsInstallConfirm.btn:"
 msgid "Install"
 msgstr "安装"
 
-msgctxt "dlgSgLfsInstallConfirm.fur"
+msgctxt "dlgSgLfsInstallConfirm.fur:"
 msgid "This will configure hooks and filters required for LFS."
 msgstr "这将配置 LFS 所需的挂钩和过滤器。"
 
-msgctxt "dlgSgLfsInstallConfirm.hdl"
+msgctxt "dlgSgLfsInstallConfirm.hdl:"
 msgid "Would you like to initialize this repository for Large File Support \\(LFS\\)?"
 msgstr "是否要为大文件支持 \\(LFS\\) 初始化此仓库？"
 
-msgctxt "dlgSgLfsInstallConfirm.tle"
+msgctxt "dlgSgLfsInstallConfirm.tle:"
 msgid "LFS Install"
 msgstr "LFS 安装"
 
@@ -5538,15 +5538,15 @@ msgctxt "dlgSgLfsPruneConfirm.btn:"
 msgid "Prune"
 msgstr ""
 
-msgctxt "dlgSgLfsPruneConfirm.fur"
+msgctxt "dlgSgLfsPruneConfirm.fur:"
 msgid "This will call the remote to ensure that any LFS files to be deleted have copies on the remote before actually deleting them."
 msgstr ""
 
-msgctxt "dlgSgLfsPruneConfirm.hdl"
+msgctxt "dlgSgLfsPruneConfirm.hdl:"
 msgid "Would you like to delete old LFS files from the local storage?"
 msgstr ""
 
-msgctxt "dlgSgLfsPruneConfirm.tle"
+msgctxt "dlgSgLfsPruneConfirm.tle:"
 msgid "LFS Prune"
 msgstr ""
 
@@ -5558,15 +5558,15 @@ msgctxt "dlgSgLfsTrack.err:"
 msgid "File '$1' does not match the specified pattern."
 msgstr "文件 “$1” 不匹配指定的模式。"
 
-msgctxt "dlgSgLfsTrack.hdl"
+msgctxt "dlgSgLfsTrack.hdl:"
 msgid "Mark a file or pattern as tracked"
 msgstr "将文件或模式标记为已跟踪"
 
-msgctxt "dlgSgLfsTrack.inf"
+msgctxt "dlgSgLfsTrack.inf:"
 msgid "Specify the file name pattern that should be handled by Large File Support \\(LFS\\)."
 msgstr "指定应该由大文件支持 \\(LFS\\) 处理的文件名模式。"
 
-msgctxt "dlgSgLfsTrack.tle"
+msgctxt "dlgSgLfsTrack.tle:"
 msgid "LFS Track"
 msgstr "LFS 跟踪"
 
@@ -5574,27 +5574,27 @@ msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.btn:"
 msgid "Revert"
 msgstr "还原"
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.fur:"
 msgid "You are about to apply lines from the Index to the working tree file '$1'. The modifications will be saved immediately."
 msgstr "您将要将索引中的行应用到工作区文件 “$1”。修改将立即保存。"
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.hdl"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.hdl:"
 msgid "Do you really want to revert changes in the working tree file?"
 msgstr "您真的想要还原工作区中文件的变更吗？"
 
-msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.tle"
+msgctxt "dlgSgLocalChangesFormTakeBlockListenerRevertWorkingTreeFile.tle:"
 msgid "Revert Working Tree File"
 msgstr "还原工作区文件"
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.fur"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.fur:"
 msgid "It's not possible to perform the requested operation on an empty repository."
 msgstr "无法在空仓库上执行请求的操作."
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.hdl"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.hdl:"
 msgid "The repository is empty."
 msgstr "该仓库为空."
 
-msgctxt "dlgSgLocalCommandRepositoryEmpty.tle"
+msgctxt "dlgSgLocalCommandRepositoryEmpty.tle:"
 msgid "Save Stash"
 msgstr "保存贮藏"
 
@@ -5610,7 +5610,7 @@ msgctxt "dlgSgLogCheckoutFileAs.edt:"
 msgid "Target File"
 msgstr "目标文件"
 
-msgctxt "dlgSgLogCheckoutFileAs.hdl"
+msgctxt "dlgSgLogCheckoutFileAs.hdl:"
 msgid "Save the repository file"
 msgstr "保存仓库文件"
 
@@ -5622,11 +5622,11 @@ msgctxt "dlgSgLogCheckoutFileAs.inf:"
 msgid "Select whether to save the file state Before or After the selected commit."
 msgstr "选择保存在所选提交之前还是之后的文件状态。"
 
-msgctxt "dlgSgLogCheckoutFileAs.tle"
+msgctxt "dlgSgLogCheckoutFileAs.tle:"
 msgid "Save File As"
 msgstr "文件另存为"
 
-msgctxt "dlgSgLogCommentDeleteConfirm.hdl"
+msgctxt "dlgSgLogCommentDeleteConfirm.hdl:"
 msgid "Do you really want to delete comment '$1'?"
 msgstr "您真的想删除 “$1” 注释吗？"
 
@@ -5634,15 +5634,15 @@ msgctxt "dlgSgLogComment(|s)DeleteConfirm.btn:"
 msgid "Delete Comment"
 msgstr "删除注释"
 
-msgctxt "dlgSgLogComment(|s)DeleteConfirm.fur"
+msgctxt "dlgSgLogComment(|s)DeleteConfirm.fur:"
 msgid "Comments can't be restored after deletion."
 msgstr "注释被删除后无法还原."
 
-msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle"
+msgctxt "dlgSgLogComment(|s)DeleteConfirm.tle:"
 msgid "Delete Comment"
 msgstr "删除注释"
 
-msgctxt "dlgSgLogCommentsDeleteConfirm.hdl"
+msgctxt "dlgSgLogCommentsDeleteConfirm.hdl:"
 msgid "Do you really want to delete $1 comments?"
 msgstr "您真的想删除 $1 注释吗？"
 
@@ -5654,15 +5654,15 @@ msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.btn:"
 msgid "Compare With Each Other"
 msgstr "相互比较"
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.fur"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.fur:"
 msgid "You may compare the selected files against each other or open up two separate compares for each file against its previous state."
 msgstr "您可以将所选文件相互比较，或者为每个文件打开单独与其之前的状态比较。"
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.hdl"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.hdl:"
 msgid "Do you want to compare the selected files against each other?"
 msgstr "您想要将所选文件相互比较吗？"
 
-msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.tle"
+msgctxt "dlgSgLogCompareSelectedFilesAgainstEachOther.tle:"
 msgid "Compare"
 msgstr "比较"
 
@@ -5678,15 +5678,15 @@ msgctxt "dlgSgLogCompareWithWorkingTree.edt:"
 msgid "Working Tree File"
 msgstr "工作区文件"
 
-msgctxt "dlgSgLogCompareWithWorkingTree.hdl"
+msgctxt "dlgSgLogCompareWithWorkingTree.hdl:"
 msgid "Compare repository file with local file"
 msgstr "将仓库文件与本地文件进行比较"
 
-msgctxt "dlgSgLogCompareWithWorkingTree.inf"
+msgctxt "dlgSgLogCompareWithWorkingTree.inf:"
 msgid "Select whether to compare with the repository file as it was Before or After the selected commit."
 msgstr "选择是与选定提交之前还是之后的仓库文件进行比较。"
 
-msgctxt "dlgSgLogCompareWithWorkingTree.tle"
+msgctxt "dlgSgLogCompareWithWorkingTree.tle:"
 msgid "Compare with Working Tree"
 msgstr "与工作区比较"
 
@@ -5694,11 +5694,11 @@ msgctxt "dlgSgLogGraphRootSwitch.chk:"
 msgid "Include tracked remote branches"
 msgstr "包括跟踪的远程分支"
 
-msgctxt "dlgSgLogGraphRootSwitch.hdl"
+msgctxt "dlgSgLogGraphRootSwitch.hdl:"
 msgid "Select shown branches"
 msgstr "选择显示的分支"
 
-msgctxt "dlgSgLogGraphRootSwitch.inf"
+msgctxt "dlgSgLogGraphRootSwitch.inf:"
 msgid "Select the branches for which to show commits in the graph."
 msgstr "选择要在图表中显示提交的分支。"
 
@@ -5706,7 +5706,7 @@ msgctxt "dlgSgLogGraphRootSwitch.mni:"
 msgid "Toggle"
 msgstr "切换"
 
-msgctxt "dlgSgLogGraphRootSwitch.tle"
+msgctxt "dlgSgLogGraphRootSwitch.tle:"
 msgid "Select Branches"
 msgstr "选择分支"
 
@@ -5718,23 +5718,23 @@ msgctxt "dlgSgLogOpenFailedRepository.fur:"
 msgid "Is the repository still valid?"
 msgstr "仓库是否仍然有效?"
 
-msgctxt "dlgSgLogOpenFailedRepository.hdl"
+msgctxt "dlgSgLogOpenFailedRepository.hdl:"
 msgid "Repository could not be opened."
 msgstr "仓库无法打开。"
 
-msgctxt "dlgSgLogOpenFailedRepository.tle"
+msgctxt "dlgSgLogOpenFailedRepository.tle:"
 msgid "Log"
 msgstr "日志"
 
-msgctxt "dlgSgLogOpenFailedSubmodule.fur"
+msgctxt "dlgSgLogOpenFailedSubmodule.fur:"
 msgid "Is the repository still valid?"
 msgstr "仓库是否仍然有效？"
 
-msgctxt "dlgSgLogOpenFailedSubmodule.hdl"
+msgctxt "dlgSgLogOpenFailedSubmodule.hdl:"
 msgid "Submodule could not be opened."
 msgstr "子模块无法打开。"
 
-msgctxt "dlgSgLogOpenFailedSubmodule.tle"
+msgctxt "dlgSgLogOpenFailedSubmodule.tle:"
 msgid "Log"
 msgstr "日志"
 
@@ -5746,15 +5746,15 @@ msgctxt "dlgSgLogOpenNewWindow.btn:"
 msgid "New Window"
 msgstr "新建窗口"
 
-msgctxt "dlgSgLogOpenNewWindow.fur"
+msgctxt "dlgSgLogOpenNewWindow.fur:"
 msgid "There is already an existing Log window which can be revealed."
 msgstr "已经存在一个可以显示的日志窗口。"
 
-msgctxt "dlgSgLogOpenNewWindow.hdl"
+msgctxt "dlgSgLogOpenNewWindow.hdl:"
 msgid "Do you want to open a new Log window?"
 msgstr "是否要打开新的日志窗口？"
 
-msgctxt "dlgSgLogOpenNewWindow.tle"
+msgctxt "dlgSgLogOpenNewWindow.tle:"
 msgid "Log"
 msgstr "日志"
 
@@ -5766,15 +5766,15 @@ msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.btn:"
 msgid "Submodule Log"
 msgstr "子模块日志"
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.fur"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.fur:"
 msgid "The history of submodule updates will show changes to the submodule link \\('GITLINK'\\) from the parent repository's perspective. The Log for the submodule repository will show all commits which have occurred in the submodule repository itself."
 msgstr "子模块更新的历史日志将显示从父仓库的角度对子模块链接 \\('GITLINK'\\) 的变更。 子模块仓库的日志将显示子模块仓库本身中发生的所有提交。"
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.hdl"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.hdl:"
 msgid "Do you want to show the history of submodule updates or the Log for the submodule repository?"
 msgstr "是否要显示子模块更新的历史日志或子模块仓库的日志？"
 
-msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.tle"
+msgctxt "dlgSgLogOpenSubmoduleLinkOrRepository.tle:"
 msgid "Open Log"
 msgstr "打开日志"
 
@@ -5782,15 +5782,15 @@ msgctxt "dlgSgLogRefActionsDeleteConfirm.btn:"
 msgid "Delete Branch"
 msgstr "删除分支"
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.fur"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.fur:"
 msgid "You may lose unpushed changes or it might be complicated to restore the branch\\(es\\)!"
 msgstr "您可能会丢失未推送的变更，或还原分支可能会很复杂 \\(es\\)！"
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.hdl:"
 msgid "Do you really want to delete the local branch '$1'?"
 msgstr "你真的想删除本地分支 “$1” 吗？"
 
-msgctxt "dlgSgLogRefActionsDeleteConfirm.tle"
+msgctxt "dlgSgLogRefActionsDeleteConfirm.tle:"
 msgid "Delete Local Branch"
 msgstr "删除本地分支"
 
@@ -5802,15 +5802,15 @@ msgctxt "dlgSgLogRefreshRepositoryInvalid.btn:"
 msgid "Remove Repository"
 msgstr "移除仓库"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.fur"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.fur:"
 msgid "This could mean that the repository at\\n\\n$1was removed or renamed outside SmartGit."
 msgstr "这可能意味着在\\n\\n $1 的仓库被删除或在 SmartGit 外部重命名。"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.hdl:"
 msgid "The opened repository '$1' became invalid."
 msgstr "打开的仓库 “$1” 变为无效。"
 
-msgctxt "dlgSgLogRefreshRepositoryInvalid.tle"
+msgctxt "dlgSgLogRefreshRepositoryInvalid.tle:"
 msgid "Refresh"
 msgstr "刷新"
 
@@ -5830,11 +5830,11 @@ msgctxt "dlgSgMerge.btn:"
 msgid "Squash-Merge"
 msgstr "压缩合并"
 
-msgctxt "dlgSgMerge.hdl"
+msgctxt "dlgSgMerge.hdl:"
 msgid "Merge"
 msgstr "合并"
 
-msgctxt "dlgSgMerge.inf"
+msgctxt "dlgSgMerge.inf:"
 msgid "Select the branch or commit to merge and how they should be merged into the Working Tree."
 msgstr "选择要合并的分支或提交以及如何将它们合并到工作区中。"
 
@@ -5850,7 +5850,7 @@ msgctxt "dlgSgMerge.mni:"
 msgid "Refresh"
 msgstr "刷新"
 
-msgctxt "dlgSgMerge.tle"
+msgctxt "dlgSgMerge.tle:"
 msgid "Merge"
 msgstr "合并"
 
@@ -5858,15 +5858,15 @@ msgctxt "dlgSgMergeConfirmNoCommit.btn:"
 msgid "Merge"
 msgstr "合并"
 
-msgctxt "dlgSgMergeConfirmNoCommit.fur"
+msgctxt "dlgSgMergeConfirmNoCommit.fur:"
 msgid "The selected revisions\\(s\\) will be merged to the working tree.\\n\\nNote that merging directly to the GitFlow-master branch is not recommended. Instead, you should start a hotfix."
 msgstr "所选修订将合并到工作区.\\n\\n请注意, 不推荐直接合并到 GitFlow-master 分支. 相反, 你应该先进行 hotfix."
 
-msgctxt "dlgSgMergeConfirmNoCommit.hdl"
+msgctxt "dlgSgMergeConfirmNoCommit.hdl:"
 msgid "Do you want to perform the merge?"
 msgstr "是否要执行合并?"
 
-msgctxt "dlgSgMergeConfirmNoCommit.tle"
+msgctxt "dlgSgMergeConfirmNoCommit.tle:"
 msgid "Merge"
 msgstr "合并"
 
@@ -5886,7 +5886,7 @@ msgctxt "dlgSgMergeHowToMerge.btn:"
 msgid "Squash-Merge"
 msgstr "压缩合并"
 
-msgctxt "dlgSgMergeHowToMerge.fur"
+msgctxt "dlgSgMergeHowToMerge.fur:"
 msgid "If there is no conflict, Git can automatically create a merge commit. Alternatively, you can opt to merge to the working tree.\\nMerge to Working Tree will prepare a merge commit while Squash-Merge will prepare a normal commit \\(discarding the information about what commits were merged\\) - in both cases to be committed manually later."
 msgstr "如果没有冲突, Git 可以自动创建一个合并提交. 或者, 您可以选择合并到工作区. \\n合并到工作区准备一个合并提交, 而 Squash-Merge 将准备一个普通提交 \\(丢弃关于哪些提交被合并的信息\\) - 在两种情况下都需要稍后手动提交"
 
@@ -5898,19 +5898,19 @@ msgctxt "dlgSgMergeHowToMerge.hdl:"
 msgid "How to merge from tag '$1'?"
 msgstr "如何从标签 '$1' 合并?"
 
-msgctxt "dlgSgMergeHowToMerge.tle"
+msgctxt "dlgSgMergeHowToMerge.tle:"
 msgid "Merge"
 msgstr "合并"
 
-msgctxt "dlgSgMergeNoop.fur"
+msgctxt "dlgSgMergeNoop.fur:"
 msgid "Merging a commit's own history into itself is technically allowed by Git but it's a no-op and will not give a new commit nor any other meaningful changes."
 msgstr "虽然 Git 在技术上允许将提交的历史记录合并到其自身中, 但这是禁止的操作，因为不会给出新的提交或任何其他有意义的更改."
 
-msgctxt "dlgSgMergeNoop.hdl"
+msgctxt "dlgSgMergeNoop.hdl:"
 msgid "There is nothing to merge."
 msgstr "没有内容需要合并."
 
-msgctxt "dlgSgMergeNoop.tle"
+msgctxt "dlgSgMergeNoop.tle:"
 msgid "Merge"
 msgstr "合并"
 
@@ -5922,15 +5922,15 @@ msgctxt "dlgSgOpenRepository.err:"
 msgid "Please specify the root directory of a Git repository."
 msgstr "请指定 Git 仓库的根目录。"
 
-msgctxt "dlgSgOpenRepository.hdl"
+msgctxt "dlgSgOpenRepository.hdl:"
 msgid "Add existing or create new repository"
 msgstr "添加现有或创建新仓库"
 
-msgctxt "dlgSgOpenRepository.inf"
+msgctxt "dlgSgOpenRepository.inf:"
 msgid "Specify the local Git repository to open. To create a new repository, specify an empty directory."
 msgstr ""
 
-msgctxt "dlgSgOpenRepository.tle"
+msgctxt "dlgSgOpenRepository.tle:"
 msgid "Add or Create Repository"
 msgstr "添加或创建仓库"
 
@@ -5938,27 +5938,27 @@ msgctxt "dlgSgOpenRepositoryInitializeGit.btn:"
 msgid "Initialize"
 msgstr "初始化"
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.fur"
+msgctxt "dlgSgOpenRepositoryInitializeGit.fur:"
 msgid "The specified directory does not appear to be a valid Git repository."
 msgstr "指定的目录似乎不是有效的 Git 仓库。"
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.hdl"
+msgctxt "dlgSgOpenRepositoryInitializeGit.hdl:"
 msgid "Should '$1' be initialized as a new Git repository?"
 msgstr "是否应该将 '$1' 初始化为新的 Git 仓库？"
 
-msgctxt "dlgSgOpenRepositoryInitializeGit.tle"
+msgctxt "dlgSgOpenRepositoryInitializeGit.tle:"
 msgid "Add or Create Repository"
 msgstr "添加或创建仓库"
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.fur:"
 msgid "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 msgstr "You are trying to open an existing SVN working copy which is not possible with SmartGit. Instead, please use $1 to create a Git clone of your SVN repository \\(i.e. a working copy based on Git instead of SVN\\)."
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.hdl"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.hdl:"
 msgid "Can't open SVN working copy, please re-clone with SmartGit."
 msgstr "无法打开 SVN 工作副本, 请使用 SmartGit 重新克隆."
 
-msgctxt "dlgSgOpenRepositorySvnWorkingCopy.tle"
+msgctxt "dlgSgOpenRepositorySvnWorkingCopy.tle:"
 msgid "Add or Create Repository"
 msgstr "添加或创建仓库"
 
@@ -6190,15 +6190,15 @@ msgctxt "dlgSgOutput.tle:"
 msgid "Output"
 msgstr "输出"
 
-msgctxt "dlgSgPingRepositoryFailed.fur"
+msgctxt "dlgSgPingRepositoryFailed.fur:"
 msgid "Please check the repository URL.\\n\\n$1"
 msgstr "请检查仓库 URL。\\n\\n$1"
 
-msgctxt "dlgSgPingRepositoryFailed.hdl"
+msgctxt "dlgSgPingRepositoryFailed.hdl:"
 msgid "Could not connect to the repository '$1'."
 msgstr "无法连接到仓库 “$1”。"
 
-msgctxt "dlgSgPingRepositoryFailed.tle"
+msgctxt "dlgSgPingRepositoryFailed.tle:"
 msgid "Clone"
 msgstr "克隆"
 
@@ -7407,7 +7407,7 @@ msgctxt "dlgSgPreferences.tab:"
 msgid "User"
 msgstr "用户"
 
-msgctxt "dlgSgPreferences.tle"
+msgctxt "dlgSgPreferences.tle:"
 msgid "Preferences"
 msgstr "偏好设置"
 
@@ -7471,7 +7471,7 @@ msgctxt "dlgSgProcessKiller.lbl:"
 msgid "If you think the process is hanging, click the 'Kill Process' button, otherwise 'Wait'."
 msgstr "如果进程卡住了, 可以终止进程或等待."
 
-msgctxt "dlgSgProcessKiller.tle"
+msgctxt "dlgSgProcessKiller.tle:"
 msgid "Process Not Responding"
 msgstr "进程无响应"
 
@@ -7483,15 +7483,15 @@ msgctxt "dlgSgProviderCommentEdit.edt:"
 msgid "Text"
 msgstr ""
 
-msgctxt "dlgSgProviderCommentEdit.hdl"
+msgctxt "dlgSgProviderCommentEdit.hdl:"
 msgid "Edit GitHub comment"
 msgstr ""
 
-msgctxt "dlgSgProviderCommentEdit.inf"
+msgctxt "dlgSgProviderCommentEdit.inf:"
 msgid "Enter the text of the comment."
 msgstr ""
 
-msgctxt "dlgSgProviderCommentEdit.tle"
+msgctxt "dlgSgProviderCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr ""
 
@@ -7503,7 +7503,7 @@ msgctxt "dlgSgProviderGenerateToken.edt:"
 msgid "Link"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.inf"
+msgctxt "dlgSgProviderGenerateToken.inf:"
 msgid "Authenticate at GitLab and grant access to SmartGit."
 msgstr ""
 
@@ -7515,19 +7515,19 @@ msgctxt "dlgSgProviderGenerateToken.lbl:"
 msgid "Your browser should have opened automatically, let you authenticate with your preferred account at GitLab and grant access to SmartGit. If this didn't happen, manually open following link:"
 msgstr ""
 
-msgctxt "dlgSgProviderGenerateToken.tle"
+msgctxt "dlgSgProviderGenerateToken.tle:"
 msgid "Generate API Token"
 msgstr ""
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.fur"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.fur:"
 msgid "The repository is no GitHub-fork and there are no other remotes which are forks of this repository."
 msgstr "该仓库不是 GitHub 复刻仓库，也没有复刻了此仓库的其它远程仓库。"
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.hdl"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.hdl:"
 msgid "No target repositories found."
 msgstr "找不到目标仓库。"
 
-msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.tle"
+msgctxt "dlgSgProviderPullRequestCreateNoTargetRepositories.tle:"
 msgid "Create Pull Request"
 msgstr "创建拉取请求"
 
@@ -7539,15 +7539,15 @@ msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.btn:"
 msgid "Skip"
 msgstr "跳过"
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.fur"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.fur:"
 msgid "You have local commits which are not yet present in the server-side Provider repository. Unless you push them now, these local commits will not be included in the merge request."
 msgstr "您有一些本地提交尚未出现在服务器端的提供者仓库中. 除非您现在推送它们, 否则这些本地提交将不会包含在合并请求中."
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.hdl"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.hdl:"
 msgid "Do you want to push your local commits first?"
 msgstr "您是否想要先推送您的本地提交?"
 
-msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.tle"
+msgctxt "dlgSgProviderPullRequestCreatePushLocalCommits.tle:"
 msgid "Create Merge Request"
 msgstr "创建合并请求"
 
@@ -7555,15 +7555,15 @@ msgctxt "dlgSgProviderPullRequestDropConfirmMr.btn:"
 msgid "Drop"
 msgstr "终止"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.fur:"
 msgid "The merge request itself will not be deleted on the server."
 msgstr "拉取请求本身不会在服务器上删除。"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.hdl:"
 msgid "Do you really want to drop the local commits of merge request $1?"
 msgstr "是否确定要删除请求 $1 的本地提交？"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmMr.tle"
+msgctxt "dlgSgProviderPullRequestDropConfirmMr.tle:"
 msgid "Drop Merge Request"
 msgstr "终止拉取请求"
 
@@ -7571,17 +7571,17 @@ msgctxt "dlgSgProviderPullRequestDropConfirmPr.btn:"
 msgid "Drop"
 msgstr "终止"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.fur:"
 msgid "The pull request itself will not be deleted on the server."
 msgstr "拉取请求本身不会在服务器上删除。"
 
 #, fuzzy
 #| msgid "Do you really want to drop the local commits of pull request $1?"
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.hdl:"
 msgid "Do you want to drop the local commits of pull request $1?"
 msgstr "是否确定要删除请求 $1 的本地提交？"
 
-msgctxt "dlgSgProviderPullRequestDropConfirmPr.tle"
+msgctxt "dlgSgProviderPullRequestDropConfirmPr.tle:"
 msgid "Drop Pull Request"
 msgstr "终止拉取请求"
 
@@ -7593,15 +7593,15 @@ msgctxt "dlgSgProviderPullRequestRetractMr.edt:"
 msgid "Comment"
 msgstr "注释"
 
-msgctxt "dlgSgProviderPullRequestRetractMr.hdl"
+msgctxt "dlgSgProviderPullRequestRetractMr.hdl:"
 msgid "Retract Merge Request"
 msgstr "撤消合并请求"
 
-msgctxt "dlgSgProviderPullRequestRetractMr.inf"
+msgctxt "dlgSgProviderPullRequestRetractMr.inf:"
 msgid "Enter the comment which will be logged with the closed merge request."
 msgstr "输入将使用已关闭的合并请求记录的注释。"
 
-msgctxt "dlgSgProviderPullRequestRetractMr.tle"
+msgctxt "dlgSgProviderPullRequestRetractMr.tle:"
 msgid "Retract Merge Request"
 msgstr "撤消合并请求"
 
@@ -7613,15 +7613,15 @@ msgctxt "dlgSgProviderPullRequestRetractPr.edt:"
 msgid "Comment"
 msgstr "注释"
 
-msgctxt "dlgSgProviderPullRequestRetractPr.hdl"
+msgctxt "dlgSgProviderPullRequestRetractPr.hdl:"
 msgid "Retract Pull Request"
 msgstr "撤消合并请求"
 
-msgctxt "dlgSgProviderPullRequestRetractPr.inf"
+msgctxt "dlgSgProviderPullRequestRetractPr.inf:"
 msgid "Enter the comment which will be logged with the closed pull request."
 msgstr "输入将使用已关闭的合并请求记录的注释。"
 
-msgctxt "dlgSgProviderPullRequestRetractPr.tle"
+msgctxt "dlgSgProviderPullRequestRetractPr.tle:"
 msgid "Retract Pull Request"
 msgstr "撤消合并请求"
 
@@ -7653,7 +7653,7 @@ msgctxt "dlgSgPull.edt:"
 msgid "Fetch From"
 msgstr "获取"
 
-msgctxt "dlgSgPull.hdl"
+msgctxt "dlgSgPull.hdl:"
 msgid "Pull commits from a remote repository"
 msgstr "从远程仓库中拉取提交"
 
@@ -7665,7 +7665,7 @@ msgctxt "dlgSgPull.inf:"
 msgid "Select the remote repository to pull. In contrast to Fetch Only, Pull will also incorporate the fetched changes \\(expand the options below to configure\\)."
 msgstr "选择要获取的远程仓库。与 “仅获取” 相比,拉取还将包含获取的变更 \\(展开下面的选项进行配置\\)。"
 
-msgctxt "dlgSgPull.tle"
+msgctxt "dlgSgPull.tle:"
 msgid "Pull"
 msgstr "拉取"
 
@@ -7677,11 +7677,11 @@ msgctxt "dlgSgPullConfiguration.chk:"
 msgid "Remember as default for other repositories"
 msgstr "记住作为其他仓库的默认选项"
 
-msgctxt "dlgSgPullConfiguration.hdl"
+msgctxt "dlgSgPullConfiguration.hdl:"
 msgid "Configure how to pull"
 msgstr "配置如何拉取"
 
-msgctxt "dlgSgPullConfiguration.inf"
+msgctxt "dlgSgPullConfiguration.inf:"
 msgid "Specify whether to merge or rebase on Pull for the current repository."
 msgstr "指定是否在当前仓库的拉取上进行合并或变基。"
 
@@ -7701,7 +7701,7 @@ msgctxt "dlgSgPullConfiguration.rbt:"
 msgid "Rebase"
 msgstr "变基"
 
-msgctxt "dlgSgPullConfiguration.tle"
+msgctxt "dlgSgPullConfiguration.tle:"
 msgid "Configure Pull"
 msgstr "配置拉取"
 
@@ -7713,15 +7713,15 @@ msgctxt "dlgSgPullMergeInsteadOfRebase.btn:"
 msgid "Rebase"
 msgstr "变基"
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.fur"
+msgctxt "dlgSgPullMergeInsteadOfRebase.fur:"
 msgid "Amongst the changes to rebase there is merge-commit $1. Rebasing merge-commits can easily cause troubles."
 msgstr "在变基的变更中有合并提交 $1。 变基合并提交很容易造成麻烦。"
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.hdl"
+msgctxt "dlgSgPullMergeInsteadOfRebase.hdl:"
 msgid "Do you want to merge your local changes instead of rebasing?"
 msgstr "您想合并本地变更而不是变基吗？"
 
-msgctxt "dlgSgPullMergeInsteadOfRebase.tle"
+msgctxt "dlgSgPullMergeInsteadOfRebase.tle:"
 msgid "Pull"
 msgstr "拉取"
 
@@ -7729,15 +7729,15 @@ msgctxt "dlgSgPullNoRemoteRepository.btn:"
 msgid "Add Remote"
 msgstr "创建远程"
 
-msgctxt "dlgSgPullNoRemoteRepository.fur"
+msgctxt "dlgSgPullNoRemoteRepository.fur:"
 msgid "You first need to add a remote repository to pull from."
 msgstr "您首先需要创建远程仓库来拉取。"
 
-msgctxt "dlgSgPullNoRemoteRepository.hdl"
+msgctxt "dlgSgPullNoRemoteRepository.hdl:"
 msgid "No remote repository has been found."
 msgstr "没有找到远程仓库。"
 
-msgctxt "dlgSgPullNoRemoteRepository.tle"
+msgctxt "dlgSgPullNoRemoteRepository.tle:"
 msgid "Pull"
 msgstr "拉取"
 
@@ -7757,15 +7757,15 @@ msgctxt "dlgSgPullOrJustFetch.chk:"
 msgid "Update existing and fetch new tags"
 msgstr "更新现有标签并获取新标签"
 
-msgctxt "dlgSgPullOrJustFetch.fur"
+msgctxt "dlgSgPullOrJustFetch.fur:"
 msgid "You can change the Pull behavior in the Repository Settings."
 msgstr "您可以在仓库设置中变更拉取行为。"
 
-msgctxt "dlgSgPullOrJustFetch.hdl"
+msgctxt "dlgSgPullOrJustFetch.hdl:"
 msgid "Do you want to pull or just fetch $1 repositories?"
 msgstr "你想拉取或只是获取 $1 的仓库？"
 
-msgctxt "dlgSgPullOrJustFetch.tle"
+msgctxt "dlgSgPullOrJustFetch.tle:"
 msgid "Pull"
 msgstr "拉取"
 
@@ -7773,11 +7773,11 @@ msgctxt "dlgSgPullSubmoduleUpdate.btn:"
 msgid "Pull"
 msgstr ""
 
-msgctxt "dlgSgPullSubmoduleUpdate.fur"
+msgctxt "dlgSgPullSubmoduleUpdate.fur:"
 msgid "The git infrastructure for this submodule will be initialized and all commits will be pulled."
 msgstr ""
 
-msgctxt "dlgSgPullSubmoduleUpdate.tle"
+msgctxt "dlgSgPullSubmoduleUpdate.tle:"
 msgid "Pull Submodule"
 msgstr ""
 
@@ -7785,19 +7785,19 @@ msgctxt "dlgSgPushConfirmSingleBranch.btn:"
 msgid "Push"
 msgstr "推送"
 
-msgctxt "dlgSgPushConfirmSingleBranch.chk"
+msgctxt "dlgSgPushConfirmSingleBranch.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgPushConfirmSingleBranch.fur"
+msgctxt "dlgSgPushConfirmSingleBranch.fur:"
 msgid "1 branch will be pushed to '$1'."
 msgstr "分支将被推至 “$1” 。"
 
-msgctxt "dlgSgPushConfirmSingleBranch.hdl"
+msgctxt "dlgSgPushConfirmSingleBranch.hdl:"
 msgid "Do you want to push branch '$1'?"
 msgstr "你想要推送分支 “$1” 吗？"
 
-msgctxt "dlgSgPushConfirmSingleBranch.tle"
+msgctxt "dlgSgPushConfirmSingleBranch.tle:"
 msgid "Push"
 msgstr "推送"
 
@@ -7805,11 +7805,11 @@ msgctxt "dlgSgPushConfirmSingleTag.btn:"
 msgid "Push"
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleTag.chk"
+msgctxt "dlgSgPushConfirmSingleTag.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgPushConfirmSingleTag.tle"
+msgctxt "dlgSgPushConfirmSingleTag.tle:"
 msgid "Push"
 msgstr ""
 
@@ -7817,15 +7817,15 @@ msgctxt "dlgSgPushForced.btn:"
 msgid "Force Push"
 msgstr "强制推送"
 
-msgctxt "dlgSgPushForced.fur"
+msgctxt "dlgSgPushForced.fur:"
 msgid "Pushing to the remote branch is not fast-forward, so the push has to be forced. The commits in the remote branch will be lost."
 msgstr "推送到远程分支不是快进的，因此必须强制推送。远程分支中的提交将丢失。"
 
-msgctxt "dlgSgPushForced.hdl"
+msgctxt "dlgSgPushForced.hdl:"
 msgid "Do you want to force-push \\(replace\\) the remote branch?"
 msgstr "你想强制推送 \\(替换\\) 远程分支吗？"
 
-msgctxt "dlgSgPushForced.tle"
+msgctxt "dlgSgPushForced.tle:"
 msgid "Push"
 msgstr "推送"
 
@@ -7833,15 +7833,15 @@ msgctxt "dlgSgPushForcedSvn.btn:"
 msgid "Force Push"
 msgstr "强制推送"
 
-msgctxt "dlgSgPushForcedSvn.fur"
+msgctxt "dlgSgPushForcedSvn.fur:"
 msgid "You are about to replace the remote branch. Revisions of that branch might not be \\(easily\\) accessible anymore."
 msgstr "您即将更换远程分支。该分支的修订可能不再是 \\(容易\\) 可访问的。"
 
-msgctxt "dlgSgPushForcedSvn.hdl"
+msgctxt "dlgSgPushForcedSvn.hdl:"
 msgid "Do you want to force-push \\(replace\\) the remote branch?"
 msgstr "是否要强制推送 \\(替换\\) 远程分支吗？"
 
-msgctxt "dlgSgPushForcedSvn.tle"
+msgctxt "dlgSgPushForcedSvn.tle:"
 msgid "Push"
 msgstr "推送"
 
@@ -7849,19 +7849,19 @@ msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.btn:"
 msgid "Push"
 msgstr "推送"
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.chk"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.chk:"
 msgid "Overwrite remote changes"
 msgstr "覆盖远程变更"
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.fur"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.fur:"
 msgid "You are about to replace the remote branch, which contains commits that you haven't seen at all. Maybe you want to merge/rebase onto the remote changes before?"
 msgstr "您即将更换远程分支，其中包含您根本没有看到的提交。也许你想在之前合并/改造远程变更？"
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.hdl"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.hdl:"
 msgid "Do you really want to overwrite the remote branch?"
 msgstr "你真的想要覆盖远程分支吗？"
 
-msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.tle"
+msgctxt "dlgSgPushOverwriteRemoteBranchConfirm.tle:"
 msgid "Push"
 msgstr "推送"
 
@@ -7869,39 +7869,39 @@ msgctxt "dlgSgPushToAddRemote.btn:"
 msgid "Add Remote"
 msgstr ""
 
-msgctxt "dlgSgPushToAddRemote.fur"
+msgctxt "dlgSgPushToAddRemote.fur:"
 msgid "There is no remote repository configured yet. To push, you first need to configure that. After having added the remote, invoke Push again."
 msgstr ""
 
-msgctxt "dlgSgPushToAddRemote.hdl"
+msgctxt "dlgSgPushToAddRemote.hdl:"
 msgid "Do you want to add a remote?"
 msgstr ""
 
-msgctxt "dlgSgPushToAddRemote.tle"
+msgctxt "dlgSgPushToAddRemote.tle:"
 msgid "Push To"
 msgstr ""
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.fur"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.fur:"
 msgid "There is no other Git-remote to which branches of the selected remote could be pushed."
 msgstr ""
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.hdl"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.hdl:"
 msgid "No more Git remote found."
 msgstr ""
 
-msgctxt "dlgSgPushToNoMoreGitRemoteFound.tle"
+msgctxt "dlgSgPushToNoMoreGitRemoteFound.tle:"
 msgid "Push To"
 msgstr ""
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.fur"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.fur:"
 msgid "You can only push tags or local branches."
 msgstr "您只能推送标签或本地分支。"
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.hdl"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.hdl:"
 msgid "No tags or local branches to push."
 msgstr "没有标签或本地分支推送。"
 
-msgctxt "dlgSgPushToNoTagsOrLocalBranches.tle"
+msgctxt "dlgSgPushToNoTagsOrLocalBranches.tle:"
 msgid "Push To"
 msgstr "推送到"
 
@@ -7945,7 +7945,7 @@ msgctxt "dlgSgPushToRef.hdl:"
 msgid "Push local commits to a remote repository"
 msgstr ""
 
-msgctxt "dlgSgPushToRef.inf"
+msgctxt "dlgSgPushToRef.inf:"
 msgid "Select the target repository where to push the ref\\(s\\)."
 msgstr "选择目标仓库，在其中推送引用。"
 
@@ -7957,7 +7957,7 @@ msgctxt "dlgSgPushToRef.rbt:"
 msgid "Tracked or matching branch"
 msgstr "跟踪或匹配分支"
 
-msgctxt "dlgSgPushToRef.tle"
+msgctxt "dlgSgPushToRef.tle:"
 msgid "Push To"
 msgstr "推送到"
 
@@ -7977,15 +7977,15 @@ msgctxt "dlgSgPushToRemote.edt:"
 msgid "Target Repository"
 msgstr "目标仓库"
 
-msgctxt "dlgSgPushToRemote.hdl"
+msgctxt "dlgSgPushToRemote.hdl:"
 msgid "Push '$1' branches to another remote"
 msgstr "将 '$1' 分支推送到其他远程"
 
-msgctxt "dlgSgPushToRemote.inf"
+msgctxt "dlgSgPushToRemote.inf:"
 msgid "All branches of '$1' \\(as locally represented by the corresponding remote branches\\) will be pushed to the target repository."
 msgstr "'$1' 的所有分支（在本地由相应的远程分支代表）将被推送到目标仓库."
 
-msgctxt "dlgSgPushToRemote.tle"
+msgctxt "dlgSgPushToRemote.tle:"
 msgid "Push To"
 msgstr "推送到"
 
@@ -7993,15 +7993,15 @@ msgctxt "dlgSgPushToRemoteRemoveTargetBranches.btn:"
 msgid "Remove"
 msgstr "删除"
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.fur"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.fur:"
 msgid "Removed branches and their commits in the target remote which will be lost afterwards."
 msgstr "删除之后会丢失的目标远程中的分支和它们的提交."
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.hdl"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.hdl:"
 msgid "Do you really want to remove target remote branches?"
 msgstr "确定要删除远程分支么?"
 
-msgctxt "dlgSgPushToRemoteRemoveTargetBranches.tle"
+msgctxt "dlgSgPushToRemoteRemoveTargetBranches.tle:"
 msgid "Push To"
 msgstr "推送到"
 
@@ -8009,19 +8009,19 @@ msgctxt "dlgSgPushToRemoteResetTargetBranches.btn:"
 msgid "Force Push"
 msgstr "强制推送"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.chk"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.fur"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.fur:"
 msgid "Forcing push will overwrite branches and their commits in the target remote which will be lost afterwards."
 msgstr "强制推送将覆盖目标远程中的分支及其提交，这些分支及其提交随后将丢失。"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.hdl"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.hdl:"
 msgid "Do you really want to reset the target remote branches?"
 msgstr "是否确定要重置目标远程分支？"
 
-msgctxt "dlgSgPushToRemoteResetTargetBranches.tle"
+msgctxt "dlgSgPushToRemoteResetTargetBranches.tle:"
 msgid "Push To"
 msgstr "推送到"
 
@@ -8033,15 +8033,15 @@ msgctxt "dlgSgPushTrackingConfigureSingle.btn:"
 msgid "Skip"
 msgstr "跳过"
 
-msgctxt "dlgSgPushTrackingConfigureSingle.fur"
+msgctxt "dlgSgPushTrackingConfigureSingle.fur:"
 msgid "For your current branch tracking \\(its corresponding remote branch\\) has not been configured yet. Configuring tracking will keep your local branches in sync with the remote branches."
 msgstr "对于当前分支跟踪 \\(其对应的远程分支\\) 尚未配置。配置跟踪将使本地分支与远程分支保持同步。"
 
-msgctxt "dlgSgPushTrackingConfigureSingle.hdl"
+msgctxt "dlgSgPushTrackingConfigureSingle.hdl:"
 msgid "Do you want to configure tracking for '$1' branch?"
 msgstr "是否要为 “$1” 分支配置跟踪？"
 
-msgctxt "dlgSgPushTrackingConfigureSingle.tle"
+msgctxt "dlgSgPushTrackingConfigureSingle.tle:"
 msgid "Push"
 msgstr "推送"
 
@@ -8053,15 +8053,15 @@ msgctxt "dlgSgRebase.btn:"
 msgid "Rebase HEAD to"
 msgstr "将 HEAD 变基至"
 
-msgctxt "dlgSgRebase.hdl"
+msgctxt "dlgSgRebase.hdl:"
 msgid "Rebase HEAD to"
 msgstr "将 HEAD 变基至"
 
-msgctxt "dlgSgRebase.inf"
+msgctxt "dlgSgRebase.inf:"
 msgid "Select the commit to which the HEAD commits should be rebased."
 msgstr "选择应变基 HEAD 的提交。"
 
-msgctxt "dlgSgRebase.tle"
+msgctxt "dlgSgRebase.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -8069,15 +8069,15 @@ msgctxt "dlgSgRebaseConfirmUnreachable.btn:"
 msgid "Rebase"
 msgstr "变基"
 
-msgctxt "dlgSgRebaseConfirmUnreachable.fur"
+msgctxt "dlgSgRebaseConfirmUnreachable.fur:"
 msgid "You only might be able to access this commit using the 'Recyclable Commits' option of the Branches view."
 msgstr "你只能使用分支视图中的'可循环提交'选项才能访问该提交."
 
-msgctxt "dlgSgRebaseConfirmUnreachable.hdl"
+msgctxt "dlgSgRebaseConfirmUnreachable.hdl:"
 msgid "The Commit $1 would become unreachable by refs."
 msgstr "该提交 $1 将会被引用变为不可访问."
 
-msgctxt "dlgSgRebaseConfirmUnreachable.tle"
+msgctxt "dlgSgRebaseConfirmUnreachable.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -8085,19 +8085,19 @@ msgctxt "dlgSgRebaseContinueAfterSplittingCommit.btn:"
 msgid "Continue"
 msgstr "继续"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.chk:"
 msgid "Don't show again"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.fur:"
 msgid "The splitting of commit $1 still is in progress and all changes of this commit have been applied."
 msgstr "提交 $1 的拆分仍在进行中，并且已应用此提交的所有变更。"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.hdl"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.hdl:"
 msgid "Do you want to continue after splitting the commit?"
 msgstr "拆分提交后是否继续？"
 
-msgctxt "dlgSgRebaseContinueAfterSplittingCommit.tle"
+msgctxt "dlgSgRebaseContinueAfterSplittingCommit.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -8105,31 +8105,31 @@ msgctxt "dlgSgRebaseContinueConfirm.btn:"
 msgid "Continue Rebase"
 msgstr "继续变基"
 
-msgctxt "dlgSgRebaseContinueConfirm.chk"
+msgctxt "dlgSgRebaseContinueConfirm.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgRebaseContinueConfirm.fur"
+msgctxt "dlgSgRebaseContinueConfirm.fur:"
 msgid "Continue the rebase operation after having resolved all conflicts."
 msgstr "在解决了所有冲突后继续执行变基操作。"
 
-msgctxt "dlgSgRebaseContinueConfirm.hdl"
+msgctxt "dlgSgRebaseContinueConfirm.hdl:"
 msgid "Do you want to continue the rebase?"
 msgstr "您想继续变基吗？"
 
-msgctxt "dlgSgRebaseContinueConfirm.tle"
+msgctxt "dlgSgRebaseContinueConfirm.tle:"
 msgid "Rebase"
 msgstr "变基"
 
-msgctxt "dlgSgRebaseContinueConflicts.fur"
+msgctxt "dlgSgRebaseContinueConflicts.fur:"
 msgid "Please resolve all conflicts before continuing the rebase."
 msgstr "请在继续变基操作之前解决所有冲突."
 
-msgctxt "dlgSgRebaseContinueConflicts.hdl"
+msgctxt "dlgSgRebaseContinueConflicts.hdl:"
 msgid "Can't continue rebase with conflicts."
 msgstr "无法在存在冲突的情况下继续变基."
 
-msgctxt "dlgSgRebaseContinueConflicts.tle"
+msgctxt "dlgSgRebaseContinueConflicts.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -8137,19 +8137,19 @@ msgctxt "dlgSgRebaseContinueNothingToCommitContinue.btn:"
 msgid "Continue Rebase"
 msgstr "继续变基"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.chk"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.fur:"
 msgid "The repository is in 'rebasing' state and there is nothing to commit, so you may just continue the Rebase."
 msgstr "仓库处于'变基'状态且没有内容可提交, 因此您可以直接继续变基操作."
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.hdl:"
 msgid "Do you want to continue the rebase?"
 msgstr "您想继续变基吗？"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitContinue.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -8157,15 +8157,15 @@ msgctxt "dlgSgRebaseContinueNothingToCommitSkip.btn:"
 msgid "Skip Commit"
 msgstr "跳过提交"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.fur"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.fur:"
 msgid "The repository is in 'rebasing' state, but there is nothing to commit, so you may just skip this rebased commit."
 msgstr "仓库处于变基状态，但没有提交任何内容，因此您可以跳过此重新提交的提交。"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.hdl"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.hdl:"
 msgid "Do you want to skip this rebased commit?"
 msgstr "您想跳过这个变基提交吗？"
 
-msgctxt "dlgSgRebaseContinueNothingToCommitSkip.tle"
+msgctxt "dlgSgRebaseContinueNothingToCommitSkip.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -8177,15 +8177,15 @@ msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.btn:"
 msgid "Preserve"
 msgstr "保留"
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.fur"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.fur:"
 msgid "Your working tree contains untracked files. You may either choose to preserve them in the working tree or include them for the rebased commit."
 msgstr "您的工作区包含未跟踪的文件。 您可以选择在工作区中保留它们，也可以将它们包含在已重新提交的提交中。"
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.hdl"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.hdl:"
 msgid "Do you want to preserve untracked files in your working tree?"
 msgstr "是否要保留工作区中未跟踪的文件？"
 
-msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.tle"
+msgctxt "dlgSgRebaseContinuePreserveUntrackedFiles.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -8193,15 +8193,15 @@ msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.fur"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.fur:"
 msgid "Rebase Continue will store all working tree changes in the commit."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.hdl"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.hdl:"
 msgid "Do you want the working tree changes to be part of the new commit?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.tle"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTree.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8209,15 +8209,15 @@ msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.btn:"
 msgid "Continue"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.fur"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.fur:"
 msgid "Rebase Continue will store both, staged changes and the working tree changes, in the new commit!\\n\\nIf the staged changes should go to a seperate commit, first commit them, and then invoke Continue again."
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.hdl"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.hdl:"
 msgid "Do you want the working tree changes to be applied, too?"
 msgstr ""
 
-msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.tle"
+msgctxt "dlgSgRebaseContinueWithDirtyWorkingTreeAndIndex.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8229,31 +8229,31 @@ msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.btn:"
 msgid "Put Changes into Index"
 msgstr "将变更放入索引"
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.fur:"
 msgid "The splitting of commit $1 still is in progress, but not all changes of this commit have been applied.\\n\\nIf this is intentional, you can continue. Otherwise, you should click 'Put Changes into Index' and review your changes."
 msgstr "提交 $1 的拆分仍在进行中，但并未应用此提交的所有变更。\\n\\n如果这是故意的，您可以继续。否则，您应单击 “将变更置于索引中” 并查看变更。"
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.hdl"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.hdl:"
 msgid "Do you want to continue splitting the commit without applying all changes?"
 msgstr "是否继续拆分提交而不应用所有变更？"
 
-msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle"
+msgctxt "dlgSgRebaseContinueWithoutApplyingAllChanges.tle:"
 msgid "Rebase"
 msgstr "变基"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.fur:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) onto the selected commit."
 msgstr "这将把工作区分支 “$1” \\(HEAD\\) 的所有提交应用到所选提交。"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBc.hdl:"
 msgid "Do you want to rebase '$1' onto the selected commit?"
 msgstr "是否要将 “$1” 变基至所选提交？"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.fur:"
 msgid "This will apply all commits from the working tree branch '$1' \\(HEAD\\) to '$2'."
 msgstr "这将应用从工作区分支 “$1” \\(HEAD\\) 到 “$2” 的所有提交。"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl"
+msgctxt "dlgSgRebaseHeadToCommitConfirmBr.hdl:"
 msgid "Do you want to rebase '$1' to '$2'?"
 msgstr "是否要将 “$1” 变基至 “$2”？"
 
@@ -8265,7 +8265,7 @@ msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).btn:"
 msgid "Rebase Interactively"
 msgstr "以交互方式变基"
 
-msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).tle"
+msgctxt "dlgSgRebaseHeadToCommitConfirm(Br|Bc|Hr|Hc).tle:"
 msgid "Rebase HEAD to Selected Commit"
 msgstr "将 HEAD 变基至选定的提交"
 
@@ -8309,11 +8309,11 @@ msgctxt "dlgSgRebaseInteractive.col:"
 msgid "Message"
 msgstr "消息"
 
-msgctxt "dlgSgRebaseInteractive.hdl"
+msgctxt "dlgSgRebaseInteractive.hdl:"
 msgid "Rewrite History"
 msgstr "重写历史"
 
-msgctxt "dlgSgRebaseInteractive.inf"
+msgctxt "dlgSgRebaseInteractive.inf:"
 msgid "Reorder or squash commits according to your needs."
 msgstr "您可以根据需要重新排序或取消提交。"
 
@@ -8329,19 +8329,19 @@ msgctxt "dlgSgRebaseInteractive.mni:"
 msgid "To Top Commit"
 msgstr "转到顶部提交"
 
-msgctxt "dlgSgRebaseInteractive.tle"
+msgctxt "dlgSgRebaseInteractive.tle:"
 msgid "Rebase Interactive"
 msgstr "交互式变基"
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.fur"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.fur:"
 msgid "You need to select the first commit in the current branch's history that should be modified. All commits between this commit and HEAD must have exactly one parent."
 msgstr "你需要选择当前分支历史中想要被修改的第1个提交. 在此提交与 HEAD 中间的提交必须是1个父系."
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.hdl"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.hdl:"
 msgid "Changing the initial commit is not supported by the interactive rebase."
 msgstr "交互式变基不支持变更初始提交."
 
-msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.tle"
+msgctxt "dlgSgRebaseInteractiveInitialCommitNotSupported.tle:"
 msgid "Rebase Interactive"
 msgstr "交互式变基"
 
@@ -8353,15 +8353,15 @@ msgctxt "dlgSgRebaseInteractiveMessage.edt:"
 msgid "New Message"
 msgstr ""
 
-msgctxt "dlgSgRebaseInteractiveMessage.hdl"
+msgctxt "dlgSgRebaseInteractiveMessage.hdl:"
 msgid "Edit commit message"
 msgstr "编辑提交消息"
 
-msgctxt "dlgSgRebaseInteractiveMessage.inf"
+msgctxt "dlgSgRebaseInteractiveMessage.inf:"
 msgid "Provide the new message for the commit."
 msgstr "提供新的提交消息."
 
-msgctxt "dlgSgRebaseInteractiveMessage.tle"
+msgctxt "dlgSgRebaseInteractiveMessage.tle:"
 msgid "Edit Message"
 msgstr "编辑消息"
 
@@ -8369,39 +8369,39 @@ msgctxt "dlgSgRebaseInteractiveRemoveCommit.btn:"
 msgid "Remove"
 msgstr "删除"
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.fur:"
 msgid "It might become hard or impossible to recover the commit again."
 msgstr "再次恢复提交可能变得困难或不可能。"
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.hdl:"
 msgid "Do you want to remove the selected commit $1?"
 msgstr "您确定要删除所选的提交 $1 吗？"
 
-msgctxt "dlgSgRebaseInteractiveRemoveCommit.tle"
+msgctxt "dlgSgRebaseInteractiveRemoveCommit.tle:"
 msgid "Remove Commit"
 msgstr "删除提交"
 
-msgctxt "dlgSgRebaseNoop.fur"
+msgctxt "dlgSgRebaseNoop.fur:"
 msgid "Rebasing a commit onto itself is technically allowed by Git but it's a no-op and will not give a new commit nor any other meaningful changes."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoop.hdl"
+msgctxt "dlgSgRebaseNoop.hdl:"
 msgid "There is nothing to rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoop.tle"
+msgctxt "dlgSgRebaseNoop.tle:"
 msgid "Merge"
 msgstr ""
 
-msgctxt "dlgSgRebaseNoopSelf.fur"
+msgctxt "dlgSgRebaseNoopSelf.fur:"
 msgid "Rebasing a commit onto itself is allowed by Git but will not create a new commit or any meaningful changes."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoopSelf.hdl"
+msgctxt "dlgSgRebaseNoopSelf.hdl:"
 msgid "There is nothing to rebase."
 msgstr ""
 
-msgctxt "dlgSgRebaseNoopSelf.tle"
+msgctxt "dlgSgRebaseNoopSelf.tle:"
 msgid "Rebase"
 msgstr ""
 
@@ -8413,15 +8413,15 @@ msgctxt "dlgSgRebaseTagCommit.btn:"
 msgid "Skip Tag"
 msgstr "跳过标签"
 
-msgctxt "dlgSgRebaseTagCommit.fur"
+msgctxt "dlgSgRebaseTagCommit.fur:"
 msgid "After the rebase, the remaining commit won't be reachable anymore."
 msgstr "在变基之后，剩余的提交将不再可用。"
 
-msgctxt "dlgSgRebaseTagCommit.hdl"
+msgctxt "dlgSgRebaseTagCommit.hdl:"
 msgid "Should commit $1 be tagged?"
 msgstr "应该标记提交 $1 吗？"
 
-msgctxt "dlgSgRebaseTagCommit.tle"
+msgctxt "dlgSgRebaseTagCommit.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -8429,15 +8429,15 @@ msgctxt "dlgSgRebasingAbortConfirm.btn:"
 msgid "Abort Rebase"
 msgstr "中止变基"
 
-msgctxt "dlgSgRebasingAbortConfirm.fur"
+msgctxt "dlgSgRebasingAbortConfirm.fur:"
 msgid "Your working tree is in 'rebasing' state. You may abort rebasing; if you just want to skip the current patch, use Branch \\| Rebase \\| Rebase HEAD To instead.\\n\\nAborting will clean any local modification \\(by invoking 'git reset --hard'\\)!"
 msgstr "您的工作区处于变基状态。你可以放弃变基; 如果您只想跳过当前的补丁，请使用 分支 \\| 变基 \\| 将 HEAD 变基至。\\n\\n中止将清除任何本地修改 \\(通过调用 “git reset --hard”\\)！"
 
-msgctxt "dlgSgRebasingAbortConfirm.hdl"
+msgctxt "dlgSgRebasingAbortConfirm.hdl:"
 msgid "Do you want to abort the rebasing?"
 msgstr "你想要中止变基吗?"
 
-msgctxt "dlgSgRebasingAbortConfirm.tle"
+msgctxt "dlgSgRebasingAbortConfirm.tle:"
 msgid "Rebase"
 msgstr "变基"
 
@@ -8449,11 +8449,11 @@ msgctxt "dlgSgRecursiveStage.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgRecursiveStage.hdl"
+msgctxt "dlgSgRecursiveStage.hdl:"
 msgid "Save working tree changes in the Index for later commit"
 msgstr "保存索引中的工作区变更以供以后提交"
 
-msgctxt "dlgSgRecursiveStage.inf"
+msgctxt "dlgSgRecursiveStage.inf:"
 msgid "Select the files to stage to the Index."
 msgstr "将选中的文件暂存到索引"
 
@@ -8469,7 +8469,7 @@ msgctxt "dlgSgRecursiveStage.mni:"
 msgid "Toggle"
 msgstr "切换"
 
-msgctxt "dlgSgRecursiveStage.tle"
+msgctxt "dlgSgRecursiveStage.tle:"
 msgid "Stage"
 msgstr "暂存"
 
@@ -8481,15 +8481,15 @@ msgctxt "dlgSgRecursiveUnstage.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgRecursiveUnstage.hdl"
+msgctxt "dlgSgRecursiveUnstage.hdl:"
 msgid "Revert staged changes from the Index to the working tree"
 msgstr "将暂存变更从索引还原到工作区"
 
-msgctxt "dlgSgRecursiveUnstage.inf"
+msgctxt "dlgSgRecursiveUnstage.inf:"
 msgid "Select the files to unstage from the Index."
 msgstr "从索引中选择要取消暂存的文件。"
 
-msgctxt "dlgSgRecursiveUnstage.tle"
+msgctxt "dlgSgRecursiveUnstage.tle:"
 msgid "Unstage"
 msgstr "取消暂存"
 
@@ -8505,15 +8505,15 @@ msgctxt "dlgSgRemoteDeleteConfirm.btn:"
 msgid "Delete"
 msgstr "删除"
 
-msgctxt "dlgSgRemoteDeleteConfirm.fur"
+msgctxt "dlgSgRemoteDeleteConfirm.fur:"
 msgid "This will just delete the link to the remote repository."
 msgstr "这只会删除到远程仓库的链接。"
 
-msgctxt "dlgSgRemoteDeleteConfirm.hdl"
+msgctxt "dlgSgRemoteDeleteConfirm.hdl:"
 msgid "Do you want to delete the remote repository '$1'?"
 msgstr "是否要删除远程仓库 “$1”？"
 
-msgctxt "dlgSgRemoteDeleteConfirm.tle"
+msgctxt "dlgSgRemoteDeleteConfirm.tle:"
 msgid "Delete Remote Repository"
 msgstr "删除远程仓库"
 
@@ -8525,27 +8525,27 @@ msgctxt "dlgSgRemoteFetchMore.col:"
 msgid "Branch"
 msgstr "分支"
 
-msgctxt "dlgSgRemoteFetchMore.hdl"
+msgctxt "dlgSgRemoteFetchMore.hdl:"
 msgid "Fetch remote branches"
 msgstr "获取远程分支"
 
-msgctxt "dlgSgRemoteFetchMore.inf"
+msgctxt "dlgSgRemoteFetchMore.inf:"
 msgid "Select the branches to fetch from the remote repository."
 msgstr "选择要从远程仓库获取的分支。"
 
-msgctxt "dlgSgRemoteFetchMore.tle"
+msgctxt "dlgSgRemoteFetchMore.tle:"
 msgid "Fetch More"
 msgstr "获取更多"
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.fur"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.fur:"
 msgid "All branches which are present in the remote repository are already locally present as well."
 msgstr "远程仓库中存在的所有分支也都已在本地存在。"
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.hdl"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.hdl:"
 msgid "There are no more remote branches to fetch."
 msgstr "没有更多的远程分支。"
 
-msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.tle"
+msgctxt "dlgSgRemoteFetchMoreNoMoreBranches.tle:"
 msgid "Fetch More"
 msgstr "获取更多"
 
@@ -8557,15 +8557,15 @@ msgctxt "dlgSgRemoteProperties.edt:"
 msgid "URL or Path"
 msgstr "URL 或路径"
 
-msgctxt "dlgSgRemoteProperties.hdl"
+msgctxt "dlgSgRemoteProperties.hdl:"
 msgid "Configure remote properties"
 msgstr "配置远程属性"
 
-msgctxt "dlgSgRemoteProperties.inf"
+msgctxt "dlgSgRemoteProperties.inf:"
 msgid "Change the URL and other properties for the remote."
 msgstr "更改远程服务器的 URL 和其他属性。"
 
-msgctxt "dlgSgRemoteProperties.tle"
+msgctxt "dlgSgRemoteProperties.tle:"
 msgid "Remote Properties"
 msgstr "远程属性"
 
@@ -8573,15 +8573,15 @@ msgctxt "dlgSgRemoteSelect.edt:"
 msgid "Remote"
 msgstr "远程"
 
-msgctxt "dlgSgRemoteSelect.hdl"
+msgctxt "dlgSgRemoteSelect.hdl:"
 msgid "Initialize remote review database"
 msgstr "初始化远程审阅数据库"
 
-msgctxt "dlgSgRemoteSelect.inf"
+msgctxt "dlgSgRemoteSelect.inf:"
 msgid "Select the remote repository for which you want to initialize the review database."
 msgstr "选择要初始化审阅数据库的远程仓库。"
 
-msgctxt "dlgSgRemoteSelect.tle"
+msgctxt "dlgSgRemoteSelect.tle:"
 msgid "Initialize Remote"
 msgstr "初始化远程"
 
@@ -8597,15 +8597,15 @@ msgctxt "dlgSgRemoteSetDepth.err:"
 msgid "Please enter a valid commit count."
 msgstr ""
 
-msgctxt "dlgSgRemoteSetDepth.hdl"
+msgctxt "dlgSgRemoteSetDepth.hdl:"
 msgid "Set repository depth"
 msgstr "设置仓库深度"
 
-msgctxt "dlgSgRemoteSetDepth.inf"
+msgctxt "dlgSgRemoteSetDepth.inf:"
 msgid "Use a large number \\(e.g. 100000\\) to set an unlimited depth."
 msgstr "使用大数 \\(例如 100000\\) 来设置无限深度。"
 
-msgctxt "dlgSgRemoteSetDepth.tle"
+msgctxt "dlgSgRemoteSetDepth.tle:"
 msgid "Set Depth"
 msgstr "设置深度"
 
@@ -8625,11 +8625,11 @@ msgctxt "dlgSgRemotesAdd.edt:"
 msgid "URL or Path"
 msgstr "URL 或路径"
 
-msgctxt "dlgSgRemotesAdd.hdl"
+msgctxt "dlgSgRemotesAdd.hdl:"
 msgid "Add a remote repository"
 msgstr "添加远程仓库"
 
-msgctxt "dlgSgRemotesAdd.inf"
+msgctxt "dlgSgRemotesAdd.inf:"
 msgid "Enter the URL and a short name for the remote repository."
 msgstr "输入远程仓库的 URL 和短名称。"
 
@@ -8665,19 +8665,19 @@ msgctxt "dlgSgRemotesAdd.mni:"
 msgid "Select Local Repository"
 msgstr "选择本地仓库"
 
-msgctxt "dlgSgRemotesAdd.tle"
+msgctxt "dlgSgRemotesAdd.tle:"
 msgid "Add Remote Repository"
 msgstr "添加远程仓库"
 
-msgctxt "dlgSgRemotesNoRemoteDetected.fur"
+msgctxt "dlgSgRemotesNoRemoteDetected.fur:"
 msgid "To perform the operation the repository configuration for $1 must contain one uniquely determined remote."
 msgstr "要执行该操作，$1 仓库配置必须包含一个唯一确定的远程地址."
 
-msgctxt "dlgSgRemotesNoRemoteDetected.hdl"
+msgctxt "dlgSgRemotesNoRemoteDetected.hdl:"
 msgid "No remote detected."
 msgstr "未检测到远程."
 
-msgctxt "dlgSgRemotesNoRemoteDetected.tle"
+msgctxt "dlgSgRemotesNoRemoteDetected.tle:"
 msgid "Push Up To"
 msgstr "推送到"
 
@@ -8697,15 +8697,15 @@ msgctxt "dlgSgRemove.col:"
 msgid "Name"
 msgstr "名称"
 
-msgctxt "dlgSgRemove.hdl"
+msgctxt "dlgSgRemove.hdl:"
 msgid "Remove files from the repository"
 msgstr "从仓库中删除文件"
 
-msgctxt "dlgSgRemove.inf"
+msgctxt "dlgSgRemove.inf:"
 msgid "Select the files you want to remove from the repository or working tree \\(stopped from tracking\\)."
 msgstr "选择要从仓库或工作区中删除的文件 \\(停止\\跟踪\\)。"
 
-msgctxt "dlgSgRemove.tle"
+msgctxt "dlgSgRemove.tle:"
 msgid "Remove"
 msgstr "移除"
 
@@ -8717,15 +8717,15 @@ msgctxt "dlgSgRenameBranch.edt:"
 msgid "Name"
 msgstr "名称"
 
-msgctxt "dlgSgRenameBranch.hdl"
+msgctxt "dlgSgRenameBranch.hdl:"
 msgid "Rename branch"
 msgstr "重命名分支"
 
-msgctxt "dlgSgRenameBranch.inf"
+msgctxt "dlgSgRenameBranch.inf:"
 msgid "Enter the new name for the branch '$1'."
 msgstr "输入分支 “$1” 的新名称。"
 
-msgctxt "dlgSgRenameBranch.tle"
+msgctxt "dlgSgRenameBranch.tle:"
 msgid "Rename"
 msgstr "重命名"
 
@@ -8737,15 +8737,15 @@ msgctxt "dlgSgRenameFile.edt:"
 msgid "Path"
 msgstr "路径"
 
-msgctxt "dlgSgRenameFile.hdl"
+msgctxt "dlgSgRenameFile.hdl:"
 msgid "Move or Rename the file"
 msgstr "移动或重命名文件"
 
-msgctxt "dlgSgRenameFile.inf"
+msgctxt "dlgSgRenameFile.inf:"
 msgid "Enter the new path and name of the file."
 msgstr "输入文件的新路径和名称。"
 
-msgctxt "dlgSgRenameFile.tle"
+msgctxt "dlgSgRenameFile.tle:"
 msgid "Move or Rename"
 msgstr "移动或重命名"
 
@@ -8757,15 +8757,15 @@ msgctxt "dlgSgRenameRemote.edt:"
 msgid "Name"
 msgstr "名称"
 
-msgctxt "dlgSgRenameRemote.hdl"
+msgctxt "dlgSgRenameRemote.hdl:"
 msgid "Change the name of an existing remote"
 msgstr "远程仓库重命名"
 
-msgctxt "dlgSgRenameRemote.inf"
+msgctxt "dlgSgRenameRemote.inf:"
 msgid "Provide the new name of the selected remote."
 msgstr "为选择的远程提供新的名称"
 
-msgctxt "dlgSgRenameRemote.tle"
+msgctxt "dlgSgRenameRemote.tle:"
 msgid "Rename Remote Repository"
 msgstr "远程仓库重命名"
 
@@ -8777,15 +8777,15 @@ msgctxt "dlgSgRenameRepository.edt:"
 msgid "Name"
 msgstr "名称"
 
-msgctxt "dlgSgRenameRepository.hdl"
+msgctxt "dlgSgRenameRepository.hdl:"
 msgid "Rename repository"
 msgstr "重命名仓库"
 
-msgctxt "dlgSgRenameRepository.inf"
+msgctxt "dlgSgRenameRepository.inf:"
 msgid "Provide the new name for the repository. The repository directory will not be renamed."
 msgstr "为仓库提供新的名称。仓库的目录不会被重命名。"
 
-msgctxt "dlgSgRenameRepository.tle"
+msgctxt "dlgSgRenameRepository.tle:"
 msgid "Rename"
 msgstr "重命名"
 
@@ -8805,11 +8805,11 @@ msgctxt "dlgSgRepositoriesSearch.edt:"
 msgid "Search In"
 msgstr "搜索中"
 
-msgctxt "dlgSgRepositoriesSearch.hdl"
+msgctxt "dlgSgRepositoriesSearch.hdl:"
 msgid "Search existing local repositories"
 msgstr "搜索现有本地仓库"
 
-msgctxt "dlgSgRepositoriesSearch.inf"
+msgctxt "dlgSgRepositoriesSearch.inf:"
 msgid "Select a root directory where the search should start and click 'Start Search'."
 msgstr "选择一个根目录作为搜索的起点, 并点击“开始搜索”."
 
@@ -8845,7 +8845,7 @@ msgctxt "dlgSgRepositoriesSearch.mni:"
 msgid "Toggle"
 msgstr "切换"
 
-msgctxt "dlgSgRepositoriesSearch.tle"
+msgctxt "dlgSgRepositoriesSearch.tle:"
 msgid "Search for Repositories"
 msgstr "搜索仓库"
 
@@ -8857,15 +8857,15 @@ msgctxt "dlgSgRepositoryAddGroup.edt:"
 msgid "Group Name"
 msgstr "分组名字"
 
-msgctxt "dlgSgRepositoryAddGroup.hdl"
+msgctxt "dlgSgRepositoryAddGroup.hdl:"
 msgid "Enter the group name"
 msgstr "输入分组名称"
 
-msgctxt "dlgSgRepositoryAddGroup.inf"
+msgctxt "dlgSgRepositoryAddGroup.inf:"
 msgid "After having created the group, you can move repositories inside it."
 msgstr "创建组后，您可以在其中移动仓库。"
 
-msgctxt "dlgSgRepositoryAddGroup.tle"
+msgctxt "dlgSgRepositoryAddGroup.tle:"
 msgid "Add Group"
 msgstr "创建分组"
 
@@ -8877,15 +8877,15 @@ msgctxt "dlgSgRepositoryClose.btn:"
 msgid "Force Close"
 msgstr "强制关闭"
 
-msgctxt "dlgSgRepositoryClose.fur"
+msgctxt "dlgSgRepositoryClose.fur:"
 msgid "Note that currently running Git processes might not be interrupted."
 msgstr "请注意，当前运行的 Git 进程可能不会被中断。"
 
-msgctxt "dlgSgRepositoryClose.hdl"
+msgctxt "dlgSgRepositoryClose.hdl:"
 msgid "Do you really want to close now?"
 msgstr "你真的想现在关闭吗？"
 
-msgctxt "dlgSgRepositoryClose.tle"
+msgctxt "dlgSgRepositoryClose.tle:"
 msgid "Close"
 msgstr "关闭"
 
@@ -8893,19 +8893,19 @@ msgctxt "dlgSgRepositoryFrameCloseWithoutPush.btn:"
 msgid "Close Now"
 msgstr "立即关闭"
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.chk"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.fur"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.fur:"
 msgid "You have pushable commits. Maybe you want to push them before closing this window."
 msgstr "你有可推送的提交。也许你想在关闭这个窗口之前推它们。"
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.hdl"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.hdl:"
 msgid "Do you want to close without having pushed commits?"
 msgstr "你确定在没有推送提交的情况下关闭吗？"
 
-msgctxt "dlgSgRepositoryFrameCloseWithoutPush.tle"
+msgctxt "dlgSgRepositoryFrameCloseWithoutPush.tle:"
 msgid "Close"
 msgstr "关闭"
 
@@ -8913,91 +8913,91 @@ msgctxt "dlgSgRepositoryOpen.btn:"
 msgid "Remove"
 msgstr "删除"
 
-msgctxt "dlgSgRepositoryOpen.fur"
+msgctxt "dlgSgRepositoryOpen.fur:"
 msgid "If it is relocated, remove it and add its new location."
 msgstr "如果重新定位，请将其删除并添加其新位置。"
 
-msgctxt "dlgSgRepositoryOpen.hdl"
+msgctxt "dlgSgRepositoryOpen.hdl:"
 msgid "Do you want to remove the missing repository '$1'?"
 msgstr "你想删除丢失的仓库 '$1' 吗？"
 
-msgctxt "dlgSgRepositoryOpen.tle"
+msgctxt "dlgSgRepositoryOpen.tle:"
 msgid "Repository Opening"
 msgstr "仓库打开"
 
-msgctxt "dlgSgRepositoryRemoveFailed1.fur"
+msgctxt "dlgSgRepositoryRemoveFailed1.fur:"
 msgid "This could happen if the repository is open in another window or currently commands are executed."
 msgstr "如果仓库在另一个窗口中打开或当前正在执行命令, 可能会发生这种情况."
 
-msgctxt "dlgSgRepositoryRemoveFailed1.hdl"
+msgctxt "dlgSgRepositoryRemoveFailed1.hdl:"
 msgid "The repository '$1' could not be removed."
 msgstr "无法移除仓库 '$1'"
 
-msgctxt "dlgSgRepositoryRemoveFailed1.tle"
+msgctxt "dlgSgRepositoryRemoveFailed1.tle:"
 msgid "Remove"
 msgstr "移除"
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "已删除组中的仓库将从该组中移出。"
 
-msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiGroup.hdl:"
 msgid "Do you want to remove $1 groups?"
 msgstr "您确定要删除 $1 组吗？"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiRepo.hdl:"
 msgid "Do you want to remove $1 repositories?"
 msgstr "您确定要删除 $1 仓库吗？"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiRepoMultiGroup.hdl:"
 msgid "Do you want to remove $1 repositories and $2 groups?"
 msgstr "您确定要删除 $1 仓库和 $2 组吗？"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveMultiRepoSingleGroup.hdl:"
 msgid "Do you want to remove $1 repositories and the group \"$2\"?"
 msgstr "您确定要删除 $1 仓库和组 “$2” 吗？"
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.fur:"
 msgid "Repositories inside a removed group will be moved out of the group."
 msgstr "已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleGroup.hdl:"
 msgid "Do you want to remove the group \"$1\"?"
 msgstr "您确定要删除 “$1” 组吗？"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleRepo.hdl:"
 msgid "Do you want to remove the repository \"$1\"?"
 msgstr "您确定要删除 $1 的仓库吗？"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleRepoMultiGroup.hdl:"
 msgid "Do you want to remove the repository \"$1\" and $2 groups?"
 msgstr "您确定要删除仓库 “$1” 和 $2 组吗？"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.fur:"
 msgid "This will keep the repositories on disk, but just let SmartGit forget about them. Repositories inside a removed group will be moved out of the group."
 msgstr "这会将仓库保留在磁盘上，但只是让 SmartGit 忘记它们。已删除组中的仓库将移出组。"
 
-msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl"
+msgctxt "dlgSgRepositoryRemoveSingleRepoSingleGroup.hdl:"
 msgid "Do you want to remove the repository \"$1\" and the group \"$2\"?"
 msgstr "您确定要删除仓库 “$1” 和组 “$2” 吗？"
 
@@ -9073,11 +9073,11 @@ msgctxt "dlgSgRepositorySettings.err:"
 msgid "Please enter a valid, comma-separated list of regular expressions."
 msgstr "请输入有效的、以逗号分隔的正则表达式列表。"
 
-msgctxt "dlgSgRepositorySettings.hdl"
+msgctxt "dlgSgRepositorySettings.hdl:"
 msgid "Edit the repository settings"
 msgstr "编辑仓库设置"
 
-msgctxt "dlgSgRepositorySettings.inf"
+msgctxt "dlgSgRepositorySettings.inf:"
 msgid "Here you can edit the Git settings for the repository. The default settings can be found in the preferences."
 msgstr "在这里, 您可以编辑该仓库的 Git 设置. 默认设置可以在首选项中找到."
 
@@ -9113,7 +9113,7 @@ msgctxt "dlgSgRepositorySettings.tab:"
 msgid "User"
 msgstr "用户"
 
-msgctxt "dlgSgRepositorySettings.tle"
+msgctxt "dlgSgRepositorySettings.tle:"
 msgid "Repository Settings"
 msgstr "仓库设置"
 
@@ -9157,7 +9157,7 @@ msgctxt "dlgSgResetAdv.chk:"
 msgid "Thoroughly fix line-endings according to .gitattributes"
 msgstr "根据 .gitattributes 彻底修复行尾序列"
 
-msgctxt "dlgSgResetAdv.hdl"
+msgctxt "dlgSgResetAdv.hdl:"
 msgid "Reset to commit $1"
 msgstr "重置提交 $1"
 
@@ -9205,7 +9205,7 @@ msgctxt "dlgSgResetAdv.rbt:"
 msgid "Reset the Index but not the working tree - 'mixed'"
 msgstr "重置索引，但不重置工作区 - “--mixed”"
 
-msgctxt "dlgSgResetAdv.tle"
+msgctxt "dlgSgResetAdv.tle:"
 msgid "Reset"
 msgstr "重置"
 
@@ -9213,15 +9213,15 @@ msgctxt "dlgSgResetConfirm.btn:"
 msgid "Reset"
 msgstr "重置"
 
-msgctxt "dlgSgResetConfirm.fur"
+msgctxt "dlgSgResetConfirm.fur:"
 msgid "Current staged and local changes will be lost!"
 msgstr "当前暂存和本地变更将丢失！"
 
-msgctxt "dlgSgResetConfirm.hdl"
+msgctxt "dlgSgResetConfirm.hdl:"
 msgid "Do you want to reset the HEAD to commit $1?"
 msgstr "您确定要将 HEAD 重置为提交 $1 吗？"
 
-msgctxt "dlgSgResetConfirm.tle"
+msgctxt "dlgSgResetConfirm.tle:"
 msgid "Reset"
 msgstr "重置"
 
@@ -9237,11 +9237,11 @@ msgctxt "dlgSgResolve.edt:"
 msgid "Content"
 msgstr "内容"
 
-msgctxt "dlgSgResolve.hdl"
+msgctxt "dlgSgResolve.hdl:"
 msgid "Resolve Conflict"
 msgstr "解决冲突"
 
-msgctxt "dlgSgResolve.inf"
+msgctxt "dlgSgResolve.inf:"
 msgid "Select which content to use for the resolved file\\(s\\)."
 msgstr "选择要用于已解决的文件的内容。"
 
@@ -9253,23 +9253,23 @@ msgctxt "dlgSgResolve.rbt:"
 msgid "Open Conflict Solver"
 msgstr "打开冲突解决工具"
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"ours\\\", $2\\)\":"
 msgid "Set to $1 \\(\"ours\", $2\\)"
 msgstr "设置为 $1 \\(“我们的”，$2 \\)"
 
-msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to $1 \\(\\\"theirs\\\", $2\\)\":"
 msgid "Set to $1 \\(\"theirs\", $2\\)"
 msgstr "设置为 $1 \\(“他们的”，$2 \\)"
 
-msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to rebase target \\(\\\"theirs\\\", $1\\)\":"
 msgid "Set to rebase target \\(\"theirs\", $1\\)"
 msgstr "设置为变基目标 \\(“他们的”，$1\\)"
 
-msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\""
+msgctxt "dlgSgResolve.rbt\"Set to rebased branch '$1' \\(\\\"ours\\\", $2\\)\":"
 msgid "Set to rebased branch '$1' \\(\"ours\", $2\\)"
 msgstr "设置为变基分支 “$1” \\(“我们的”，$2\\)"
 
-msgctxt "dlgSgResolve.tle"
+msgctxt "dlgSgResolve.tle:"
 msgid "Resolve"
 msgstr "解决"
 
@@ -9277,15 +9277,15 @@ msgctxt "dlgSgResolveManuallyModifiedSingle.btn:"
 msgid "Overwrite"
 msgstr "覆盖"
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.fur"
+msgctxt "dlgSgResolveManuallyModifiedSingle.fur:"
 msgid "$1 seems to contain manual conflict resolutions. They will be lost when continuing."
 msgstr "$1 似乎包含手动冲突解决方案。如果继续，它们将会丢失。"
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.hdl"
+msgctxt "dlgSgResolveManuallyModifiedSingle.hdl:"
 msgid "Do you want to overwrite your manual conflict resolution?"
 msgstr "您确定要覆盖手动冲突解决？"
 
-msgctxt "dlgSgResolveManuallyModifiedSingle.tle"
+msgctxt "dlgSgResolveManuallyModifiedSingle.tle:"
 msgid "Resolve"
 msgstr "解决"
 
@@ -9293,11 +9293,11 @@ msgctxt "dlgSgResolveSubmodule.btn:"
 msgid "Resolve"
 msgstr "解决"
 
-msgctxt "dlgSgResolveSubmodule.hdl"
+msgctxt "dlgSgResolveSubmodule.hdl:"
 msgid "Resolve Conflict"
 msgstr "解决冲突"
 
-msgctxt "dlgSgResolveSubmodule.inf"
+msgctxt "dlgSgResolveSubmodule.inf:"
 msgid "Select to which submodule commit you want to resolve."
 msgstr "选择要解决的子模块提交。"
 
@@ -9309,7 +9309,7 @@ msgctxt "dlgSgResolveSubmodule.rbt:"
 msgid "Leave submodule pointer as is"
 msgstr "保持子模块指针不变"
 
-msgctxt "dlgSgResolveSubmodule.tle"
+msgctxt "dlgSgResolveSubmodule.tle:"
 msgid "Resolve"
 msgstr "解决"
 
@@ -9321,15 +9321,15 @@ msgctxt "dlgSgRevealCommitLocalOrTracked.btn:"
 msgid "Reveal Tracked"
 msgstr "显示跟踪"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.chk"
+msgctxt "dlgSgRevealCommitLocalOrTracked.chk:"
 msgid "Always reveal local branch"
 msgstr "始终显示当地分支"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.fur"
+msgctxt "dlgSgRevealCommitLocalOrTracked.fur:"
 msgid "Select whether to reveal '$1' or '$2'."
 msgstr "选择是否显示 “$1” 或 “$2” 。"
 
-msgctxt "dlgSgRevealCommitLocalOrTracked.hdl"
+msgctxt "dlgSgRevealCommitLocalOrTracked.hdl:"
 msgid "Do you want to reveal the local or the tracked branch?"
 msgstr "是否要显示本地分支或跟踪分支？"
 
@@ -9349,15 +9349,15 @@ msgctxt "dlgSgRevertAndCommitConfirmSingle.btn:"
 msgid "Revert"
 msgstr "还原"
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.fur"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.fur:"
 msgid "This will undo the changes introduced with the selected commit."
 msgstr "这将撤消所选提交引入的变更。"
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.hdl"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.hdl:"
 msgid "Do you want to revert the selected commit?"
 msgstr "是否要还原所选提交？"
 
-msgctxt "dlgSgRevertAndCommitConfirmSingle.tle"
+msgctxt "dlgSgRevertAndCommitConfirmSingle.tle:"
 msgid "Revert"
 msgstr "还原"
 
@@ -9365,7 +9365,7 @@ msgctxt "dlgSgRevertConfigurationFile.btn:"
 msgid "Revert"
 msgstr "还原"
 
-msgctxt "dlgSgRevertConfigurationFile.fur"
+msgctxt "dlgSgRevertConfigurationFile.fur:"
 msgid "Only changes of these files will be reverted \\(without committing\\)."
 msgstr "只有这些文件的变更才会被还原 \\(不提交\\)。"
 
@@ -9373,35 +9373,35 @@ msgctxt "dlgSgRevertConfigurationFile.hdl:"
 msgid "Do you want to revert changes of '$1'?"
 msgstr "您确定要还原 '$1' 的变更？"
 
-msgctxt "dlgSgRevertConfigurationFile.tle"
+msgctxt "dlgSgRevertConfigurationFile.tle:"
 msgid "Revert"
 msgstr "还原"
 
-msgctxt "dlgSgRevertInProgress.fur"
+msgctxt "dlgSgRevertInProgress.fur:"
 msgid "You have to finish the Revert before you can continue. To finish the Revert use Commit, to abort use Discard."
 msgstr "您必须先完成还原，然后才能继续。 要完成 “还原” 使用 “提交”，要中止使用 “丢弃”。"
 
-msgctxt "dlgSgRevertInProgress.hdl"
+msgctxt "dlgSgRevertInProgress.hdl:"
 msgid "There is currently a Revert in progress."
 msgstr "目前还有还原正在进行中。"
 
-msgctxt "dlgSgRevertInProgress.tle"
+msgctxt "dlgSgRevertInProgress.tle:"
 msgid "Revert"
 msgstr "还原"
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.chk"
+msgctxt "dlgSgRevertNotAllConflictsResolved.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.fur"
+msgctxt "dlgSgRevertNotAllConflictsResolved.fur:"
 msgid "You may need to resolve the conflicts before proceeding."
 msgstr "您可能需要在继续之前解决冲突。"
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.hdl"
+msgctxt "dlgSgRevertNotAllConflictsResolved.hdl:"
 msgid "Reverting failed because of conflicts."
 msgstr "由于冲突而还原失败。"
 
-msgctxt "dlgSgRevertNotAllConflictsResolved.tle"
+msgctxt "dlgSgRevertNotAllConflictsResolved.tle:"
 msgid "Revert"
 msgstr "还原"
 
@@ -9409,11 +9409,11 @@ msgctxt "dlgSgReviewCommentAdd.btn:"
 msgid "Add"
 msgstr "创建"
 
-msgctxt "dlgSgReviewCommentAdd.hdl"
+msgctxt "dlgSgReviewCommentAdd.hdl:"
 msgid "Add comment"
 msgstr "创建注释"
 
-msgctxt "dlgSgReviewCommentAdd.tle"
+msgctxt "dlgSgReviewCommentAdd.tle:"
 msgid "Add Comment"
 msgstr "创建注释"
 
@@ -9421,11 +9421,11 @@ msgctxt "dlgSgReviewCommentEdit.btn:"
 msgid "Edit"
 msgstr "编辑"
 
-msgctxt "dlgSgReviewCommentEdit.hdl"
+msgctxt "dlgSgReviewCommentEdit.hdl:"
 msgid "Edit comment"
 msgstr "编辑注释"
 
-msgctxt "dlgSgReviewCommentEdit.tle"
+msgctxt "dlgSgReviewCommentEdit.tle:"
 msgid "Edit Comment"
 msgstr "编辑注释"
 
@@ -9433,11 +9433,11 @@ msgctxt "dlgSgReviewCommentReply.btn:"
 msgid "Reply"
 msgstr "回复"
 
-msgctxt "dlgSgReviewCommentReply.hdl"
+msgctxt "dlgSgReviewCommentReply.hdl:"
 msgid "Reply to selected comment"
 msgstr "回复所选注释"
 
-msgctxt "dlgSgReviewCommentReply.tle"
+msgctxt "dlgSgReviewCommentReply.tle:"
 msgid "Reply To Comment"
 msgstr "回复注释"
 
@@ -9445,7 +9445,7 @@ msgctxt "dlgSgReviewComment(Add|Edit|Reply).edt:"
 msgid "Text"
 msgstr "文本"
 
-msgctxt "dlgSgReviewComment(Add|Edit|Reply).inf"
+msgctxt "dlgSgReviewComment(Add|Edit|Reply).inf:"
 msgid "Enter the text of the comment."
 msgstr "输入注释的文本。"
 
@@ -9453,15 +9453,15 @@ msgctxt "dlgSgReviewConfigureDisposeDatabase.btn:"
 msgid "Dispose"
 msgstr "配置"
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.fur"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.fur:"
 msgid "This will disable the Reviewing system and unpushed local data will be lost."
 msgstr "这将禁用审阅系统，并且未推送的本地数据将丢失。"
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.hdl"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.hdl:"
 msgid "Do you really want to dispose all local review data?"
 msgstr "您真的想要处理所有本地注释数据吗？"
 
-msgctxt "dlgSgReviewConfigureDisposeDatabase.tle"
+msgctxt "dlgSgReviewConfigureDisposeDatabase.tle:"
 msgid "Dispose Database"
 msgstr "配置数据库"
 
@@ -9469,15 +9469,15 @@ msgctxt "dlgSgReviewConfigureForGitHub.btn:"
 msgid "Continue"
 msgstr "继续"
 
-msgctxt "dlgSgReviewConfigureForGitHub.fur"
+msgctxt "dlgSgReviewConfigureForGitHub.fur:"
 msgid "This repository is connected to a GitHub server. GitHub comes with its own reviewing concepts, like commit comments and pull requests. Hence, you probably do not want to have SmartGit's review database in addition to GitHub's existing capabilities."
 msgstr "此仓库连接到 GitHub 服务器。GitHub 有自己的审阅概念，比如提交审阅和拉取请求。因此，除了 GitHub 的现有功能之外，您可能不希望拥有 SmartGit 的审阅数据库。"
 
-msgctxt "dlgSgReviewConfigureForGitHub.hdl"
+msgctxt "dlgSgReviewConfigureForGitHub.hdl:"
 msgid "Do you really want to configure SmartGit's review database for your GitHub repository?"
 msgstr "您真的想为您的 GitHub 仓库配置 SmartGit 的审阅数据库吗？"
 
-msgctxt "dlgSgReviewConfigureForGitHub.tle"
+msgctxt "dlgSgReviewConfigureForGitHub.tle:"
 msgid "Configure Review System"
 msgstr "配置审阅系统"
 
@@ -9485,15 +9485,15 @@ msgctxt "dlgSgReviewConfigureIntializeNew.btn:"
 msgid "Initialize"
 msgstr "初始化"
 
-msgctxt "dlgSgReviewConfigureIntializeNew.fur"
+msgctxt "dlgSgReviewConfigureIntializeNew.fur:"
 msgid "This will create a new Review database in the current repository which may be pushed to other remotes later."
 msgstr "这将在当前仓库中创建新的审阅数据库，稍后可能会将其推送到其他远程位置。"
 
-msgctxt "dlgSgReviewConfigureIntializeNew.hdl"
+msgctxt "dlgSgReviewConfigureIntializeNew.hdl:"
 msgid "Do you want to initialize a new Review database?"
 msgstr "是否要初始化新的审阅数据库？"
 
-msgctxt "dlgSgReviewConfigureIntializeNew.tle"
+msgctxt "dlgSgReviewConfigureIntializeNew.tle:"
 msgid "Configure Review System"
 msgstr "配置审阅系统"
 
@@ -9509,15 +9509,15 @@ msgctxt "dlgSgReviewConfigureWhat.btn:"
 msgid "Initialize a Remote"
 msgstr "初始化远程"
 
-msgctxt "dlgSgReviewConfigureWhat.fur"
+msgctxt "dlgSgReviewConfigureWhat.fur:"
 msgid "The user database allows to define aliases \\(e.g. @mike\\) that make addressing teammates easier in review comments."
 msgstr "用户数据库允许定义别名 \\(例如 @mike\\)，使得在审阅注释中更容易解决队友问题。"
 
-msgctxt "dlgSgReviewConfigureWhat.hdl"
+msgctxt "dlgSgReviewConfigureWhat.hdl:"
 msgid "Select what you want to configure."
 msgstr "选择要配置的内容。"
 
-msgctxt "dlgSgReviewConfigureWhat.tle"
+msgctxt "dlgSgReviewConfigureWhat.tle:"
 msgid "Configure Review Database"
 msgstr "配置审核数据库"
 
@@ -9525,15 +9525,15 @@ msgctxt "dlgSgReviewPullRequestClose.edt:"
 msgid "Comment"
 msgstr "注释"
 
-msgctxt "dlgSgReviewPullRequestClose.hdl"
+msgctxt "dlgSgReviewPullRequestClose.hdl:"
 msgid "Close Pull Request"
 msgstr "关闭拉取请求"
 
-msgctxt "dlgSgReviewPullRequestClose.inf"
+msgctxt "dlgSgReviewPullRequestClose.inf:"
 msgid "Enter the comment which will be logged when closing the pull request."
 msgstr "输入关闭拉取请求时将记录的注释。"
 
-msgctxt "dlgSgReviewPullRequestClose.tle"
+msgctxt "dlgSgReviewPullRequestClose.tle:"
 msgid "Close Pull Request"
 msgstr "关闭拉取请求"
 
@@ -9553,11 +9553,11 @@ msgctxt "dlgSgReviewPullRequestCreate.err:"
 msgid "Unknown user '$1'."
 msgstr "未知用户 “$1”。"
 
-msgctxt "dlgSgReviewPullRequestCreate.hdl"
+msgctxt "dlgSgReviewPullRequestCreate.hdl:"
 msgid "Create a Pull Request"
 msgstr "创建拉取请求"
 
-msgctxt "dlgSgReviewPullRequestCreate.inf"
+msgctxt "dlgSgReviewPullRequestCreate.inf:"
 msgid "A Pull Request suggests the integration of one branch into another."
 msgstr "拉取请求建议将一个分支集成到另一个分支中。"
 
@@ -9569,7 +9569,7 @@ msgctxt "dlgSgReviewPullRequestCreate.lbl:"
 msgid "The pull request will be highlighted to those users which are listed as assignees."
 msgstr "拉取请求将高亮显示给列为申请人的用户。"
 
-msgctxt "dlgSgReviewPullRequestCreate.tle"
+msgctxt "dlgSgReviewPullRequestCreate.tle:"
 msgid "Create Pull Request"
 msgstr "创建拉取请求"
 
@@ -9589,15 +9589,15 @@ msgctxt "dlgSgReviewPullRequestState.err:"
 msgid "Unknown user '$1'."
 msgstr "未知用户 “$1”。"
 
-msgctxt "dlgSgReviewPullRequestState.hdl"
+msgctxt "dlgSgReviewPullRequestState.hdl:"
 msgid "Assign Pull Request"
 msgstr "分配拉取请求"
 
-msgctxt "dlgSgReviewPullRequestState.inf"
+msgctxt "dlgSgReviewPullRequestState.inf:"
 msgid "Enter the user\\(s\\) to which the Pull Request should be assigned to."
 msgstr "输入应将拉取请求分配给的用户 \\(s\\)。"
 
-msgctxt "dlgSgReviewPullRequestState.tle"
+msgctxt "dlgSgReviewPullRequestState.tle:"
 msgid "Assign"
 msgstr "分配"
 
@@ -9633,7 +9633,7 @@ msgctxt "dlgSgReviewUserAddEdit.hdl:"
 msgid "Edit User"
 msgstr ""
 
-msgctxt "dlgSgReviewUserAddEdit.inf"
+msgctxt "dlgSgReviewUserAddEdit.inf:"
 msgid "Enter the user's name and email address \\(as used for Git\\), one or more space- or comma-separated aliases and optional contact details."
 msgstr "输入用户的姓名和电子邮件地址 \\(用于 Git\\)，1个或多个空格或逗号分隔的别名和可选的联系人详细信息。"
 
@@ -9689,7 +9689,7 @@ msgctxt "dlgSgReviewUsersEdit.hdl:"
 msgid "Edit review database users"
 msgstr ""
 
-msgctxt "dlgSgReviewUsersEdit.inf"
+msgctxt "dlgSgReviewUsersEdit.inf:"
 msgid "Users can have aliases which are used in comment texts and they have optional contact details."
 msgstr "用户可以在注释文本中使用别名，并且可以选择联系人详细信息。"
 
@@ -9709,11 +9709,11 @@ msgctxt "dlgSgRollbackToCommit.btn:"
 msgid "Rollback"
 msgstr ""
 
-msgctxt "dlgSgRollbackToCommit.fur"
+msgctxt "dlgSgRollbackToCommit.fur:"
 msgid "All differences between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr ""
 
-msgctxt "dlgSgRollbackToCommit.tle"
+msgctxt "dlgSgRollbackToCommit.tle:"
 msgid "Rollback To"
 msgstr ""
 
@@ -9725,7 +9725,7 @@ msgctxt "dlgSgRollbackToFiles.btn:"
 msgid "Rollback"
 msgstr ""
 
-msgctxt "dlgSgRollbackToFiles.fur"
+msgctxt "dlgSgRollbackToFiles.fur:"
 msgid "All differences of the selected files between the HEAD and the selected commit will be checked out into the working tree and optionally be staged."
 msgstr "所有选择的文件中的介于 HEAD 与所选提交节点中的差异，将会被检出到工作区，也可选择将其贮藏。"
 
@@ -9733,7 +9733,7 @@ msgctxt "dlgSgRollbackToFiles.hdl:"
 msgid "Do you want to rollback the selected files to the state of commit $1?"
 msgstr "你要将所选的文件回滚至编号为 $1 的提交时的状态吗？"
 
-msgctxt "dlgSgRollbackToFiles.tle"
+msgctxt "dlgSgRollbackToFiles.tle:"
 msgid "Rollback To"
 msgstr "回滚至"
 
@@ -9757,7 +9757,7 @@ msgctxt "dlgSgSelectBranch.inf:"
 msgid "Select which auxiliary branch should be shown in addition to the current branch."
 msgstr "选择除当前分支外还应显示的辅助分支。"
 
-msgctxt "dlgSgSelectBranch.tle"
+msgctxt "dlgSgSelectBranch.tle:"
 msgid "Set Tracked Branch"
 msgstr "设置跟踪分支"
 
@@ -9953,15 +9953,15 @@ msgctxt "dlgSgSetupStdWnd.btn:"
 msgid "Use Standard Window"
 msgstr "使用标准窗口"
 
-msgctxt "dlgSgSetupStdWnd.fur"
+msgctxt "dlgSgSetupStdWnd.fur:"
 msgid "We recommend the Standard window for \\*new or less experienced Git users\\*.\\n\\nIf you have used older SmartGit versions, you might be surprised that the Standard window \\*looks different\\* than you are used to. In case you want to get the previous experience, consider to select the \\*Log Graph\\* or \\*Working Tree\\* window instead."
 msgstr "对于 \\*初出茅庐的 Git 用户\\* ，我们推荐使用标准窗口。如果您对 SmartGit 的老版本十分熟悉，或许会对标准窗口与自己熟悉的界面 \\*十分不同\\* 感到诧异。若您对旧有体验情有独钟，可以考虑启用 \\*日志图\\* 或 \\*工作区\\* 窗口。"
 
-msgctxt "dlgSgSetupStdWnd.hdl"
+msgctxt "dlgSgSetupStdWnd.hdl:"
 msgid "Do you want to use the Standard Window?"
 msgstr "您是否想要使用标准窗口?"
 
-msgctxt "dlgSgSetupStdWnd.tle"
+msgctxt "dlgSgSetupStdWnd.tle:"
 msgid "Setup SmartGit $1"
 msgstr "设置 SmartGit $1"
 
@@ -9969,11 +9969,11 @@ msgctxt "dlgSgShowLocalChanges.btn:"
 msgid "Compare"
 msgstr "比较"
 
-msgctxt "dlgSgShowLocalChanges.hdl"
+msgctxt "dlgSgShowLocalChanges.hdl:"
 msgid "File $1 modified in Index and working tree"
 msgstr "在索引和工作区中修改了文件 $1"
 
-msgctxt "dlgSgShowLocalChanges.inf"
+msgctxt "dlgSgShowLocalChanges.inf:"
 msgid "Select the file states to compare."
 msgstr "选择要比较的文件状态。"
 
@@ -9989,7 +9989,7 @@ msgctxt "dlgSgShowLocalChanges.rbt:"
 msgid "Index vs. Working Tree"
 msgstr "索引与工作区"
 
-msgctxt "dlgSgShowLocalChanges.tle"
+msgctxt "dlgSgShowLocalChanges.tle:"
 msgid "Show Changes"
 msgstr "显示变更"
 
@@ -10013,27 +10013,27 @@ msgctxt "dlgSgSplitOffFiles.edt:"
 msgid "Commit Message"
 msgstr "提交信息"
 
-msgctxt "dlgSgSplitOffFiles.hdl"
+msgctxt "dlgSgSplitOffFiles.hdl:"
 msgid "Move files to a second commit"
 msgstr "将文件移动到第二次提交"
 
-msgctxt "dlgSgSplitOffFiles.inf"
+msgctxt "dlgSgSplitOffFiles.inf:"
 msgid "Provide the message for the second commit that should contain the changes from the selected files."
 msgstr "为第二个提交提供消息，该消息应包含所选文档中的变更。"
 
-msgctxt "dlgSgSplitOffFiles.tle"
+msgctxt "dlgSgSplitOffFiles.tle:"
 msgid "Split Off Files"
 msgstr "拆分文件"
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.fur"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.fur:"
 msgid "By splitting off all files, the resulting commit would become empty."
 msgstr "通过拆分所有文件，结果提交将变为空"
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.hdl"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.hdl:"
 msgid "You can't split off all files from a commit"
 msgstr "不能从1个提交中拆分所有文件"
 
-msgctxt "dlgSgSplitOffFilesEmptyCommit.tle"
+msgctxt "dlgSgSplitOffFilesEmptyCommit.tle:"
 msgid "Commit"
 msgstr "提交"
 
@@ -10065,11 +10065,11 @@ msgctxt "dlgSgSshCredentials.edt:"
 msgid "Private Key File"
 msgstr "私钥文件"
 
-msgctxt "dlgSgSshCredentials.hdl"
+msgctxt "dlgSgSshCredentials.hdl:"
 msgid "SSH Credentials"
 msgstr "SSH 凭据"
 
-msgctxt "dlgSgSshCredentials.inf"
+msgctxt "dlgSgSshCredentials.inf:"
 msgid "Provide the credentials for authenticating to the SSH server '$1' as user '$2'."
 msgstr "提供用于以 “root” 身份向 SSH 服务器 “git” 进行身份验证的凭据。"
 
@@ -10085,7 +10085,7 @@ msgctxt "dlgSgSshCredentials.rbt:"
 msgid "Private Key"
 msgstr "私钥"
 
-msgctxt "dlgSgSshCredentials.tle"
+msgctxt "dlgSgSshCredentials.tle:"
 msgid "SSH Authentication"
 msgstr "SSH 身份验证"
 
@@ -10097,27 +10097,27 @@ msgctxt "dlgSgStageConflict.btn:"
 msgid "Stage Anyway"
 msgstr "总是暂存"
 
-msgctxt "dlgSgStageConflict.fur"
+msgctxt "dlgSgStageConflict.fur:"
 msgid "The file contains conflict markers which indicate that you have not resolved all conflicts."
 msgstr "该文件包含冲突标记，这些标记指示您尚未解决所有冲突。"
 
-msgctxt "dlgSgStageConflict.hdl"
+msgctxt "dlgSgStageConflict.hdl:"
 msgid "Should $1 really be staged?"
 msgstr "$1 真的应该暂存吗？"
 
-msgctxt "dlgSgStageConflict.tle"
+msgctxt "dlgSgStageConflict.tle:"
 msgid "Stage"
 msgstr "暂存"
 
-msgctxt "dlgSgStageNoFilesFound.fur"
+msgctxt "dlgSgStageNoFilesFound.fur:"
 msgid "Could not find files with modified working tree, untracked or missing files."
 msgstr "找不到包含已修改工作区，未跟踪或丢失文件的文件。"
 
-msgctxt "dlgSgStageNoFilesFound.hdl"
+msgctxt "dlgSgStageNoFilesFound.hdl:"
 msgid "No files found that could be staged."
 msgstr "找不到可以暂存的文件。"
 
-msgctxt "dlgSgStageNoFilesFound.tle"
+msgctxt "dlgSgStageNoFilesFound.tle:"
 msgid "Stage"
 msgstr "暂存"
 
@@ -10137,15 +10137,15 @@ msgctxt "dlgSgStartupExpired.btn:"
 msgid "Exit"
 msgstr "退出"
 
-msgctxt "dlgSgStartupExpired.fur"
+msgctxt "dlgSgStartupExpired.fur:"
 msgid "Please download and install a new one or a release version."
 msgstr "请下载安装新版本."
 
-msgctxt "dlgSgStartupExpired.hdl"
+msgctxt "dlgSgStartupExpired.hdl:"
 msgid "This beta version expired."
 msgstr "该 beta 版本已过期."
 
-msgctxt "dlgSgStartupExpired.tle"
+msgctxt "dlgSgStartupExpired.tle:"
 msgid "Beta Version Expired"
 msgstr "Beta 版本已过期"
 
@@ -10169,15 +10169,15 @@ msgctxt "dlgSgStashAll.edt:"
 msgid "Message"
 msgstr "消息"
 
-msgctxt "dlgSgStashAll.hdl"
+msgctxt "dlgSgStashAll.hdl:"
 msgid "Stash Index and Working Tree changes"
 msgstr "存储索引和工作区变更"
 
-msgctxt "dlgSgStashAll.inf"
+msgctxt "dlgSgStashAll.inf:"
 msgid "The saved stash can be applied later. By default, Index and Working Tree are cleaned, but you may keep the Index or both."
 msgstr "保存的存储可以在以后应用。默认情况下，清理索引和工作区，但您可以保留索引或两者。"
 
-msgctxt "dlgSgStashAll.tle"
+msgctxt "dlgSgStashAll.tle:"
 msgid "Save Stash"
 msgstr "贮藏"
 
@@ -10201,11 +10201,11 @@ msgctxt "dlgSgStashApply.hdl:"
 msgid "Apply the latest saved stash"
 msgstr "应用最新保存的贮藏"
 
-msgctxt "dlgSgStashApply.inf"
+msgctxt "dlgSgStashApply.inf:"
 msgid "Decide how to apply the stash to the Index or working tree."
 msgstr "确定如何将贮藏之更改应用于索引或工作区。"
 
-msgctxt "dlgSgStashApply.tle"
+msgctxt "dlgSgStashApply.tle:"
 msgid "Apply Stash"
 msgstr "应用贮藏"
 
@@ -10213,15 +10213,15 @@ msgctxt "dlgSgStashApplyWithoutRestoringIndex.btn:"
 msgid "Try Without Restoring Index"
 msgstr "尝试不还原索引"
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.fur"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.fur:"
 msgid "Restoring the index failed while applying the patch."
 msgstr "应用修补程序时还原索引失败。"
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.hdl"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.hdl:"
 msgid "Should the stash been applied without restoring the index?"
 msgstr "是否应用存储而不还原索引？"
 
-msgctxt "dlgSgStashApplyWithoutRestoringIndex.tle"
+msgctxt "dlgSgStashApplyWithoutRestoringIndex.tle:"
 msgid "Apply Stash"
 msgstr "应用贮藏"
 
@@ -10233,7 +10233,7 @@ msgctxt "dlgSgStashOnDemandConfirmation.btn:"
 msgid "Save Stash"
 msgstr "贮藏"
 
-msgctxt "dlgSgStashOnDemandConfirmation.chk"
+msgctxt "dlgSgStashOnDemandConfirmation.chk:"
 msgid "Automatically save stash"
 msgstr "自动贮藏"
 
@@ -10305,7 +10305,7 @@ msgctxt "dlgSgStashOnDemandConfirmation.hdl:"
 msgid "What to do with the working tree or Index changes?"
 msgstr ""
 
-msgctxt "dlgSgStashOnDemandConfirmation.tle"
+msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Reset"
 msgstr ""
 
@@ -10317,15 +10317,15 @@ msgctxt "dlgSgStashOnDemandConfirmation.tle:"
 msgid "Pull"
 msgstr "拉取"
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.fur:"
 msgid "Once you have concluded the Pull, you should manually apply the latest stash to get your local changes back into the working tree."
 msgstr "完成拉取操作后，您应该手动应用最新的存储，以将本地变更还原到工作区中。"
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.hdl:"
 msgid "Your local changes have been stashed away, but could not be reapplied."
 msgstr "您的本地变更已被贮藏，但无法重新应用。"
 
-msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.tle"
+msgctxt "dlgSgStashOnDemandLocalChangesCantBeReapplied.tle:"
 msgid "Pull"
 msgstr "拉取"
 
@@ -10333,15 +10333,15 @@ msgctxt "dlgSgStashOnDemandProceedWithoutStashing.btn:"
 msgid "Proceed"
 msgstr "继续"
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.fur"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.fur:"
 msgid "Auto-stashing changes is not possible due to technical reasons. Changes will be discarded!"
 msgstr "由于技术原因，无法自动贮藏变更. 变更将会被丢弃!"
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.hdl"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.hdl:"
 msgid "Do you want to proceed without stashing changes?"
 msgstr "是否继续并排除贮藏?"
 
-msgctxt "dlgSgStashOnDemandProceedWithoutStashing.tle"
+msgctxt "dlgSgStashOnDemandProceedWithoutStashing.tle:"
 msgid "Reset"
 msgstr "重置"
 
@@ -10353,15 +10353,15 @@ msgctxt "dlgSgStashRename.edt:"
 msgid "Message"
 msgstr "消息"
 
-msgctxt "dlgSgStashRename.hdl"
+msgctxt "dlgSgStashRename.hdl:"
 msgid "Rename Stash"
 msgstr "重命名贮藏"
 
-msgctxt "dlgSgStashRename.inf"
+msgctxt "dlgSgStashRename.inf:"
 msgid "Enter the new message for the stash"
 msgstr "输入贮藏的新消息"
 
-msgctxt "dlgSgStashRename.tle"
+msgctxt "dlgSgStashRename.tle:"
 msgid "Rename"
 msgstr "重命名"
 
@@ -10373,15 +10373,15 @@ msgctxt "dlgSgStashesDropConfirm.btn:"
 msgid "Drop Stashes"
 msgstr "丢弃贮藏"
 
-msgctxt "dlgSgStashesDropConfirm.fur"
+msgctxt "dlgSgStashesDropConfirm.fur:"
 msgid "The stashed changes will be lost."
 msgstr "贮藏的变更将会丢失。"
 
-msgctxt "dlgSgStashesDropConfirm.hdl"
+msgctxt "dlgSgStashesDropConfirm.hdl:"
 msgid "Do you want to drop the selected stash?"
 msgstr "你想丢弃选定的贮藏吗？"
 
-msgctxt "dlgSgStashesDropConfirm.tle"
+msgctxt "dlgSgStashesDropConfirm.tle:"
 msgid "Drop Stash"
 msgstr "丢弃贮藏"
 
@@ -10474,7 +10474,7 @@ msgctxt "dlgSgSubmoduleAdd.rbt:"
 msgid "Remote repository"
 msgstr "远程仓库"
 
-msgctxt "dlgSgSubmoduleAdd.tle"
+msgctxt "dlgSgSubmoduleAdd.tle:"
 msgid "Add Submodule"
 msgstr "添加子模块"
 
@@ -10482,19 +10482,19 @@ msgctxt "dlgSgSubmoduleDeinitConfirm.btn:"
 msgid "Deinit"
 msgstr "删除"
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.chk"
+msgctxt "dlgSgSubmoduleDeinitConfirm.chk:"
 msgid "Force \\(for modified submodules\\)"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.fur"
+msgctxt "dlgSgSubmoduleDeinitConfirm.fur:"
 msgid "The submodule will be skipped from the working tree. To get rid from the \\(remote\\) repository, you have to use Unregister instead."
 msgstr "子模块将从工作区中跳过。 要摆脱 \\(远程\\) 仓库，您必须使用取消注册。"
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.hdl"
+msgctxt "dlgSgSubmoduleDeinitConfirm.hdl:"
 msgid "Do you want to deinit submodule '$1'?"
 msgstr "你想要删除子模块 '$1' 吗？"
 
-msgctxt "dlgSgSubmoduleDeinitConfirm.tle"
+msgctxt "dlgSgSubmoduleDeinitConfirm.tle:"
 msgid "Deinit Submodule"
 msgstr "删除子模块"
 
@@ -10506,15 +10506,15 @@ msgctxt "dlgSgSubmoduleInitAll.chk:"
 msgid "Pull submodule repositories"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitAll.hdl"
+msgctxt "dlgSgSubmoduleInitAll.hdl:"
 msgid "Initialize all submodules"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitAll.inf"
+msgctxt "dlgSgSubmoduleInitAll.inf:"
 msgid "Submodule entries will be added to .git/config. You may customize the URLs afterwards or pull immediately."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitAll.tle"
+msgctxt "dlgSgSubmoduleInitAll.tle:"
 msgid "Initialize Submodule"
 msgstr ""
 
@@ -10530,15 +10530,15 @@ msgctxt "dlgSgSubmoduleInitGit.edt:"
 msgid "URL"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitGit.hdl"
+msgctxt "dlgSgSubmoduleInitGit.hdl:"
 msgid "Set submodule URL"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitGit.inf"
+msgctxt "dlgSgSubmoduleInitGit.inf:"
 msgid "You can customize the submodule's clone URL used in .git/config for your local setup."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleInitGit.tle"
+msgctxt "dlgSgSubmoduleInitGit.tle:"
 msgid "Initialize Submodule"
 msgstr ""
 
@@ -10546,15 +10546,15 @@ msgctxt "dlgSgSubmoduleRegister.edt:"
 msgid "URL"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleRegister.hdl"
+msgctxt "dlgSgSubmoduleRegister.hdl:"
 msgid "Register nested root as submodule"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleRegister.inf"
+msgctxt "dlgSgSubmoduleRegister.inf:"
 msgid "Select the URL for the submodule to register."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleRegister.tle"
+msgctxt "dlgSgSubmoduleRegister.tle:"
 msgid "Register Submodule"
 msgstr ""
 
@@ -10562,15 +10562,15 @@ msgctxt "dlgSgSubmoduleResetConfirm.btn:"
 msgid "Reset"
 msgstr "重置"
 
-msgctxt "dlgSgSubmoduleResetConfirm.fur"
+msgctxt "dlgSgSubmoduleResetConfirm.fur:"
 msgid "The corresponding commit will be checked out, so the submodule content will match the content of the registered commit."
 msgstr "将检出相应的提交，因此子模块内容将匹配已注册提交的内容。"
 
-msgctxt "dlgSgSubmoduleResetConfirm.hdl"
+msgctxt "dlgSgSubmoduleResetConfirm.hdl:"
 msgid "Do you want to reset submodule '$1' to the commit registered in the repository?"
 msgstr "是否要将子模块 $1 重置为仓库中注册的提交？"
 
-msgctxt "dlgSgSubmoduleResetConfirm.tle"
+msgctxt "dlgSgSubmoduleResetConfirm.tle:"
 msgid "Reset Submodule"
 msgstr "重置子模块"
 
@@ -10578,15 +10578,15 @@ msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.btn:"
 msgid "Reset"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.fur"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.fur:"
 msgid "The submodule HEAD is not reachable from any ref. After resetting, it will be hard to access this commit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.hdl"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.hdl:"
 msgid "Do you want to perform the reset even though you will loose access to the current HEAD commit?"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.tle"
+msgctxt "dlgSgSubmoduleResetHeadNotAccessibleAnymore.tle:"
 msgid "Reset Submodule"
 msgstr ""
 
@@ -10602,27 +10602,27 @@ msgctxt "dlgSgSubmoduleSync.chk:"
 msgid "Pull submodule repository"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSync.hdl"
+msgctxt "dlgSgSubmoduleSync.hdl:"
 msgid "Synchronize all submodules"
 msgstr "同步所有子模块"
 
-msgctxt "dlgSgSubmoduleSync.inf"
+msgctxt "dlgSgSubmoduleSync.inf:"
 msgid "Submodule entries will be updated in .git/config. You may customize the URLs afterwards or pull immediately."
 msgstr "子模块条目将在 .git/config 文件夹中更新. 您可以稍后自定义URL或立即拉取."
 
-msgctxt "dlgSgSubmoduleSync.tle"
+msgctxt "dlgSgSubmoduleSync.tle:"
 msgid "Synchronize Submodules"
 msgstr "同步子模块"
 
-msgctxt "dlgSgSubmoduleSyncConfigured.fur"
+msgctxt "dlgSgSubmoduleSyncConfigured.fur:"
 msgid "You may now pull individual submodules or on the root directory to clone the configured repositories."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSyncConfigured.hdl"
+msgctxt "dlgSgSubmoduleSyncConfigured.hdl:"
 msgid "Submodules have been configured."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleSyncConfigured.tle"
+msgctxt "dlgSgSubmoduleSyncConfigured.tle:"
 msgid "Synchronize Submodules"
 msgstr ""
 
@@ -10630,11 +10630,11 @@ msgctxt "dlgSgSubmoduleUnregisterConfirm.btn:"
 msgid "Unregister"
 msgstr ""
 
-msgctxt "dlgSgSubmoduleUnregisterConfirm.fur"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.fur:"
 msgid "All relevant files will be adjusted. Afterwards you will only need to perform a commit to finish the operation. To just skip the submodule from the working tree, use Deinit."
 msgstr ""
 
-msgctxt "dlgSgSubmoduleUnregisterConfirm.tle"
+msgctxt "dlgSgSubmoduleUnregisterConfirm.tle:"
 msgid "Unregister Submodule"
 msgstr ""
 
@@ -10690,7 +10690,7 @@ msgctxt "dlgSgSubtreeAdd.rbt:"
 msgid "Remote repository"
 msgstr "远程仓库"
 
-msgctxt "dlgSgSubtreeAdd.tle"
+msgctxt "dlgSgSubtreeAdd.tle:"
 msgid "Add Subtree"
 msgstr "添加子树"
 
@@ -10710,19 +10710,19 @@ msgctxt "dlgSgSvnClientCertificate.edt:"
 msgid "Passphrase"
 msgstr "密码"
 
-msgctxt "dlgSgSvnClientCertificate.hdl"
+msgctxt "dlgSgSvnClientCertificate.hdl:"
 msgid "Client Certificate"
 msgstr "客户端证书"
 
-msgctxt "dlgSgSvnClientCertificate.inf"
+msgctxt "dlgSgSvnClientCertificate.inf:"
 msgid "Provide the client certificate for authentication to the SVN repository '$1'."
 msgstr "为 SVN 仓库 “$1” 提供身份验证的客户端证书。"
 
-msgctxt "dlgSgSvnClientCertificate.tle"
+msgctxt "dlgSgSvnClientCertificate.tle:"
 msgid "SVN Authentication"
 msgstr "SVN 认证"
 
-msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\""
+msgctxt "dlgSgSvnClientCertificate.wrn\"Authentication to the SVN repository '$1' failed with error: $2\":"
 msgid "Authentication to the SVN repository '$1' failed with error: $2'"
 msgstr "对 SVN 仓库 “$1” 的身份验证失败，错误：$2"
 
@@ -10754,7 +10754,7 @@ msgctxt "dlgSgSvnSslFingerprintChanged.lbl:"
 msgid "This might indicate a security problem! When in doubt, contact your server administrator."
 msgstr "这可能表明存在安全问题！如果有疑问，请与服务器管理员联系。"
 
-msgctxt "dlgSgSvnSslFingerprintChanged.tle"
+msgctxt "dlgSgSvnSslFingerprintChanged.tle:"
 msgid "SVN Authentication"
 msgstr "SVN 身份验证"
 
@@ -10762,19 +10762,19 @@ msgctxt "dlgSgSyncConfirm.btn:"
 msgid "Synchronize"
 msgstr "同步"
 
-msgctxt "dlgSgSyncConfirm.chk"
+msgctxt "dlgSgSyncConfirm.chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlgSgSyncConfirm.fur"
+msgctxt "dlgSgSyncConfirm.fur:"
 msgid "First, local changes will be pushed, then possible remote changes pulled. The advantage over a normal push is that if it fails because of remote changes, they will be pulled automatically."
 msgstr "首先，将推送本地变更，然后可能会拉取远程变更。比普通推送的优势在于，如果由于远程变更而推送失败，它们将被自动拉取。"
 
-msgctxt "dlgSgSyncConfirm.hdl"
+msgctxt "dlgSgSyncConfirm.hdl:"
 msgid "Do you want to proceed with sync?"
 msgstr "你确定要继续同步吗？"
 
-msgctxt "dlgSgSyncConfirm.tle"
+msgctxt "dlgSgSyncConfirm.tle:"
 msgid "Synchronize"
 msgstr "同步"
 
@@ -10802,15 +10802,15 @@ msgctxt "dlgSgTagAdd.err:"
 msgid "The name must not end with a slash or dot."
 msgstr "名称不得以斜杠或点结尾。"
 
-msgctxt "dlgSgTagAdd.hdl"
+msgctxt "dlgSgTagAdd.hdl:"
 msgid "Add tag to selected commit"
 msgstr "在当前 HEAD 提交创建标签"
 
-msgctxt "dlgSgTagAdd.inf"
+msgctxt "dlgSgTagAdd.inf:"
 msgid "Enter the name of the tag to create. If entering a message, an annotated tag is created."
 msgstr "输入要创建的标签名称。如果输入消息，则会创建带注释的标签。"
 
-msgctxt "dlgSgTagAdd.tle"
+msgctxt "dlgSgTagAdd.tle:"
 msgid "Add Tag"
 msgstr "创建标签"
 
@@ -10818,15 +10818,15 @@ msgctxt "dlgSgTagAddOverwrite.btn:"
 msgid "Overwrite"
 msgstr "覆盖"
 
-msgctxt "dlgSgTagAddOverwrite.fur"
+msgctxt "dlgSgTagAddOverwrite.fur:"
 msgid "Click 'Cancel' to choose a different tag name."
 msgstr "单击 “取消” 以选择其他标签名称。"
 
-msgctxt "dlgSgTagAddOverwrite.hdl"
+msgctxt "dlgSgTagAddOverwrite.hdl:"
 msgid "The tag '$1' already exists. Do you want to overwrite it?"
 msgstr "标签 '$1' 已经存在。 你想覆盖吗？"
 
-msgctxt "dlgSgTagAddOverwrite.tle"
+msgctxt "dlgSgTagAddOverwrite.tle:"
 msgid "Add Tag"
 msgstr "创建标签"
 
@@ -10834,23 +10834,23 @@ msgctxt "dlgSgTagDeleteConfirmSingle.btn:"
 msgid "Delete"
 msgstr "删除"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk:"
 msgid "Delete from all remotes"
 msgstr ""
 
-msgctxt "dlgSgTagDeleteConfirmSingle.chk"
+msgctxt "dlgSgTagDeleteConfirmSingle.chk:"
 msgid "Delete from remote '$1'"
 msgstr "从远程 “$1” 删除"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.fur"
+msgctxt "dlgSgTagDeleteConfirmSingle.fur:"
 msgid "You will not be able to restore it."
 msgstr "你将无法恢复它。"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.hdl"
+msgctxt "dlgSgTagDeleteConfirmSingle.hdl:"
 msgid "Do you want to delete the tag '$1'?"
 msgstr "您确定要删除 “$1” 标签吗？"
 
-msgctxt "dlgSgTagDeleteConfirmSingle.tle"
+msgctxt "dlgSgTagDeleteConfirmSingle.tle:"
 msgid "Delete"
 msgstr "删除"
 
@@ -10874,11 +10874,11 @@ msgctxt "dlgSgToolAdd.err:"
 msgid "The options 'Can be used by the Open command' and 'Show output and wait until finished' cannot both be set."
 msgstr "The options 'Can be used by the Open command' and 'Show output and wait until finished' cannot both be set."
 
-msgctxt "dlgSgToolAdd.hdl"
+msgctxt "dlgSgToolAdd.hdl:"
 msgid "Add external tool"
 msgstr "添加外部工具"
 
-msgctxt "dlgSgToolAdd.tle"
+msgctxt "dlgSgToolAdd.tle:"
 msgid "Add"
 msgstr "添加"
 
@@ -10890,11 +10890,11 @@ msgctxt "dlgSgToolEdit.err:"
 msgid "Please enter the name for this command."
 msgstr "请输入此命令的名称。"
 
-msgctxt "dlgSgToolEdit.hdl"
+msgctxt "dlgSgToolEdit.hdl:"
 msgid "Edit external tool"
 msgstr "编辑外部工具"
 
-msgctxt "dlgSgToolEdit.tle"
+msgctxt "dlgSgToolEdit.tle:"
 msgid "Edit"
 msgstr "编辑"
 
@@ -10938,7 +10938,7 @@ msgctxt "dlgSgTool(Add|Edit).edt:"
 msgid "Menu Item Name"
 msgstr "菜单项名称"
 
-msgctxt "dlgSgTool(Add|Edit).inf"
+msgctxt "dlgSgTool(Add|Edit).inf:"
 msgid "Define the name of the tool menu item, the command which should be executed and configure its arguments. The used variables define on what selection the tool may be used."
 msgstr "定义工具菜单项的名称，应执行的命令并配置其参数。使用的变量定义了可以使用工具的选择。"
 
@@ -11042,23 +11042,23 @@ msgctxt "dlgSgUndoLastCommitConfirm.fur:"
 msgid "Undoing an already pushed commit might cause serious problems!\\n\\nMessage: $1"
 msgstr "撤消已推送的提交可能会导致严重问题！\\n\\n详情：$1"
 
-msgctxt "dlgSgUndoLastCommitConfirm.hdl"
+msgctxt "dlgSgUndoLastCommitConfirm.hdl:"
 msgid "Do you want to undo the last local commit?"
 msgstr "您确定要撤消上次本地提交吗？"
 
-msgctxt "dlgSgUndoLastCommitConfirm.tle"
+msgctxt "dlgSgUndoLastCommitConfirm.tle:"
 msgid "Undo Last Commit"
 msgstr "撤消上次提交"
 
-msgctxt "dlgSgUnstageNoFilesFound.fur"
+msgctxt "dlgSgUnstageNoFilesFound.fur:"
 msgid "Could not find files with staged changes."
 msgstr "找不到具有暂存变更的文件。"
 
-msgctxt "dlgSgUnstageNoFilesFound.hdl"
+msgctxt "dlgSgUnstageNoFilesFound.hdl:"
 msgid "No files found that could be unstaged."
 msgstr "找不到可能取消暂存的文件。"
 
-msgctxt "dlgSgUnstageNoFilesFound.tle"
+msgctxt "dlgSgUnstageNoFilesFound.tle:"
 msgid "Unstage"
 msgstr "取消暂存"
 
@@ -11066,11 +11066,11 @@ msgctxt "dlgSgWelcome.chk:"
 msgid "Show this dialog if no repository was opened"
 msgstr "如果没有打开仓库，则显示此对话框"
 
-msgctxt "dlgSgWelcome.hdl"
+msgctxt "dlgSgWelcome.hdl:"
 msgid "What do you want to do?"
 msgstr "你想做什么?"
 
-msgctxt "dlgSgWelcome.inf"
+msgctxt "dlgSgWelcome.inf:"
 msgid "Select whether to open a new, local repository, clone a \\(remote\\) repository or open an existing repository."
 msgstr "选择是否打开新的本地仓库，克隆 \\(远程\\) 仓库或打开现有仓库。"
 
@@ -11086,7 +11086,7 @@ msgctxt "dlgSgWelcome.rbt:"
 msgid "Reopen previously used repository:"
 msgstr "重新打开以前使用的仓库："
 
-msgctxt "dlgSgWelcome.tle"
+msgctxt "dlgSgWelcome.tle:"
 msgid "Welcome to SmartGit"
 msgstr "欢迎使用 SmartGit"
 
@@ -11098,39 +11098,39 @@ msgctxt "dlgSgWorktreeAdd.edt:"
 msgid "Directory"
 msgstr "目录"
 
-msgctxt "dlgSgWorktreeAdd.hdl"
+msgctxt "dlgSgWorktreeAdd.hdl:"
 msgid "Create another worktree from this repository"
 msgstr "从此仓库创建其他工作区"
 
-msgctxt "dlgSgWorktreeAdd.inf"
+msgctxt "dlgSgWorktreeAdd.inf:"
 msgid "Select the branch and directory to use for the new worktree."
 msgstr "选择要用于新工作区的分支和目录。"
 
-msgctxt "dlgSgWorktreeAdd.tle"
+msgctxt "dlgSgWorktreeAdd.tle:"
 msgid "Add Worktree"
 msgstr "创建工作区"
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.fur"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.fur:"
 msgid "You only can create worktrees for existing local branches that don't yet have an associated worktree."
 msgstr "只能为尚无关联工作区的现有本地分支创建工作区。"
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.hdl"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.hdl:"
 msgid "No \\(more\\) local branches available."
 msgstr "没有可用的 \\(更多\\) 本地分支。"
 
-msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.tle"
+msgctxt "dlgSgWorktreeAddNoMoreLocalBranches.tle:"
 msgid "Add Worktree"
 msgstr "添加工作区"
 
-msgctxt "dlgSgWorktreePruneNoWorktree.fur"
+msgctxt "dlgSgWorktreePruneNoWorktree.fur:"
 msgid "All your worktrees are still available."
 msgstr "您的所有工作区仍然可用。"
 
-msgctxt "dlgSgWorktreePruneNoWorktree.hdl"
+msgctxt "dlgSgWorktreePruneNoWorktree.hdl:"
 msgid "No worktree to prune."
 msgstr "没有要删除的工作区。"
 
-msgctxt "dlgSgWorktreePruneNoWorktree.tle"
+msgctxt "dlgSgWorktreePruneNoWorktree.tle:"
 msgid "Prune Obsolete Worktrees"
 msgstr "删除废弃的工作区"
 
@@ -11138,15 +11138,15 @@ msgctxt "dlgSgWorktreePruneWorktrees.btn:"
 msgid "Prune Worktrees"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneWorktrees.fur"
+msgctxt "dlgSgWorktreePruneWorktrees.fur:"
 msgid "Git reported following worktrees as obsolete:"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneWorktrees.hdl"
+msgctxt "dlgSgWorktreePruneWorktrees.hdl:"
 msgid "Do you want to prune following worktrees?"
 msgstr ""
 
-msgctxt "dlgSgWorktreePruneWorktrees.tle"
+msgctxt "dlgSgWorktreePruneWorktrees.tle:"
 msgid "Prune Obsolete Worktrees"
 msgstr ""
 
@@ -11166,15 +11166,15 @@ msgctxt "dlgShPushTrackingLocalSvnBranches.btn:"
 msgid "Push onto Existing"
 msgstr "推到现有的"
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.fur"
+msgctxt "dlgShPushTrackingLocalSvnBranches.fur:"
 msgid "You are going to push local branches back to the SVN repository. These branches may either be pushed as new branches or onto their existing SVN counterparts \\(recommended in most cases\\)."
 msgstr "您将把本地分支推送回 SVN 仓库。 这些分支可能作为新分支推送到现有的 SVN 对应部分 \\(在大多数情况下推荐使用\\)。"
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.hdl"
+msgctxt "dlgShPushTrackingLocalSvnBranches.hdl:"
 msgid "Do you want to push local branches as new SVN branches?"
 msgstr "你想推动本地分支作为新的 SVN 分支吗？"
 
-msgctxt "dlgShPushTrackingLocalSvnBranches.tle"
+msgctxt "dlgShPushTrackingLocalSvnBranches.tle:"
 msgid "Push"
 msgstr "推送"
 
@@ -11186,15 +11186,15 @@ msgctxt "dlgTxtEditor.fileModified.btn:"
 msgid "Reload"
 msgstr "重新加载"
 
-msgctxt "dlgTxtEditor.fileModified.fur"
+msgctxt "dlgTxtEditor.fileModified.fur:"
 msgid "Unless you want to see the old file state, it is recommended to reload."
 msgstr "重新加载将显示最新的文件状态."
 
-msgctxt "dlgTxtEditor.fileModified.hdl"
+msgctxt "dlgTxtEditor.fileModified.hdl:"
 msgid "The file config was changed. Reload it?"
 msgstr "该文件配置已变更. 是否重新加载?"
 
-msgctxt "dlgTxtEditor.fileModified.tle"
+msgctxt "dlgTxtEditor.fileModified.tle:"
 msgid "Editor"
 msgstr "编辑器"
 
@@ -11258,11 +11258,11 @@ msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).btn:"
 msgid "Move to Trash"
 msgstr "移动到回收站"
 
-msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).fur"
+msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).fur:"
 msgid "If you click Delete you may require file recovery tools to restore the deleted files!"
 msgstr "如果单击 “删除”，则可能需要文件还原工具来还原已删除的文件！"
 
-msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).tle"
+msgctxt "dlg(SgDeleteFileTrash|SgDeleteFilesTrash).tle:"
 msgid "Delete"
 msgstr "删除"
 
@@ -11270,11 +11270,11 @@ msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgReposito
 msgid "Remove"
 msgstr "删除"
 
-msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).chk"
+msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).chk:"
 msgid "Don't show again"
 msgstr "不再显示"
 
-msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).tle"
+msgctxt "dlg(SgRepositoryRemoveMultiGroup|SgRepositoryRemoveMultiRepo|SgRepositoryRemoveMultiRepoMultiGroup|SgRepositoryRemoveMultiRepoSingleGroup|SgRepositoryRemoveSingleGroup|SgRepositoryRemoveSingleRepo|SgRepositoryRemoveSingleRepoMultiGroup|SgRepositoryRemoveSingleRepoSingleGroup).tle:"
 msgid "Remove"
 msgstr "删除"
 
@@ -11654,7 +11654,7 @@ msgctxt "ttpBranches:"
 msgid "<b>Incoming</b> from repository <b>$1</b> branch <b>$2</b> to branch <b>$3</b>"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\""
+msgctxt "ttpBranches\"<b>Last Updated By:\\t</b>$1\":"
 msgid "<b>Last Updated By: </b>$1"
 msgstr ""
 
@@ -11662,11 +11662,11 @@ msgctxt "ttpBranches:"
 msgid "<b>Local Branch:\\t</b>$1"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>On:\\t</b>$1\""
+msgctxt "ttpBranches\"<b>On:\\t</b>$1\":"
 msgid "<b>On: </b>$1"
 msgstr ""
 
-msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\""
+msgctxt "ttpBranches\"<b>Outgoing</b> from branch <b>main</b> to repository <b>$1</b> branch <b>$2</b>\":"
 msgid "<b>Outgoing</b> from branch <b>$1</b> to repository <b>$2</b> branch <b>main</b>"
 msgstr ""
 
@@ -11958,83 +11958,83 @@ msgctxt "wndAnnotate.mni:"
 msgid "Show Changes"
 msgstr "显示变更"
 
-msgctxt "wndAnnotate.mniCommit-first"
+msgctxt "wndAnnotate.mniCommit-first:"
 msgid "Go to First Commit"
 msgstr "转到第一次提交"
 
-msgctxt "wndAnnotate.mniCommit-last"
+msgctxt "wndAnnotate.mniCommit-last:"
 msgid "Go to Last Commit"
 msgstr "转到最后一次提交"
 
-msgctxt "wndAnnotate.mniCommit-next"
+msgctxt "wndAnnotate.mniCommit-next:"
 msgid "Go to Next Commit"
 msgstr "转到下一个提交"
 
-msgctxt "wndAnnotate.mniCommit-preceding-line"
+msgctxt "wndAnnotate.mniCommit-preceding-line:"
 msgid "Go to Preceding Commit"
 msgstr "转到前一个提交"
 
-msgctxt "wndAnnotate.mniCommit-previous"
+msgctxt "wndAnnotate.mniCommit-previous:"
 msgid "Go to Previous Commit"
 msgstr "转到上一个提交"
 
-msgctxt "wndAnnotate.mniCompare"
+msgctxt "wndAnnotate.mniCompare:"
 msgid "Show Changes"
 msgstr "显示变更"
 
-msgctxt "wndAnnotate.mniCustomize"
+msgctxt "wndAnnotate.mniCustomize:"
 msgid "Customize"
 msgstr "自定义"
 
-msgctxt "wndAnnotate.mniEdit-copy"
+msgctxt "wndAnnotate.mniEdit-copy:"
 msgid "Copy"
 msgstr "复制"
 
-msgctxt "wndAnnotate.mniFile-close"
+msgctxt "wndAnnotate.mniFile-close:"
 msgid "Close"
 msgstr "关闭"
 
-msgctxt "wndAnnotate.mniGoto-line"
+msgctxt "wndAnnotate.mniGoto-line:"
 msgid "Go to Line"
 msgstr "转到行"
 
-msgctxt "wndAnnotate.mniLog"
+msgctxt "wndAnnotate.mniLog:"
 msgid "Log"
 msgstr "打开日志"
 
-msgctxt "wndAnnotate.mniSearch-find"
+msgctxt "wndAnnotate.mniSearch-find:"
 msgid "Find"
 msgstr "查找"
 
-msgctxt "wndAnnotate.mniSearch-next"
+msgctxt "wndAnnotate.mniSearch-next:"
 msgid "Find Next"
 msgstr "向下查找"
 
-msgctxt "wndAnnotate.mniSearch-previous"
+msgctxt "wndAnnotate.mniSearch-previous:"
 msgid "Find Previous"
 msgstr "向上查找"
 
-msgctxt "wndAnnotate.mniSet-syntax"
+msgctxt "wndAnnotate.mniSet-syntax:"
 msgid "Syntax Language"
 msgstr "语言模式"
 
-msgctxt "wndAnnotate.mniShowChanges"
+msgctxt "wndAnnotate.mniShowChanges:"
 msgid "Show Changes"
 msgstr "显示修改"
 
-msgctxt "wndAnnotate.mniUndo-goto"
+msgctxt "wndAnnotate.mniUndo-goto:"
 msgid "Undo Go To"
 msgstr "撤消转到"
 
-msgctxt "wndAnnotate.mniView-settings"
+msgctxt "wndAnnotate.mniView-settings:"
 msgid "Settings"
 msgstr "设置"
 
-msgctxt "wndAnnotate.mniWindowHideView"
+msgctxt "wndAnnotate.mniWindowHideView:"
 msgid "Hide View"
 msgstr "隐藏视图"
 
-msgctxt "wndAnnotate.mniWindowLineHistory"
+msgctxt "wndAnnotate.mniWindowLineHistory:"
 msgid "Line History"
 msgstr "行历史记录"
 
@@ -12110,43 +12110,43 @@ msgctxt "wndCompare.mni:"
 msgid "Apply Selection to Right"
 msgstr ""
 
-msgctxt "wndCompare.mniRefresh"
+msgctxt "wndCompare.mniRefresh:"
 msgid "Reload"
 msgstr "重新加载"
 
-msgctxt "wndCompare.mniView-ignore-whitespaces"
+msgctxt "wndCompare.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr ""
 
-msgctxt "wndCompare.mniView-layout-left-beside-right"
+msgctxt "wndCompare.mniView-layout-left-beside-right:"
 msgid "Left Beside Right"
 msgstr "左侧右侧"
 
-msgctxt "wndCompare.mniView-layout-left-over-right"
+msgctxt "wndCompare.mniView-layout-left-over-right:"
 msgid "Left Above Right"
 msgstr "左上方"
 
-msgctxt "wndCompare.tbtEdit-take-left"
+msgctxt "wndCompare.tbtEdit-take-left:"
 msgid "Take the left block to the right. Depending on the left block, this will insert, replace or delete at the right."
 msgstr "采用左侧代码块到右侧文件. 取决于左侧代码块, 这将在右侧文件中插入、替换或删除."
 
-msgctxt "wndCompare.tbtEdit-take-right"
+msgctxt "wndCompare.tbtEdit-take-right:"
 msgid "Take the right block to the left. Depending on the right block, this will insert, replace or delete at the left."
 msgstr "采用右侧代码块到左侧文件. 取决于右侧代码块, 这将在左侧文件中插入、替换或删除."
 
-msgctxt "wndCompare.tbtFile-save"
+msgctxt "wndCompare.tbtFile-save:"
 msgid "Save file modifications."
 msgstr "保存文件变更"
 
-msgctxt "wndCompare.tbtGoto-next-diff"
+msgctxt "wndCompare.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "下一处差异。"
 
-msgctxt "wndCompare.tbtGoto-previous-diff"
+msgctxt "wndCompare.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "上一处差异。"
 
-msgctxt "wndCompare.tbtRefresh"
+msgctxt "wndCompare.tbtRefresh:"
 msgid "Reload content from file system and recompare."
 msgstr "从文件系统中重新加载文件内容进行对比"
 
@@ -12166,23 +12166,23 @@ msgctxt "wndConflictSolver.mni:"
 msgid "Apply Selection to Working Tree"
 msgstr "应用选定内容到工作区"
 
-msgctxt "wndConflictSolver.mniView-ignore-whitespaces"
+msgctxt "wndConflictSolver.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr ""
 
-msgctxt "wndConflictSolver.mniView-layout-all"
+msgctxt "wndConflictSolver.mniView-layout-all:"
 msgid "All"
 msgstr "所有"
 
-msgctxt "wndConflictSolver.mniView-layout-left-merge"
+msgctxt "wndConflictSolver.mniView-layout-left-merge:"
 msgid "Left and Merge"
 msgstr "左合并"
 
-msgctxt "wndConflictSolver.mniView-layout-left-right-above-merge"
+msgctxt "wndConflictSolver.mniView-layout-left-right-above-merge:"
 msgid "Left and Right Above Merge"
 msgstr "左右合并"
 
-msgctxt "wndConflictSolver.mniView-layout-right-merge"
+msgctxt "wndConflictSolver.mniView-layout-right-merge:"
 msgid "Merge and Right"
 msgstr "右合并"
 
@@ -12234,59 +12234,59 @@ msgctxt "wndConflictSolver.tbr:"
 msgid "Take Right, Left"
 msgstr "先采用右侧文件块, 再采用左侧文件块"
 
-msgctxt "wndConflictSolver.tbtEdit-take-left"
+msgctxt "wndConflictSolver.tbtEdit-take-left:"
 msgid "Take the left block to the merge result. Depending on the left block, this will insert, replace or delete at the merge result."
 msgstr "采用左侧代码块. 取决于左侧代码块, 这将在合并结果中插入、替换或删除."
 
-msgctxt "wndConflictSolver.tbtEdit-take-left-right"
+msgctxt "wndConflictSolver.tbtEdit-take-left-right:"
 msgid "Take the left block, then the right one."
 msgstr "先采用左侧代码块, 再采用右侧文件块"
 
-msgctxt "wndConflictSolver.tbtEdit-take-right"
+msgctxt "wndConflictSolver.tbtEdit-take-right:"
 msgid "Take the right block to the merge result. Depending on the right block, this will insert, replace or delete at the merge result."
 msgstr "采用右侧代码块. 取决于右侧代码块, 这将在合并结果中插入、替换或删除."
 
-msgctxt "wndConflictSolver.tbtEdit-take-right-left"
+msgctxt "wndConflictSolver.tbtEdit-take-right-left:"
 msgid "Take the right block, then the left one."
 msgstr "先采用右侧文件块, 再采用左侧文件块"
 
-msgctxt "wndConflictSolver.tbtFile-open-base"
+msgctxt "wndConflictSolver.tbtFile-open-base:"
 msgid "Open the left and right changes from the common base file."
 msgstr "从通用基础文档中打开左右变更。"
 
-msgctxt "wndConflictSolver.tbtFile-save"
+msgctxt "wndConflictSolver.tbtFile-save:"
 msgid "Save file modifications."
 msgstr "保存文件修改。"
 
-msgctxt "wndConflictSolver.tbtGoto-next-conflict"
+msgctxt "wndConflictSolver.tbtGoto-next-conflict:"
 msgid "Go to next conflict."
 msgstr "下一处冲突。"
 
-msgctxt "wndConflictSolver.tbtGoto-next-diff"
+msgctxt "wndConflictSolver.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "下一处冲突变更。"
 
-msgctxt "wndConflictSolver.tbtGoto-previous-conflict"
+msgctxt "wndConflictSolver.tbtGoto-previous-conflict:"
 msgid "Go to previous conflict."
 msgstr "上一处冲突。"
 
-msgctxt "wndConflictSolver.tbtGoto-previous-diff"
+msgctxt "wndConflictSolver.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "上一处变更。"
 
-msgctxt "wndConflictSolver.tbtView-layout-all"
+msgctxt "wndConflictSolver.tbtView-layout-all:"
 msgid "Show the left, merge and right file."
 msgstr "显示左侧, 合并和右侧文件."
 
-msgctxt "wndConflictSolver.tbtView-layout-left-merge"
+msgctxt "wndConflictSolver.tbtView-layout-left-merge:"
 msgid "Show the left and merge file."
 msgstr "显示左侧和合并文件."
 
-msgctxt "wndConflictSolver.tbtView-layout-left-right-above-merge"
+msgctxt "wndConflictSolver.tbtView-layout-left-right-above-merge:"
 msgid "Show the left and right files above the merge file."
 msgstr "在合并文件上方显示左右文件。"
 
-msgctxt "wndConflictSolver.tbtView-layout-right-merge"
+msgctxt "wndConflictSolver.tbtView-layout-right-merge:"
 msgid "Show the merge and right file."
 msgstr "显示合并和右侧文件"
 
@@ -12562,167 +12562,167 @@ msgctxt "wndDeepgit.mni:"
 msgid "Open Repository Log"
 msgstr "打开仓库日志"
 
-msgctxt "wndDeepgit.mniDbBack"
+msgctxt "wndDeepgit.mniDbBack:"
 msgid "Go Back"
 msgstr ""
 
-msgctxt "wndDeepgit.mniDgAbout"
+msgctxt "wndDeepgit.mniDgAbout:"
 msgid "About DeepGit"
 msgstr "关于 DeepGit"
 
-msgctxt "wndDeepgit.mniDgBack"
+msgctxt "wndDeepgit.mniDgBack:"
 msgid "Go Back"
 msgstr "回退"
 
-msgctxt "wndDeepgit.mniDgConfigureRefGroups"
+msgctxt "wndDeepgit.mniDgConfigureRefGroups:"
 msgid "Tag-Grouping"
 msgstr "引用标签分组"
 
-msgctxt "wndDeepgit.mniDgExtendLineToBlock"
+msgctxt "wndDeepgit.mniDgExtendLineToBlock:"
 msgid "Extend Lines to Blocks"
 msgstr "单行/代码块"
 
-msgctxt "wndDeepgit.mniDgFilterAddSelection"
+msgctxt "wndDeepgit.mniDgFilterAddSelection:"
 msgid "Add Selection to Filter"
 msgstr "将选定内容添加到筛选器"
 
-msgctxt "wndDeepgit.mniDgFilterReset"
+msgctxt "wndDeepgit.mniDgFilterReset:"
 msgid "Reset Filter"
 msgstr "重置筛选器"
 
-msgctxt "wndDeepgit.mniDgFilterSetSelection"
+msgctxt "wndDeepgit.mniDgFilterSetSelection:"
 msgid "Set Selection as Filter"
 msgstr "将选定内容设置为筛选器"
 
-msgctxt "wndDeepgit.mniDgFollowRenames"
+msgctxt "wndDeepgit.mniDgFollowRenames:"
 msgid "Follow Renames"
 msgstr "关注重命名"
 
-msgctxt "wndDeepgit.mniDgForward"
+msgctxt "wndDeepgit.mniDgForward:"
 msgid "Go Forward"
 msgstr "前进"
 
-msgctxt "wndDeepgit.mniDgHighlightBlameChanges"
+msgctxt "wndDeepgit.mniDgHighlightBlameChanges:"
 msgid "Highlight Changes of Current Blame Commit"
 msgstr "高亮当前追溯提交的变更"
 
-msgctxt "wndDeepgit.mniDgHighlightOriginChanges"
+msgctxt "wndDeepgit.mniDgHighlightOriginChanges:"
 msgid "Highlight Changes of Current Origin Commit"
 msgstr "高亮当前来源提交的变更"
 
-msgctxt "wndDeepgit.mniDgIgnoreWhitespaceOnlyChanges"
+msgctxt "wndDeepgit.mniDgIgnoreWhitespaceOnlyChanges:"
 msgid "Ignore Whitespace Changes"
 msgstr "忽略空白变更"
 
-msgctxt "wndDeepgit.mniDgLicenseAgreement"
+msgctxt "wndDeepgit.mniDgLicenseAgreement:"
 msgid "License Agreement"
 msgstr "许可协议"
 
-msgctxt "wndDeepgit.mniDgOptimizeCreationOrigins"
+msgctxt "wndDeepgit.mniDgOptimizeCreationOrigins:"
 msgid "Optimize 'Appeared Here' Origins"
 msgstr "优化 “出现在此处” 的来源"
 
-msgctxt "wndDeepgit.mniDgPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.mniDgPerspectiveBlameOrigin:"
 msgid "Blame+Origins Perspective"
 msgstr "追溯起源视角"
 
-msgctxt "wndDeepgit.mniDgPerspectiveBlameSimple"
+msgctxt "wndDeepgit.mniDgPerspectiveBlameSimple:"
 msgid "Blame Perspective"
 msgstr "追溯视角"
 
-msgctxt "wndDeepgit.mniDgPerspectiveCommit"
+msgctxt "wndDeepgit.mniDgPerspectiveCommit:"
 msgid "Log Perspective"
 msgstr "记录视角"
 
-msgctxt "wndDeepgit.mniDgPerspectiveHistory"
+msgctxt "wndDeepgit.mniDgPerspectiveHistory:"
 msgid "Diff Perspective"
 msgstr "比较透视"
 
-msgctxt "wndDeepgit.mniDgPerspectiveOrigins"
+msgctxt "wndDeepgit.mniDgPerspectiveOrigins:"
 msgid "Origins Perspective"
 msgstr "起源视角"
 
-msgctxt "wndDeepgit.mniDgResetInlineHelp"
+msgctxt "wndDeepgit.mniDgResetInlineHelp:"
 msgid "Reshow All Inline Help"
 msgstr "重新显示所有内联帮助"
 
-msgctxt "wndDeepgit.mniDgSetEncoding"
+msgctxt "wndDeepgit.mniDgSetEncoding:"
 msgid "Encoding"
 msgstr "编码"
 
-msgctxt "wndDeepgit.mniDgShowAtRefs"
+msgctxt "wndDeepgit.mniDgShowAtRefs:"
 msgid "Show At Refs"
 msgstr "在引用处显示"
 
-msgctxt "wndDeepgit.mniDgShowLinePrefixes"
+msgctxt "wndDeepgit.mniDgShowLinePrefixes:"
 msgid "Show Line Prefixes"
 msgstr "显示行前缀"
 
-msgctxt "wndDeepgit.mniDgShowOnRefs"
+msgctxt "wndDeepgit.mniDgShowOnRefs:"
 msgid "Show On Refs"
 msgstr "显示引用"
 
-msgctxt "wndDeepgit.mniDgToggleLineHistory"
+msgctxt "wndDeepgit.mniDgToggleLineHistory:"
 msgid "Line History"
 msgstr "行历史记录"
 
-msgctxt "wndDeepgit.mniDgViewToolbar"
+msgctxt "wndDeepgit.mniDgViewToolbar:"
 msgid "Show Toolbar"
 msgstr "显示工具栏"
 
-msgctxt "wndDeepgit.mniDgWindowHorizontalLayout"
+msgctxt "wndDeepgit.mniDgWindowHorizontalLayout:"
 msgid "Horizontal Blame + Origins Layout"
 msgstr "水平追溯起源布局"
 
-msgctxt "wndDeepgit.mniDgWindowVerticalLayout"
+msgctxt "wndDeepgit.mniDgWindowVerticalLayout:"
 msgid "Vertical Blame + Origins Layout"
 msgstr "垂直追溯起源布局"
 
-msgctxt "wndDeepgit.mniEdit-copy"
+msgctxt "wndDeepgit.mniEdit-copy:"
 msgid "Copy"
 msgstr "复制"
 
-msgctxt "wndDeepgit.mniFile-close"
+msgctxt "wndDeepgit.mniFile-close:"
 msgid "Close"
 msgstr "关闭"
 
-msgctxt "wndDeepgit.mniGoto-line"
+msgctxt "wndDeepgit.mniGoto-line:"
 msgid "Go to Line"
 msgstr "转到行"
 
-msgctxt "wndDeepgit.mniGoto-next-diff"
+msgctxt "wndDeepgit.mniGoto-next-diff:"
 msgid "Next Change"
 msgstr "下一处差异"
 
-msgctxt "wndDeepgit.mniGoto-previous-diff"
+msgctxt "wndDeepgit.mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr "上一处差异"
 
-msgctxt "wndDeepgit.mniNextChange"
+msgctxt "wndDeepgit.mniNextChange:"
 msgid "Next Change"
 msgstr "下一处变更"
 
-msgctxt "wndDeepgit.mniOpenFileLog"
+msgctxt "wndDeepgit.mniOpenFileLog:"
 msgid "Open File Log"
 msgstr "打开文件日志"
 
-msgctxt "wndDeepgit.mniOpenRepositoryLog"
+msgctxt "wndDeepgit.mniOpenRepositoryLog:"
 msgid "Open Repository Log"
 msgstr "打开仓库日志"
 
-msgctxt "wndDeepgit.mniPreviousChange"
+msgctxt "wndDeepgit.mniPreviousChange:"
 msgid "Previous Change"
 msgstr "上一处变更"
 
-msgctxt "wndDeepgit.mniSearch-find"
+msgctxt "wndDeepgit.mniSearch-find:"
 msgid "Find"
 msgstr "查找"
 
-msgctxt "wndDeepgit.mniSearch-next"
+msgctxt "wndDeepgit.mniSearch-next:"
 msgid "Find Next"
 msgstr "向下查找"
 
-msgctxt "wndDeepgit.mniSearch-previous"
+msgctxt "wndDeepgit.mniSearch-previous:"
 msgid "Find Previous"
 msgstr "向上查找"
 
@@ -12814,59 +12814,59 @@ msgctxt "wndDeepgit.tbt:"
 msgid "Go to previous change."
 msgstr "上一处变更"
 
-msgctxt "wndDeepgit.tbtBack"
+msgctxt "wndDeepgit.tbtBack:"
 msgid "Go back to previous blame..."
 msgstr "上一个提交..."
 
-msgctxt "wndDeepgit.tbtDbBack"
+msgctxt "wndDeepgit.tbtDbBack:"
 msgid "Go back to previous blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgForward"
+msgctxt "wndDeepgit.tbtDgForward:"
 msgid "Go forward to next blame..."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.tbtDgPerspectiveBlameOrigin:"
 msgid "Find where the line originates from in cases where you need to choose from one of possible Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveBlameSimple"
+msgctxt "wndDeepgit.tbtDgPerspectiveBlameSimple:"
 msgid "Find where the line originates from in simple cases when there are no alternative Origins."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveCommit"
+msgctxt "wndDeepgit.tbtDgPerspectiveCommit:"
 msgid "Investigate Log."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveHistory"
+msgctxt "wndDeepgit.tbtDgPerspectiveHistory:"
 msgid "Investigate Diff between file's revisions."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtDgPerspectiveOrigins"
+msgctxt "wndDeepgit.tbtDgPerspectiveOrigins:"
 msgid "Find out what else happened where the line originates from.\\n\\nIn order to inspect available Origins, they have to be evaluated first. First, select the file you want to investigate using File\\|Open and select a line in it. Then wait until the calculation of possible Origins has finished."
 msgstr ""
 
-msgctxt "wndDeepgit.tbtForward"
+msgctxt "wndDeepgit.tbtForward:"
 msgid "Go forward to next blame..."
 msgstr "下一个提交..."
 
-msgctxt "wndDeepgit.tbtPerspectiveBlameOrigin"
+msgctxt "wndDeepgit.tbtPerspectiveBlameOrigin:"
 msgid "Find where the line originates from in cases where you need to choose from one of possible Origins."
 msgstr "在可能的起源中查找行的起源位置。"
 
-msgctxt "wndDeepgit.tbtPerspectiveBlameSimple"
+msgctxt "wndDeepgit.tbtPerspectiveBlameSimple:"
 msgid "Find where the line originates from in simple cases when there are no alternative Origins."
 msgstr "在没有替代起源的情况下，在简单的情况下找到线的起源。"
 
-msgctxt "wndDeepgit.tbtPerspectiveCommit"
+msgctxt "wndDeepgit.tbtPerspectiveCommit:"
 msgid "Investigate Log."
 msgstr "审查记录。"
 
-msgctxt "wndDeepgit.tbtPerspectiveHistory"
+msgctxt "wndDeepgit.tbtPerspectiveHistory:"
 msgid "Investigate Diff between file's revisions."
 msgstr "审查文件修订之间的差异。"
 
-msgctxt "wndDeepgit.tbtPerspectiveOrigins"
+msgctxt "wndDeepgit.tbtPerspectiveOrigins:"
 msgid "Find out what else happened where the line originates from.\\n\\nIn order to inspect available Origins, they have to be evaluated first. First, select the file you want to investigate using File\\|Open and select a line in it. Then wait until the calculation of possible Origins has finished."
 msgstr "找出该行的起源处所发生的其他情况。\\n\\n 为了检查可用的原点，必须首先对其进行评估。首先，使用文件\\|打开选择要审查的文件，并选择其中的一行。然后等到可能原点的计算完成。"
 
@@ -12890,31 +12890,31 @@ msgctxt "wndEditor.mni:"
 msgid "LF \\(Unix, macOS\\)"
 msgstr "LF \\(Unix, macOS 系统\\)"
 
-msgctxt "wndEditor.mniEdit-undo"
+msgctxt "wndEditor.mniEdit-undo:"
 msgid "Undo"
 msgstr "撤销"
 
-msgctxt "wndEditor.mniEofEnforceLineEnding"
+msgctxt "wndEditor.mniEofEnforceLineEnding:"
 msgid "Enforce Line Ending on End of File"
 msgstr "在文件末尾强制使用行尾序列"
 
-msgctxt "wndEditor.mniReplaceTabsWithSpaces"
+msgctxt "wndEditor.mniReplaceTabsWithSpaces:"
 msgid "Replace Tabs With Spaces"
 msgstr "将制表符 \\(Tab\\) 替换为空格"
 
-msgctxt "wndEditor.mniSaveAuto"
+msgctxt "wndEditor.mniSaveAuto:"
 msgid "Auto-Save"
 msgstr ""
 
-msgctxt "wndEditor.mniView-remember-as-default"
+msgctxt "wndEditor.mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr "记住为默认值"
 
-msgctxt "wndEditor.mniView-settings"
+msgctxt "wndEditor.mniView-settings:"
 msgid "Settings"
 msgstr "设置"
 
-msgctxt "wndEditor.tbtFile-save"
+msgctxt "wndEditor.tbtFile-save:"
 msgid "Save file modifications."
 msgstr "保存文件修改。"
 
@@ -12958,59 +12958,59 @@ msgctxt "wndGit.indexEditor.mni:"
 msgid "Unstage Selection"
 msgstr "取消暂存选择"
 
-msgctxt "wndGit.indexEditor.mniView-ignore-whitespaces"
+msgctxt "wndGit.indexEditor.mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr ""
 
-msgctxt "wndGit.indexEditor.mniView-layout-all"
+msgctxt "wndGit.indexEditor.mniView-layout-all:"
 msgid "All"
 msgstr "所有"
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-index"
+msgctxt "wndGit.indexEditor.mniView-layout-head-index:"
 msgid "HEAD and Index"
 msgstr "HEAD 和索引"
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-index-wt"
+msgctxt "wndGit.indexEditor.mniView-layout-head-index-wt:"
 msgid "All"
 msgstr "所有"
 
-msgctxt "wndGit.indexEditor.mniView-layout-head-wt-above-index"
+msgctxt "wndGit.indexEditor.mniView-layout-head-wt-above-index:"
 msgid "HEAD and Working Tree Above Index"
 msgstr "HEAD 和工作区在索引上方"
 
-msgctxt "wndGit.indexEditor.mniView-layout-index-wt"
+msgctxt "wndGit.indexEditor.mniView-layout-index-wt:"
 msgid "Index and Working Tree"
 msgstr "索引和工作区"
 
-msgctxt "wndGit.indexEditor.mniView-layout-left-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-left-merge:"
 msgid "HEAD and Index"
 msgstr "左合并"
 
-msgctxt "wndGit.indexEditor.mniView-layout-left-right-above-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-left-right-above-merge:"
 msgid "HEAD and Working Tree Above Index"
 msgstr "左右合并"
 
-msgctxt "wndGit.indexEditor.mniView-layout-right-merge"
+msgctxt "wndGit.indexEditor.mniView-layout-right-merge:"
 msgid "Index and Working Tree"
 msgstr "右合并"
 
-msgctxt "wndGit.indexEditor.tbtEdit-take-left"
+msgctxt "wndGit.indexEditor.tbtEdit-take-left:"
 msgid "Take the left block to the merge result. Depending on the left block, this will insert, replace or delete at the merge result."
 msgstr "将左侧块移至合并结果。根据左侧块，这将在合并结果处插入，替换或删除。"
 
-msgctxt "wndGit.indexEditor.tbtEdit-take-right"
+msgctxt "wndGit.indexEditor.tbtEdit-take-right:"
 msgid "Take the right block to the merge result. Depending on the right block, this will insert, replace or delete at the merge result."
 msgstr "采用右侧代码块到合并结果. 取决于右侧代码块, 这将在合并结果中插入、替换或删除."
 
-msgctxt "wndGit.indexEditor.tbtFile-save"
+msgctxt "wndGit.indexEditor.tbtFile-save:"
 msgid "Save file modifications."
 msgstr "保存文件修改。"
 
-msgctxt "wndGit.indexEditor.tbtGoto-next-diff"
+msgctxt "wndGit.indexEditor.tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "下一处变更。"
 
-msgctxt "wndGit.indexEditor.tbtGoto-previous-diff"
+msgctxt "wndGit.indexEditor.tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "上一处变更。"
 
@@ -13022,7 +13022,7 @@ msgctxt "wndLog.hnt:"
 msgid "No graph roots selected."
 msgstr ""
 
-msgctxt "wndLog.mniFixCaseChange"
+msgctxt "wndLog.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr ""
 
@@ -13174,31 +13174,31 @@ msgctxt "wndStd.mni:"
 msgid "Sort by Path"
 msgstr ""
 
-msgctxt "wndStd.mniBisectTryCommit"
+msgctxt "wndStd.mniBisectTryCommit:"
 msgid "Try Commit"
 msgstr ""
 
-msgctxt "wndStd.mniFixCaseChange"
+msgctxt "wndStd.mniFixCaseChange:"
 msgid "Fix Case-Change"
 msgstr ""
 
-msgctxt "wndStd.mniIntegrateMain"
+msgctxt "wndStd.mniIntegrateMain:"
 msgid "Integrate Main"
 msgstr ""
 
-msgctxt "wndStd.mniStdOpenSubmodule"
+msgctxt "wndStd.mniStdOpenSubmodule:"
 msgid "Open a Submodule"
 msgstr ""
 
-msgctxt "wndStd.mniStdOpenSubmoduleFromFile"
+msgctxt "wndStd.mniStdOpenSubmoduleFromFile:"
 msgid "Open this Submodule"
 msgstr ""
 
-msgctxt "wndStd.mniStdSetModeHistory"
+msgctxt "wndStd.mniStdSetModeHistory:"
 msgid "Show History"
 msgstr ""
 
-msgctxt "wndStd.mniStdSetModeWt"
+msgctxt "wndStd.mniStdSetModeWt:"
 msgid "Show Local Changes"
 msgstr ""
 
@@ -13210,7 +13210,7 @@ msgctxt "wndStd.tbr:"
 msgid "Submodule"
 msgstr ""
 
-msgctxt "wndStd.tbtFlowFeatureStart"
+msgctxt "wndStd.tbtFlowFeatureStart:"
 msgid "Start a new feature branch."
 msgstr ""
 
@@ -13218,19 +13218,19 @@ msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|
 msgid "Ready"
 msgstr "就绪"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-fullScreen:"
 msgid "Full Screen"
 msgstr "全屏"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeMaximize:"
 msgid "Maximize"
 msgstr "最大化"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-maximizeRestore:"
 msgid "Restore"
 msgstr "还原"
 
-msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-minimize"
+msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|Project|Std|).mniWindow-minimize:"
 msgid "Minimize"
 msgstr "最小化"
 
@@ -13250,83 +13250,83 @@ msgctxt "wnd(Annotate|Compare|ConflictSolver|Deepgit|Git.indexEditor|Editor|Log|
 msgid "Window"
 msgstr "窗口"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left:"
 msgid "Take Left Block"
 msgstr "使用左边文件块"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left-right"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-left-right:"
 msgid "Take Left, then Right Block"
 msgstr "使用左边文件块，然后使用右边文件块"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right:"
 msgid "Take Right Block"
 msgstr "使用右边文件块"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right-left"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-take-right-left:"
 msgid "Take Right, then Left Block"
 msgstr "使用右边文件块，然后使用左边文件块"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-undo"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniEdit-undo:"
 msgid "Undo"
 msgstr "撤销"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-export-html"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-export-html:"
 msgid "Export as HTML-File"
 msgstr "导出为 HTML 文件"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-open-base"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniFile-open-base:"
 msgid "Open Base File Changes"
 msgstr "打开基本文件变更"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-conflict"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-conflict:"
 msgid "Next Conflict"
 msgstr "下一处冲突"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-diff"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-next-diff:"
 msgid "Next Change"
 msgstr "下一处差异"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-conflict"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-conflict:"
 msgid "Previous Conflict"
 msgstr "上一处冲突"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-diff"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr "上一处差异"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniShow-line-numbers"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniShow-line-numbers:"
 msgid "Show Line Numbers"
 msgstr "显示行号"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-all"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-all:"
 msgid "Ignore All Whitespaces for Line Comparison"
 msgstr "忽略所有空白字符变化"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-leading-trailing"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-leading-trailing:"
 msgid "Ignore Leading/Trailing Whitespaces for Line Comparison"
 msgstr "忽略前导/尾随空格以进行行比较"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-none"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-ignore-whitespaces-none:"
 msgid "Ignore No Whitespace for Line Comparison"
 msgstr "忽略没有用于行比较的空格"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-refresh"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-refresh:"
 msgid "Reload"
 msgstr "刷新"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-remember-as-default"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr "记住默认"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-settings"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-settings:"
 msgid "Settings"
 msgstr "设置"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-show-current-line-control"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-show-current-line-control:"
 msgid "Show Long Current Lines"
 msgstr "显示长的当前行"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-synchronize-scrolling"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor).mniView-synchronize-scrolling:"
 msgid "Synchronize Scrolling"
 msgstr "同步滚动"
 
@@ -13354,59 +13354,59 @@ msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mni:"
 msgid "Copy Selection"
 msgstr "复制选中"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniCustomize"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniCustomize:"
 msgid "Customize"
 msgstr "自定义"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-copy"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-copy:"
 msgid "Copy"
 msgstr "复制"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-cut"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-cut:"
 msgid "Cut"
 msgstr "剪切"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-ignore-case-changes"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-ignore-case-changes:"
 msgid "Ignore Case Change for Line Comparison"
 msgstr "忽略行比较的大小写变更"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-paste"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-paste:"
 msgid "Paste"
 msgstr "粘贴"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-redo"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniEdit-redo:"
 msgid "Redo"
 msgstr "重做"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-close"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-close:"
 msgid "Close"
 msgstr "关闭"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-save"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniFile-save:"
 msgid "Save"
 msgstr "保存"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniGoto-line"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniGoto-line:"
 msgid "Go to Line"
 msgstr "转到行"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-find"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-find:"
 msgid "Find"
 msgstr "查找"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-next"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-next:"
 msgid "Find Next"
 msgstr "向下查找"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-previous"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-previous:"
 msgid "Find Previous"
 msgstr "向上查找"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-replace"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSearch-replace:"
 msgid "Find and Replace"
 msgstr "查找并替换"
 
-msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSet-syntax"
+msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).mniSet-syntax:"
 msgid "Syntax Language"
 msgstr "语言模式"
 
@@ -13430,11 +13430,11 @@ msgctxt "wnd(Compare|ConflictSolver|Git.indexEditor|Editor).tbr:"
 msgid "Save"
 msgstr "保存"
 
-msgctxt "wnd(Log|Project|).tbtFlowFeatureFinish"
+msgctxt "wnd(Log|Project|).tbtFlowFeatureFinish:"
 msgid "Finish a Git-Flow feature."
 msgstr "完成 Git 流功能。"
 
-msgctxt "wnd(Log|Project|).tbtFlowFeatureStart"
+msgctxt "wnd(Log|Project|).tbtFlowFeatureStart:"
 msgid "Start a new Git-Flow feature."
 msgstr "启动新的 Git 流功能。"
 
@@ -13735,7 +13735,7 @@ msgctxt "wnd(Log|Project|Std|).lbl:"
 msgid "Files"
 msgstr "个文件"
 
-msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\""
+msgctxt "wnd(Log|Project|Std|).mni\"  Show Rewritten Behind Commits\":"
 msgid "Show Rewritten Behind Commits"
 msgstr "在提交后显示重写"
 
@@ -14514,308 +14514,308 @@ msgctxt "wnd(Log|Project|Std|).mni:"
 msgid "Varying Coloring"
 msgstr "变色"
 
-msgctxt "wnd(Log|Project|Std|).mniAbout"
+msgctxt "wnd(Log|Project|Std|).mniAbout:"
 msgid "About SmartGit"
 msgstr "关于 SmartGit"
 
-msgctxt "wnd(Log|Project|Std|).mniAdd"
+msgctxt "wnd(Log|Project|Std|).mniAdd:"
 msgid "Add"
 msgstr "创建"
 
-msgctxt "wnd(Log|Project|Std|).mniAnnotate"
+msgctxt "wnd(Log|Project|Std|).mniAnnotate:"
 msgid "Blame"
 msgstr "追溯"
 
-msgctxt "wnd(Log|Project|Std|).mniAssume-unchanged-toggle"
+msgctxt "wnd(Log|Project|Std|).mniAssume-unchanged-toggle:"
 msgid "Toggle 'Assume Unchanged'"
 msgstr "切换 “假设不变”"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectBad"
+msgctxt "wnd(Log|Project|Std|).mniBisectBad:"
 msgid "Mark HEAD as Bad"
 msgstr "将 HEAD 标记为损坏"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectExit"
+msgctxt "wnd(Log|Project|Std|).mniBisectExit:"
 msgid "Reset"
 msgstr "重置"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectGood"
+msgctxt "wnd(Log|Project|Std|).mniBisectGood:"
 msgid "Mark HEAD as Good"
 msgstr "将 HEAD 标记为正常"
 
-msgctxt "wnd(Log|Project|Std|).mniBisectStart"
+msgctxt "wnd(Log|Project|Std|).mniBisectStart:"
 msgid "Start"
 msgstr "开始"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAbort"
+msgctxt "wnd(Log|Project|Std|).mniBranchAbort:"
 msgid "Abort"
 msgstr "中止分支"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAdd"
+msgctxt "wnd(Log|Project|Std|).mniBranchAdd:"
 msgid "Add Branch"
 msgstr "创建分支"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchAddTag"
+msgctxt "wnd(Log|Project|Std|).mniBranchAddTag:"
 msgid "Add Tag"
 msgstr "创建标签"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchClose"
+msgctxt "wnd(Log|Project|Std|).mniBranchClose:"
 msgid "Close"
 msgstr "关闭"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchContinue"
+msgctxt "wnd(Log|Project|Std|).mniBranchContinue:"
 msgid "Continue"
 msgstr "继续"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchDelete"
+msgctxt "wnd(Log|Project|Std|).mniBranchDelete:"
 msgid "Delete"
 msgstr "删除分支"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchRename"
+msgctxt "wnd(Log|Project|Std|).mniBranchRename:"
 msgid "Rename"
 msgstr "重命名"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchResetTracking"
+msgctxt "wnd(Log|Project|Std|).mniBranchResetTracking:"
 msgid "Stop Tracking"
 msgstr "停止跟踪"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSetTracking"
+msgctxt "wnd(Log|Project|Std|).mniBranchSetTracking:"
 msgid "Set Tracked Branch"
 msgstr "设置跟踪分支"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSplit"
+msgctxt "wnd(Log|Project|Std|).mniBranchSplit:"
 msgid "Modify or Split Commit"
 msgstr "修改或拆分提交"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchSplitFiles"
+msgctxt "wnd(Log|Project|Std|).mniBranchSplitFiles:"
 msgid "Split Off Files"
 msgstr "拆分文件"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowRemoteOnly"
+msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowRemoteOnly:"
 msgid "Show remote branches in their Git-Flow sections"
 msgstr "在 Git 工作流部分显示远程分支"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowTracked"
+msgctxt "wnd(Log|Project|Std|).mniBranchesGitFlowTracked:"
 msgid "Show remote, tracked branches"
 msgstr "显示远程，跟踪分支"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionize"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionize:"
 msgid "Group tags and branches by path-like name \\(foo/bar\\)"
 msgstr "按路径名称分组标签和分支 (foo/bar)"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeAfterLastSlash"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeAfterLastSlash:"
 msgid "After last slash"
 msgstr "在最后一个斜杠后"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeCompact"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionizeCompact:"
 msgid "Except for single refs"
 msgstr "除了单项"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSectionsBeforeRefs"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSectionsBeforeRefs:"
 msgid "Show groups first"
 msgstr "优先显示组"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSelectObsolete"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSelectObsolete:"
 msgid "Select Obsolete Local Branches"
 msgstr "选择过时的本地分支"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByName"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByName:"
 msgid "Sort Refs by Name"
 msgstr "按名称排序引用"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByNameReversed"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByNameReversed:"
 msgid "Sort Refs by Name \\(Numbers Reversed\\)"
 msgstr "按名称排序引用 (数字反转)"
 
-msgctxt "wnd(Log|Project|Std|).mniBranchesSortByTime"
+msgctxt "wnd(Log|Project|Std|).mniBranchesSortByTime:"
 msgid "Sort Refs by Commit Time"
 msgstr "按提交时间排序引用"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.compact"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.compact:"
 msgid "Compact"
 msgstr "压缩"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.ignoreLineSeparators"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.ignoreLineSeparators:"
 msgid "Ignore Line-Ending Changes"
 msgstr "忽略行尾序列变更"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.sideBySide"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.sideBySide:"
 msgid "Side by Side"
 msgstr "并排"
 
-msgctxt "wnd(Log|Project|Std|).mniChangesView.unified"
+msgctxt "wnd(Log|Project|Std|).mniChangesView.unified:"
 msgid "Unified"
 msgstr "合并"
 
-msgctxt "wnd(Log|Project|Std|).mniCheckForLatestBuild"
+msgctxt "wnd(Log|Project|Std|).mniCheckForLatestBuild:"
 msgid "Check for Latest Build"
 msgstr "检查更新 \\(编译版本\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniCheckForNewVersion"
+msgctxt "wnd(Log|Project|Std|).mniCheckForNewVersion:"
 msgid "Check for New Version"
 msgstr "检查更新"
 
-msgctxt "wnd(Log|Project|Std|).mniCheckout"
+msgctxt "wnd(Log|Project|Std|).mniCheckout:"
 msgid "Check Out"
 msgstr "检出"
 
-msgctxt "wnd(Log|Project|Std|).mniCherryPick"
+msgctxt "wnd(Log|Project|Std|).mniCherryPick:"
 msgid "Cherry-Pick"
 msgstr "摘取"
 
-msgctxt "wnd(Log|Project|Std|).mniClean"
+msgctxt "wnd(Log|Project|Std|).mniClean:"
 msgid "Clean Working Tree"
 msgstr "清理工作区"
 
-msgctxt "wnd(Log|Project|Std|).mniClearOutput"
+msgctxt "wnd(Log|Project|Std|).mniClearOutput:"
 msgid "Clear Output"
 msgstr "清理输出"
 
-msgctxt "wnd(Log|Project|Std|).mniCommit"
+msgctxt "wnd(Log|Project|Std|).mniCommit:"
 msgid "Commit"
 msgstr "提交"
 
-msgctxt "wnd(Log|Project|Std|).mniCompact-display"
+msgctxt "wnd(Log|Project|Std|).mniCompact-display:"
 msgid "Compact Change Display"
 msgstr "紧凑型显示"
 
-msgctxt "wnd(Log|Project|Std|).mniCompareWithWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniCompareWithWorkingTree:"
 msgid "Compare with Working Tree"
 msgstr "与工作区比较"
 
-msgctxt "wnd(Log|Project|Std|).mniConfigureTagGrouping"
+msgctxt "wnd(Log|Project|Std|).mniConfigureTagGrouping:"
 msgid "Tag-Grouping"
 msgstr "标签分组"
 
-msgctxt "wnd(Log|Project|Std|).mniConfigureToolbar"
+msgctxt "wnd(Log|Project|Std|).mniConfigureToolbar:"
 msgid "Configure Toolbar"
 msgstr "配置工具栏"
 
-msgctxt "wnd(Log|Project|Std|).mniConflictSolver"
+msgctxt "wnd(Log|Project|Std|).mniConflictSolver:"
 msgid "Conflict Solver"
 msgstr "冲突解决工具"
 
-msgctxt "wnd(Log|Project|Std|).mniContactSupport"
+msgctxt "wnd(Log|Project|Std|).mniContactSupport:"
 msgid "Contact Support"
 msgstr "技术支持"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyCommitId"
+msgctxt "wnd(Log|Project|Std|).mniCopyCommitId:"
 msgid "Copy ID"
 msgstr "复制 ID"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyCommitMessage"
+msgctxt "wnd(Log|Project|Std|).mniCopyCommitMessage:"
 msgid "Copy Message"
 msgstr "复制消息"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyName"
+msgctxt "wnd(Log|Project|Std|).mniCopyName:"
 msgid "Copy Name"
 msgstr "复制文件名"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyPath"
+msgctxt "wnd(Log|Project|Std|).mniCopyPath:"
 msgid "Copy Path"
 msgstr "复制路径"
 
-msgctxt "wnd(Log|Project|Std|).mniCopyRelativePath"
+msgctxt "wnd(Log|Project|Std|).mniCopyRelativePath:"
 msgid "Copy Relative Path"
 msgstr "复制相对路径"
 
-msgctxt "wnd(Log|Project|Std|).mniCustomize"
+msgctxt "wnd(Log|Project|Std|).mniCustomize:"
 msgid "Customize"
 msgstr "自定义"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugCreateHeapDump"
+msgctxt "wnd(Log|Project|Std|).mniDebugCreateHeapDump:"
 msgid "Create Heap Dump"
 msgstr "创建堆转储"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugCreateThreadDumps"
+msgctxt "wnd(Log|Project|Std|).mniDebugCreateThreadDumps:"
 msgid "Create Periodical Thread Dumps"
 msgstr "创建定期线程转储"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugEnableRefreshTraceLogging"
+msgctxt "wnd(Log|Project|Std|).mniDebugEnableRefreshTraceLogging:"
 msgid "Starting Tracing Refreshing"
 msgstr "开始跟踪刷新"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorEvents"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorEvents:"
 msgid "Log File Monitor Events"
 msgstr "记录文件监控事件"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorState"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogFileMonitorState:"
 msgid "Log File Monitor State"
 msgstr "记录文件监控状态"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugLogOpenRepositories"
+msgctxt "wnd(Log|Project|Std|).mniDebugLogOpenRepositories:"
 msgid "Log Open Repositories"
 msgstr "记录打开仓库"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugRestart"
+msgctxt "wnd(Log|Project|Std|).mniDebugRestart:"
 msgid "Restart"
 msgstr "重新开始"
 
-msgctxt "wnd(Log|Project|Std|).mniDebugRunGc"
+msgctxt "wnd(Log|Project|Std|).mniDebugRunGc:"
 msgid "Run GC"
 msgstr "运行垃圾回收 \\(GC\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniDelete"
+msgctxt "wnd(Log|Project|Std|).mniDelete:"
 msgid "Delete"
 msgstr "删除"
 
-msgctxt "wnd(Log|Project|Std|).mniDiscard"
+msgctxt "wnd(Log|Project|Std|).mniDiscard:"
 msgid "Discard"
 msgstr "丢弃"
 
-msgctxt "wnd(Log|Project|Std|).mniEdit-ignore-case-changes"
+msgctxt "wnd(Log|Project|Std|).mniEdit-ignore-case-changes:"
 msgid "Ignore Case Change for Line Comparison"
 msgstr "忽略行比较的大小写变更"
 
-msgctxt "wnd(Log|Project|Std|).mniEditCommitAuthor"
+msgctxt "wnd(Log|Project|Std|).mniEditCommitAuthor:"
 msgid "Edit Author"
 msgstr "编辑作者"
 
-msgctxt "wnd(Log|Project|Std|).mniEditCommitMessage"
+msgctxt "wnd(Log|Project|Std|).mniEditCommitMessage:"
 msgid "Edit Message"
 msgstr "编辑提交消息"
 
-msgctxt "wnd(Log|Project|Std|).mniEditFile"
+msgctxt "wnd(Log|Project|Std|).mniEditFile:"
 msgid "Edit File"
 msgstr "编辑文件"
 
-msgctxt "wnd(Log|Project|Std|).mniExit"
+msgctxt "wnd(Log|Project|Std|).mniExit:"
 msgid "Exit"
 msgstr "退出"
 
-msgctxt "wnd(Log|Project|Std|).mniFastForward"
+msgctxt "wnd(Log|Project|Std|).mniFastForward:"
 msgid "Fast-Forward Merge"
 msgstr "快进合并"
 
-msgctxt "wnd(Log|Project|Std|).mniFetch"
+msgctxt "wnd(Log|Project|Std|).mniFetch:"
 msgid "Pull"
 msgstr "拉取"
 
-msgctxt "wnd(Log|Project|Std|).mniFile-close"
+msgctxt "wnd(Log|Project|Std|).mniFile-close:"
 msgid "Close"
 msgstr "关闭"
 
-msgctxt "wnd(Log|Project|Std|).mniFilterCommits"
+msgctxt "wnd(Log|Project|Std|).mniFilterCommits:"
 msgid "Filter Commits"
 msgstr "过滤提交"
 
-msgctxt "wnd(Log|Project|Std|).mniFilterFiles"
+msgctxt "wnd(Log|Project|Std|).mniFilterFiles:"
 msgid "Filter Files"
 msgstr "过滤文件"
 
-msgctxt "wnd(Log|Project|Std|).mniFindAction"
+msgctxt "wnd(Log|Project|Std|).mniFindAction:"
 msgid "Find Command"
 msgstr "查找命令"
 
-msgctxt "wnd(Log|Project|Std|).mniFindObject"
+msgctxt "wnd(Log|Project|Std|).mniFindObject:"
 msgid "Find Object"
 msgstr "查找对象"
 
-msgctxt "wnd(Log|Project|Std|).mniFixup"
+msgctxt "wnd(Log|Project|Std|).mniFixup:"
 msgid "Use Message for Commit"
 msgstr "修复"
 
 #, fuzzy
-msgctxt "wnd(Log|Project|Std|).mniFlowConfigure"
+msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure"
 msgstr "配置"
 
@@ -14828,184 +14828,184 @@ msgctxt "wnd(Log|Project|Std|).mniFlowConfigure:"
 msgid "Configure"
 msgstr "配置"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowContext"
+msgctxt "wnd(Log|Project|Std|).mniFlowContext:"
 msgid "Git-Flow"
 msgstr "Git 工作流"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowFeatureFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowFeatureFinish:"
 msgid "Finish Feature"
 msgstr "完成 Feature"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowFeatureStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowFeatureStart:"
 msgid "Start Feature"
 msgstr "开始 Feature"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowHotfixFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowHotfixFinish:"
 msgid "Finish Hotfix"
 msgstr "完成 Hotfix"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowHotfixStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowHotfixStart:"
 msgid "Start Hotfix"
 msgstr "开始 Hotfix"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowIntegrateDevelop"
+msgctxt "wnd(Log|Project|Std|).mniFlowIntegrateDevelop:"
 msgid "Integrate Develop"
 msgstr "整合开发"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowReleaseFinish"
+msgctxt "wnd(Log|Project|Std|).mniFlowReleaseFinish:"
 msgid "Finish Release"
 msgstr "完成 Release"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowReleaseStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowReleaseStart:"
 msgid "Start Release"
 msgstr "开始 Release"
 
-msgctxt "wnd(Log|Project|Std|).mniFlowSupportStart"
+msgctxt "wnd(Log|Project|Std|).mniFlowSupportStart:"
 msgid "Start Support Branch"
 msgstr "开始 Support 分支"
 
-msgctxt "wnd(Log|Project|Std|).mniForgetCommit"
+msgctxt "wnd(Log|Project|Std|).mniForgetCommit:"
 msgid "Forget Commit"
 msgstr "忘记提交"
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-line"
+msgctxt "wnd(Log|Project|Std|).mniGoto-line:"
 msgid "Go to Line"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-next-diff"
+msgctxt "wnd(Log|Project|Std|).mniGoto-next-diff:"
 msgid "Next Change"
 msgstr "下一处差异"
 
-msgctxt "wnd(Log|Project|Std|).mniGoto-previous-diff"
+msgctxt "wnd(Log|Project|Std|).mniGoto-previous-diff:"
 msgid "Previous Change"
 msgstr "上一处差异"
 
-msgctxt "wnd(Log|Project|Std|).mniGotoChildrenCommit"
+msgctxt "wnd(Log|Project|Std|).mniGotoChildrenCommit:"
 msgid "Select Child Commit"
 msgstr "选择子提交"
 
-msgctxt "wnd(Log|Project|Std|).mniGotoParentsCommit"
+msgctxt "wnd(Log|Project|Std|).mniGotoParentsCommit:"
 msgid "Select Parent Commit"
 msgstr "选择父提交"
 
-msgctxt "wnd(Log|Project|Std|).mniIgnore"
+msgctxt "wnd(Log|Project|Std|).mniIgnore:"
 msgid "Ignore"
 msgstr "忽略"
 
-msgctxt "wnd(Log|Project|Std|).mniIgnore-line-separators"
+msgctxt "wnd(Log|Project|Std|).mniIgnore-line-separators:"
 msgid "Ignore Line-Ending Changes"
 msgstr "忽略行尾序列变更"
 
-msgctxt "wnd(Log|Project|Std|).mniIgnoreReveal"
+msgctxt "wnd(Log|Project|Std|).mniIgnoreReveal:"
 msgid "Edit Ignore File"
 msgstr "编辑忽略文件"
 
-msgctxt "wnd(Log|Project|Std|).mniIncludeTrackedRemoteBranches"
+msgctxt "wnd(Log|Project|Std|).mniIncludeTrackedRemoteBranches:"
 msgid "Include Tracked Remote Branches"
 msgstr "包括跟踪远程分支"
 
-msgctxt "wnd(Log|Project|Std|).mniIndexEditor"
+msgctxt "wnd(Log|Project|Std|).mniIndexEditor:"
 msgid "Index Editor"
 msgstr "索引编辑器"
 
-msgctxt "wnd(Log|Project|Std|).mniInvestigate"
+msgctxt "wnd(Log|Project|Std|).mniInvestigate:"
 msgid "Investigate"
 msgstr "审查"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsInstall"
+msgctxt "wnd(Log|Project|Std|).mniLfsInstall:"
 msgid "Install"
 msgstr "安装"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsLock"
+msgctxt "wnd(Log|Project|Std|).mniLfsLock:"
 msgid "Lock"
 msgstr "加锁"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsPrune"
+msgctxt "wnd(Log|Project|Std|).mniLfsPrune:"
 msgid "Prune"
 msgstr "修剪"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsTrack"
+msgctxt "wnd(Log|Project|Std|).mniLfsTrack:"
 msgid "Track"
 msgstr "跟踪"
 
-msgctxt "wnd(Log|Project|Std|).mniLfsUnlock"
+msgctxt "wnd(Log|Project|Std|).mniLfsUnlock:"
 msgid "Unlock"
 msgstr "解锁"
 
-msgctxt "wnd(Log|Project|Std|).mniLicenseAgreement"
+msgctxt "wnd(Log|Project|Std|).mniLicenseAgreement:"
 msgid "License Agreement"
 msgstr "许可协议"
 
-msgctxt "wnd(Log|Project|Std|).mniLocalGc"
+msgctxt "wnd(Log|Project|Std|).mniLocalGc:"
 msgid "Run Garbage Collector"
 msgstr "运行垃圾收集器"
 
-msgctxt "wnd(Log|Project|Std|).mniLog"
+msgctxt "wnd(Log|Project|Std|).mniLog:"
 msgid "Log"
 msgstr "日志"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringBranch"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringBranch:"
 msgid "Branch Coloring"
 msgstr "分支着色"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringDefault"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringDefault:"
 msgid "Default Coloring"
 msgstr "默认着色"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringLegacy"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringLegacy:"
 msgid "Varying Coloring"
 msgstr "变色"
 
-msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringMerge"
+msgctxt "wnd(Log|Project|Std|).mniLogCommitsColoringMerge:"
 msgid "Mergeable Coloring"
 msgstr "可合并着色"
 
-msgctxt "wnd(Log|Project|Std|).mniLogRepository"
+msgctxt "wnd(Log|Project|Std|).mniLogRepository:"
 msgid "Show Log Window"
 msgstr "日志窗口"
 
-msgctxt "wnd(Log|Project|Std|).mniLogShowAllParents"
+msgctxt "wnd(Log|Project|Std|).mniLogShowAllParents:"
 msgid "Follow All Parents"
 msgstr "关注所有父系"
 
-msgctxt "wnd(Log|Project|Std|).mniLogShowOnlyFirstParents"
+msgctxt "wnd(Log|Project|Std|).mniLogShowOnlyFirstParents:"
 msgid "Follow Only First Parent"
 msgstr "只显示第一个父系"
 
-msgctxt "wnd(Log|Project|Std|).mniLogTopoFiltering"
+msgctxt "wnd(Log|Project|Std|).mniLogTopoFiltering:"
 msgid "Show Graph While Filtering"
 msgstr "筛选时显示图形"
 
-msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexOnDemand"
+msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexOnDemand:"
 msgid "Show Working Tree  Index On Demand"
 msgstr "按需显示工作区索引"
 
-msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexPermanent"
+msgctxt "wnd(Log|Project|Std|).mniLogWorkingTreeIndexPermanent:"
 msgid "Show Working Tree Permanently"
 msgstr "永久显示工作区索引"
 
-msgctxt "wnd(Log|Project|Std|).mniMailingList"
+msgctxt "wnd(Log|Project|Std|).mniMailingList:"
 msgid "SmartGit Website"
 msgstr "SmartGit 官方网站"
 
-msgctxt "wnd(Log|Project|Std|).mniMerge"
+msgctxt "wnd(Log|Project|Std|).mniMerge:"
 msgid "Merge"
 msgstr "合并"
 
-msgctxt "wnd(Log|Project|Std|).mniModifyCommit"
+msgctxt "wnd(Log|Project|Std|).mniModifyCommit:"
 msgid "Modify"
 msgstr "修改"
 
-msgctxt "wnd(Log|Project|Std|).mniNewStandardWindow"
+msgctxt "wnd(Log|Project|Std|).mniNewStandardWindow:"
 msgid "Show Standard Window"
 msgstr "显示标准窗口"
 
-msgctxt "wnd(Log|Project|Std|).mniNewWindow"
+msgctxt "wnd(Log|Project|Std|).mniNewWindow:"
 msgid "New Window"
 msgstr "新窗口"
 
 #, fuzzy
-msgctxt "wnd(Log|Project|Std|).mniOpen"
+msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open from Working Tree"
 msgstr "打开"
 
@@ -15018,99 +15018,99 @@ msgctxt "wnd(Log|Project|Std|).mniOpen:"
 msgid "Open"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniOpenDocumentation"
+msgctxt "wnd(Log|Project|Std|).mniOpenDocumentation:"
 msgid "Online Documentation"
 msgstr "在线文档"
 
-msgctxt "wnd(Log|Project|Std|).mniOpenRootLog"
+msgctxt "wnd(Log|Project|Std|).mniOpenRootLog:"
 msgid "Open Root Log"
 msgstr "打开根日志"
 
-msgctxt "wnd(Log|Project|Std|).mniOpenUserEcho"
+msgctxt "wnd(Log|Project|Std|).mniOpenUserEcho:"
 msgid "Feature Requests"
 msgstr "功能请求"
 
-msgctxt "wnd(Log|Project|Std|).mniOpenWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniOpenWorkingTree:"
 msgid "Open Working Tree"
 msgstr "打开工作区"
 
-msgctxt "wnd(Log|Project|Std|).mniPreferences"
+msgctxt "wnd(Log|Project|Std|).mniPreferences:"
 msgid "Preferences"
 msgstr "偏好设置"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCommentNext"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCommentNext:"
 msgid "Next Comment"
 msgstr "下一条注释"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCommentPrevious"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCommentPrevious:"
 msgid "Previous Comment"
 msgstr "上一条注释"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareAutomatic"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareAutomatic:"
 msgid "Automatic"
 msgstr "自动"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareHeadVsIndex"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareHeadVsIndex:"
 msgid "HEAD vs. Index"
 msgstr "HEAD 与索引"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewCompareIndexVsWT"
+msgctxt "wnd(Log|Project|Std|).mniPreviewCompareIndexVsWT:"
 msgid "Index vs. Working Tree"
 msgstr "索引与工作区"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewRefresh"
+msgctxt "wnd(Log|Project|Std|).mniPreviewRefresh:"
 msgid "Reload"
 msgstr "刷新"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewShowCurrentLines"
+msgctxt "wnd(Log|Project|Std|).mniPreviewShowCurrentLines:"
 msgid "Show Long Current Lines"
 msgstr "显示长的当前行"
 
-msgctxt "wnd(Log|Project|Std|).mniPreviewUndo"
+msgctxt "wnd(Log|Project|Std|).mniPreviewUndo:"
 msgid "Undo"
 msgstr "撤销"
 
-msgctxt "wnd(Log|Project|Std|).mniPush"
+msgctxt "wnd(Log|Project|Std|).mniPush:"
 msgid "Push"
 msgstr "推送"
 
-msgctxt "wnd(Log|Project|Std|).mniPushCommits"
+msgctxt "wnd(Log|Project|Std|).mniPushCommits:"
 msgid "Push Up To"
 msgstr "推送提交"
 
-msgctxt "wnd(Log|Project|Std|).mniPushTo"
+msgctxt "wnd(Log|Project|Std|).mniPushTo:"
 msgid "Push To"
 msgstr "推送到"
 
-msgctxt "wnd(Log|Project|Std|).mniPushToGerrit"
+msgctxt "wnd(Log|Project|Std|).mniPushToGerrit:"
 msgid "Push to Gerrit"
 msgstr "推送到 Gerrit"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseAbort"
+msgctxt "wnd(Log|Project|Std|).mniRebaseAbort:"
 msgid "Abort"
 msgstr "中止"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseContinue"
+msgctxt "wnd(Log|Project|Std|).mniRebaseContinue:"
 msgid "Continue"
 msgstr "继续"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseHeadTo"
+msgctxt "wnd(Log|Project|Std|).mniRebaseHeadTo:"
 msgid "Rebase"
 msgstr "将 HEAD 变基至"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseInteractive"
+msgctxt "wnd(Log|Project|Std|).mniRebaseInteractive:"
 msgid "Rebase Interactive From"
 msgstr "交互式变基至"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseSkip"
+msgctxt "wnd(Log|Project|Std|).mniRebaseSkip:"
 msgid "Skip"
 msgstr "跳过"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseStep"
+msgctxt "wnd(Log|Project|Std|).mniRebaseStep:"
 msgid "Step"
 msgstr "步骤"
 
-msgctxt "wnd(Log|Project|Std|).mniRebaseToHead"
+msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD"
 msgstr "变基至 HEAD"
 
@@ -15122,75 +15122,75 @@ msgctxt "wnd(Log|Project|Std|).mniRebaseToHead:"
 msgid "Rebase to HEAD"
 msgstr "变基至 HEAD"
 
-msgctxt "wnd(Log|Project|Std|).mniRefresh"
+msgctxt "wnd(Log|Project|Std|).mniRefresh:"
 msgid "Refresh"
 msgstr "刷新"
 
-msgctxt "wnd(Log|Project|Std|).mniRegister"
+msgctxt "wnd(Log|Project|Std|).mniRegister:"
 msgid "Register"
 msgstr "注册产品"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteAdd"
+msgctxt "wnd(Log|Project|Std|).mniRemoteAdd:"
 msgid "Add"
 msgstr "创建"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteCopyUrl"
+msgctxt "wnd(Log|Project|Std|).mniRemoteCopyUrl:"
 msgid "Copy URL"
 msgstr "复制网址"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteDelete"
+msgctxt "wnd(Log|Project|Std|).mniRemoteDelete:"
 msgid "Delete"
 msgstr "删除"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetch"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetch:"
 msgid "Fetch"
 msgstr "获取"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetchAll"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetchAll:"
 msgid "Fetch All"
 msgstr "获取所有"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteFetchMore"
+msgctxt "wnd(Log|Project|Std|).mniRemoteFetchMore:"
 msgid "Fetch More"
 msgstr "获取更多"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteProperties"
+msgctxt "wnd(Log|Project|Std|).mniRemoteProperties:"
 msgid "Properties"
 msgstr "属性"
 
-msgctxt "wnd(Log|Project|Std|).mniRemoteRename"
+msgctxt "wnd(Log|Project|Std|).mniRemoteRename:"
 msgid "Rename"
 msgstr "重命名"
 
-msgctxt "wnd(Log|Project|Std|).mniRemove"
+msgctxt "wnd(Log|Project|Std|).mniRemove:"
 msgid "Remove"
 msgstr "移除"
 
-msgctxt "wnd(Log|Project|Std|).mniRename"
+msgctxt "wnd(Log|Project|Std|).mniRename:"
 msgid "Move or Rename"
 msgstr "重命名"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryAdd"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryAdd:"
 msgid "Add or Create"
 msgstr "添加或创建"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryAddGroup"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryAddGroup:"
 msgid "Add Group"
 msgstr "创建分组"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryClone"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryClone:"
 msgid "Clone"
 msgstr "克隆"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryClose"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryClose:"
 msgid "Close Repository"
 msgstr "关闭"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfig"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfig:"
 msgid "Repository"
 msgstr "仓库"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfigUser"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryEditConfigUser:"
 msgid "User"
 msgstr "用户"
 
@@ -15206,95 +15206,95 @@ msgctxt "wnd(Log|Project|Std|).mniRepositoryFavorite:"
 msgid "Unmark as Favorite"
 msgstr "取消标记收藏"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryOpen"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryOpen:"
 msgid "Open Repository"
 msgstr "打开仓库"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryOpenInNewWindow"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryOpenInNewWindow:"
 msgid "Open Repository in New Window"
 msgstr "在新窗口中打开仓库"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryRemove"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryRemove:"
 msgid "Remove"
 msgstr "删除"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositoryRename"
+msgctxt "wnd(Log|Project|Std|).mniRepositoryRename:"
 msgid "Rename"
 msgstr "重命名"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySearch"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySearch:"
 msgid "Search for Repositories"
 msgstr "搜索仓库"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySelectObsolete"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySelectObsolete:"
 msgid "Select Obsolete Repositories"
 msgstr "选择过时的仓库"
 
-msgctxt "wnd(Log|Project|Std|).mniRepositorySettings"
+msgctxt "wnd(Log|Project|Std|).mniRepositorySettings:"
 msgid "Settings"
 msgstr "设置"
 
-msgctxt "wnd(Log|Project|Std|).mniReset"
+msgctxt "wnd(Log|Project|Std|).mniReset:"
 msgid "Reset"
 msgstr "重置提交"
 
-msgctxt "wnd(Log|Project|Std|).mniResetAdvanced"
+msgctxt "wnd(Log|Project|Std|).mniResetAdvanced:"
 msgid "Reset Advanced"
 msgstr "重置提交 \\(高级\\)"
 
-msgctxt "wnd(Log|Project|Std|).mniResolve"
+msgctxt "wnd(Log|Project|Std|).mniResolve:"
 msgid "Resolve"
 msgstr "解决"
 
-msgctxt "wnd(Log|Project|Std|).mniResolveOurs"
+msgctxt "wnd(Log|Project|Std|).mniResolveOurs:"
 msgid "Take Ours"
 msgstr "采用 我们的"
 
-msgctxt "wnd(Log|Project|Std|).mniResolveRecreateConflict"
+msgctxt "wnd(Log|Project|Std|).mniResolveRecreateConflict:"
 msgid "Recreate Conflict"
 msgstr "重现冲突"
 
-msgctxt "wnd(Log|Project|Std|).mniResolveTheirs"
+msgctxt "wnd(Log|Project|Std|).mniResolveTheirs:"
 msgid "Take Theirs"
 msgstr "采用 他们的"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommit"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommit:"
 msgid "Reveal Commit"
 msgstr "显示提交"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommitExtend"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommitExtend:"
 msgid "Compare with Selected Commit"
 msgstr "与选中提交比较"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealCommitWithHead"
+msgctxt "wnd(Log|Project|Std|).mniRevealCommitWithHead:"
 msgid "Compare with HEAD"
 msgstr "与 HEAD 比较"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealPrevCommit"
+msgctxt "wnd(Log|Project|Std|).mniRevealPrevCommit:"
 msgid "Reveal Previous Commit"
 msgstr "显示先前的提交"
 
-msgctxt "wnd(Log|Project|Std|).mniRevealWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniRevealWorkingTree:"
 msgid "Reveal Working Tree"
 msgstr "显示工作区"
 
-msgctxt "wnd(Log|Project|Std|).mniRevert"
+msgctxt "wnd(Log|Project|Std|).mniRevert:"
 msgid "Revert"
 msgstr "还原"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewCommentCreate"
+msgctxt "wnd(Log|Project|Std|).mniReviewCommentCreate:"
 msgid "Add Comment"
 msgstr "添加注释"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewConfigure"
+msgctxt "wnd(Log|Project|Std|).mniReviewConfigure:"
 msgid "Configure"
 msgstr "配置"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase"
+msgctxt "wnd(Log|Project|Std|).mniReviewDumpDatabase:"
 msgid "Dump Database"
 msgstr "转储数据库"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate"
+msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Pull Request"
 msgstr "创建拉取请求"
 
@@ -15306,335 +15306,335 @@ msgctxt "wnd(Log|Project|Std|).mniReviewPullRequestCreate:"
 msgid "Create Pull Request"
 msgstr "创建拉取请求"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewShowClosedPullRequests"
+msgctxt "wnd(Log|Project|Std|).mniReviewShowClosedPullRequests:"
 msgid "Show Closed Pull Requests"
 msgstr "显示已关闭的拉取请求"
 
-msgctxt "wnd(Log|Project|Std|).mniReviewSync"
+msgctxt "wnd(Log|Project|Std|).mniReviewSync:"
 msgid "Sync"
 msgstr "同步"
 
-msgctxt "wnd(Log|Project|Std|).mniRewriteTextFile"
+msgctxt "wnd(Log|Project|Std|).mniRewriteTextFile:"
 msgid "Fix Line-Endings"
 msgstr "修复换行符"
 
-msgctxt "wnd(Log|Project|Std|).mniRollbackTo"
+msgctxt "wnd(Log|Project|Std|).mniRollbackTo:"
 msgid "Rollback To"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniSaveAs"
+msgctxt "wnd(Log|Project|Std|).mniSaveAs:"
 msgid "Save As"
 msgstr "另存为"
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-find"
+msgctxt "wnd(Log|Project|Std|).mniSearch-find:"
 msgid "Find"
 msgstr "查找"
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-next"
+msgctxt "wnd(Log|Project|Std|).mniSearch-next:"
 msgid "Find Next"
 msgstr "查找下一处"
 
-msgctxt "wnd(Log|Project|Std|).mniSearch-previous"
+msgctxt "wnd(Log|Project|Std|).mniSearch-previous:"
 msgid "Find Previous"
 msgstr "查找上一处"
 
-msgctxt "wnd(Log|Project|Std|).mniSelectCommittableFiles"
+msgctxt "wnd(Log|Project|Std|).mniSelectCommittableFiles:"
 msgid "Select Committable Files"
 msgstr "选择可提交文件"
 
-msgctxt "wnd(Log|Project|Std|).mniSelectDirectory"
+msgctxt "wnd(Log|Project|Std|).mniSelectDirectory:"
 msgid "Select Directory"
 msgstr "选择目录"
 
-msgctxt "wnd(Log|Project|Std|).mniSelectRoot"
+msgctxt "wnd(Log|Project|Std|).mniSelectRoot:"
 msgid "Select Repository Root"
 msgstr "选择仓库根目录"
 
-msgctxt "wnd(Log|Project|Std|).mniSet-syntax"
+msgctxt "wnd(Log|Project|Std|).mniSet-syntax:"
 msgid "Syntax Language"
 msgstr "语言模式"
 
-msgctxt "wnd(Log|Project|Std|).mniSetDepth"
+msgctxt "wnd(Log|Project|Std|).mniSetDepth:"
 msgid "Set Depth"
 msgstr "设置深度"
 
-msgctxt "wnd(Log|Project|Std|).mniShow-line-numbers"
+msgctxt "wnd(Log|Project|Std|).mniShow-line-numbers:"
 msgid "Show Line Numbers"
 msgstr "显示行号"
 
-msgctxt "wnd(Log|Project|Std|).mniShowChanges"
+msgctxt "wnd(Log|Project|Std|).mniShowChanges:"
 msgid "Show Changes"
 msgstr "显示变更"
 
-msgctxt "wnd(Log|Project|Std|).mniSkipWorkTree"
+msgctxt "wnd(Log|Project|Std|).mniSkipWorkTree:"
 msgid "Toggle 'Skip Worktree'"
 msgstr "切换 “跳过工作区”"
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsAsIs"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsAsIs:"
 msgid "Sort By Time"
 msgstr "按时间排序"
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsFirstParentsBeforeMergeParents"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsFirstParentsBeforeMergeParents:"
 msgid "Sort First Parents before Merge Parents"
 msgstr "Sort First Parents before Merge Parents"
 
-msgctxt "wnd(Log|Project|Std|).mniSortCommitsMergeParentsBeforeFirstParents"
+msgctxt "wnd(Log|Project|Std|).mniSortCommitsMergeParentsBeforeFirstParents:"
 msgid "Sort Merge Parents before First Parents"
 msgstr "Sort Merge Parents before First Parents"
 
-msgctxt "wnd(Log|Project|Std|).mniSplitCommit"
+msgctxt "wnd(Log|Project|Std|).mniSplitCommit:"
 msgid "Split"
 msgstr "拆分"
 
-msgctxt "wnd(Log|Project|Std|).mniSquashCommits"
+msgctxt "wnd(Log|Project|Std|).mniSquashCommits:"
 msgid "Squash"
 msgstr "压缩"
 
-msgctxt "wnd(Log|Project|Std|).mniStage"
+msgctxt "wnd(Log|Project|Std|).mniStage:"
 msgid "Stage"
 msgstr "暂存"
 
-msgctxt "wnd(Log|Project|Std|).mniStashApply"
+msgctxt "wnd(Log|Project|Std|).mniStashApply:"
 msgid "Apply Stash"
 msgstr "应用贮藏"
 
-msgctxt "wnd(Log|Project|Std|).mniStashDrop"
+msgctxt "wnd(Log|Project|Std|).mniStashDrop:"
 msgid "Drop Stash"
 msgstr "丢弃贮藏"
 
-msgctxt "wnd(Log|Project|Std|).mniStashRename"
+msgctxt "wnd(Log|Project|Std|).mniStashRename:"
 msgid "Rename Stash"
 msgstr "重命名贮藏"
 
-msgctxt "wnd(Log|Project|Std|).mniStashSave"
+msgctxt "wnd(Log|Project|Std|).mniStashSave:"
 msgid "Stash All"
 msgstr "贮藏所有"
 
-msgctxt "wnd(Log|Project|Std|).mniStashSaveSelection"
+msgctxt "wnd(Log|Project|Std|).mniStashSaveSelection:"
 msgid "Stash Selection"
 msgstr "贮藏选中"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeactivate"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeactivate:"
 msgid "Deactivate"
 msgstr "停用"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeinit"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleDeinit:"
 msgid "Deinit"
 msgstr "定义"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleInit"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleInit:"
 msgid "Initialize"
 msgstr "初始化"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleRegister"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleRegister:"
 msgid "Add"
 msgstr "创建"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleReset"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleReset:"
 msgid "Reset"
 msgstr "重置"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleSync"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleSync:"
 msgid "Synchronize"
 msgstr "同步"
 
-msgctxt "wnd(Log|Project|Std|).mniSubmoduleUnregister"
+msgctxt "wnd(Log|Project|Std|).mniSubmoduleUnregister:"
 msgid "Unregister"
 msgstr "注销"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeAdd"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeAdd:"
 msgid "Add"
 msgstr "创建"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeMerge"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeMerge:"
 msgid "Merge"
 msgstr "合并"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreePush"
+msgctxt "wnd(Log|Project|Std|).mniSubtreePush:"
 msgid "Push"
 msgstr "推送"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeReset"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeReset:"
 msgid "Reset"
 msgstr "重置"
 
-msgctxt "wnd(Log|Project|Std|).mniSubtreeSplit"
+msgctxt "wnd(Log|Project|Std|).mniSubtreeSplit:"
 msgid "Split"
 msgstr "拆分"
 
-msgctxt "wnd(Log|Project|Std|).mniSync"
+msgctxt "wnd(Log|Project|Std|).mniSync:"
 msgid "Synchronize"
 msgstr "同步"
 
-msgctxt "wnd(Log|Project|Std|).mniUndoLastCommit"
+msgctxt "wnd(Log|Project|Std|).mniUndoLastCommit:"
 msgid "Undo Last Commit"
 msgstr "取消最后一次提交"
 
-msgctxt "wnd(Log|Project|Std|).mniUnstage"
+msgctxt "wnd(Log|Project|Std|).mniUnstage:"
 msgid "Unstage"
 msgstr "取消暂存"
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces:"
 msgid "Ignore Whitespace"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-all"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-all:"
 msgid "Ignore All Whitespaces for Line Comparison"
 msgstr "忽略所有空白字符变化"
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-leading-trailing"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-leading-trailing:"
 msgid "Ignore Leading/Trailing Whitespaces for Line Comparison"
 msgstr "行比较时忽略前导/尾随空格"
 
-msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-none"
+msgctxt "wnd(Log|Project|Std|).mniView-ignore-whitespaces-none:"
 msgid "Ignore No Whitespace for Line Comparison"
 msgstr "行比较时忽略没有用于比较的空格"
 
-msgctxt "wnd(Log|Project|Std|).mniView-remember-as-default"
+msgctxt "wnd(Log|Project|Std|).mniView-remember-as-default:"
 msgid "Remember as Default"
 msgstr "记住默认"
 
-msgctxt "wnd(Log|Project|Std|).mniView-settings"
+msgctxt "wnd(Log|Project|Std|).mniView-settings:"
 msgid "Settings"
 msgstr "设置"
 
-msgctxt "wnd(Log|Project|Std|).mniView-show-current-line-control"
+msgctxt "wnd(Log|Project|Std|).mniView-show-current-line-control:"
 msgid "Show Long Current Lines"
 msgstr "显示长的当前行"
 
-msgctxt "wnd(Log|Project|Std|).mniViewFromSubmodules"
+msgctxt "wnd(Log|Project|Std|).mniViewFromSubmodules:"
 msgid "Show Files From Submodules"
 msgstr "从子模块显示文件"
 
-msgctxt "wnd(Log|Project|Std|).mniViewIgnored"
+msgctxt "wnd(Log|Project|Std|).mniViewIgnored:"
 msgid "Show Ignored Files"
 msgstr "显示忽略文件"
 
-msgctxt "wnd(Log|Project|Std|).mniViewRecursive"
+msgctxt "wnd(Log|Project|Std|).mniViewRecursive:"
 msgid "Files from Subdirectories"
 msgstr "来自子目录的文件"
 
-msgctxt "wnd(Log|Project|Std|).mniViewRenameSource"
+msgctxt "wnd(Log|Project|Std|).mniViewRenameSource:"
 msgid "Show Rename Source Files"
 msgstr "显示重命名源文件"
 
-msgctxt "wnd(Log|Project|Std|).mniViewSeparateWtAndIndex"
+msgctxt "wnd(Log|Project|Std|).mniViewSeparateWtAndIndex:"
 msgid "Separate Working Tree and Index"
 msgstr "单独的工作区和索引"
 
-msgctxt "wnd(Log|Project|Std|).mniViewSetAnchorCommit"
+msgctxt "wnd(Log|Project|Std|).mniViewSetAnchorCommit:"
 msgid "Set Anchor Commit"
 msgstr "设置锚点提交"
 
-msgctxt "wnd(Log|Project|Std|).mniViewSkipped"
+msgctxt "wnd(Log|Project|Std|).mniViewSkipped:"
 msgid "Show Skipped Files"
 msgstr "显示跳过文件"
 
-msgctxt "wnd(Log|Project|Std|).mniViewStaged"
+msgctxt "wnd(Log|Project|Std|).mniViewStaged:"
 msgid "Show Staged Files"
 msgstr "显示暂存文件"
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleIndex"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleIndex:"
 msgid "Only Index"
 msgstr "只有索引"
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleMixed"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleMixed:"
 msgid "Mixed"
 msgstr "混合"
 
-msgctxt "wnd(Log|Project|Std|).mniViewStyleWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniViewStyleWorkingTree:"
 msgid "Only Working Tree"
 msgstr "仅工作区"
 
-msgctxt "wnd(Log|Project|Std|).mniViewToolBar"
+msgctxt "wnd(Log|Project|Std|).mniViewToolBar:"
 msgid "Show Toolbar"
 msgstr "显示工具栏"
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnchanged"
+msgctxt "wnd(Log|Project|Std|).mniViewUnchanged:"
 msgid "Show Unchanged Files"
 msgstr "显示未变更的文件"
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnchangedAssumed"
+msgctxt "wnd(Log|Project|Std|).mniViewUnchangedAssumed:"
 msgid "Show Assume-Unchanged Files"
 msgstr "显示 “假设不变” 的文件"
 
-msgctxt "wnd(Log|Project|Std|).mniViewUnversioned"
+msgctxt "wnd(Log|Project|Std|).mniViewUnversioned:"
 msgid "Show Unversioned Files"
 msgstr "显示无版本文件"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowBranches"
+msgctxt "wnd(Log|Project|Std|).mniWindowBranches:"
 msgid "Branches"
 msgstr "分支视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowChanges"
+msgctxt "wnd(Log|Project|Std|).mniWindowChanges:"
 msgid "Changes"
 msgstr "变更视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowClose"
+msgctxt "wnd(Log|Project|Std|).mniWindowClose:"
 msgid "Close"
 msgstr "关闭"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowComments"
+msgctxt "wnd(Log|Project|Std|).mniWindowComments:"
 msgid "Comments"
 msgstr "注释视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowCommit"
+msgctxt "wnd(Log|Project|Std|).mniWindowCommit:"
 msgid "Commit"
 msgstr "提交视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowDebugLog"
+msgctxt "wnd(Log|Project|Std|).mniWindowDebugLog:"
 msgid "Debug Log"
 msgstr "调试记录"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowDirectories"
+msgctxt "wnd(Log|Project|Std|).mniWindowDirectories:"
 msgid "Repositories"
 msgstr "仓库视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowFiles"
+msgctxt "wnd(Log|Project|Std|).mniWindowFiles:"
 msgid "Files"
 msgstr "文件视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowGraph"
+msgctxt "wnd(Log|Project|Std|).mniWindowGraph:"
 msgid "Graph"
 msgstr "图形视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowHideView"
+msgctxt "wnd(Log|Project|Std|).mniWindowHideView:"
 msgid "Hide View"
 msgstr "隐藏选中视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowJournal"
+msgctxt "wnd(Log|Project|Std|).mniWindowJournal:"
 msgid "Journal"
 msgstr "日志视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutReset"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutReset:"
 msgid "Reset Perspective"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetMain"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetMain:"
 msgid "Main Perspective"
 msgstr "主要审阅"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetReview"
+msgctxt "wnd(Log|Project|Std|).mniWindowLayoutSetReview:"
 msgid "Review Perspective"
 msgstr "审阅视角"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowOutput"
+msgctxt "wnd(Log|Project|Std|).mniWindowOutput:"
 msgid "Output"
 msgstr "输出视图"
 
-msgctxt "wnd(Log|Project|Std|).mniWindowWorkingTree"
+msgctxt "wnd(Log|Project|Std|).mniWindowWorkingTree:"
 msgid "Show Working Tree Window"
 msgstr "工作区窗口"
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreeAdd"
+msgctxt "wnd(Log|Project|Std|).mniWorktreeAdd:"
 msgid "Add Worktree"
 msgstr "创建工作区"
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreePrune"
+msgctxt "wnd(Log|Project|Std|).mniWorktreePrune:"
 msgid "Prune Obsolete Worktrees"
 msgstr "修剪过时的工作区"
 
-msgctxt "wnd(Log|Project|Std|).mniWorktreeRemove"
+msgctxt "wnd(Log|Project|Std|).mniWorktreeRemove:"
 msgid "Remove Worktree"
 msgstr "远程工作树"
 
@@ -15830,7 +15830,7 @@ msgctxt "wnd(Log|Project|Std|).tab:"
 msgid "Repositories"
 msgstr "仓库"
 
-msgctxt "wnd(Log|Project|Std|).tbr\"  History  \""
+msgctxt "wnd(Log|Project|Std|).tbr\"  History  \":"
 msgid "History"
 msgstr "历史"
 
@@ -16098,119 +16098,119 @@ msgctxt "wnd(Log|Project|Std|).tbt:"
 msgid "Show directories tree"
 msgstr "显示目录树"
 
-msgctxt "wnd(Log|Project|Std|).tbtAnnotate"
+msgctxt "wnd(Log|Project|Std|).tbtAnnotate:"
 msgid "Show a blame \\(annotated\\) view of the selected file."
 msgstr "显示所选文件的追溯 \\(注释\\) 视图。"
 
-msgctxt "wnd(Log|Project|Std|).tbtBranchAdd"
+msgctxt "wnd(Log|Project|Std|).tbtBranchAdd:"
 msgid "Add a new branch for the current commit."
 msgstr "为当前提交添加新分支。"
 
-msgctxt "wnd(Log|Project|Std|).tbtBranchAddTag"
+msgctxt "wnd(Log|Project|Std|).tbtBranchAddTag:"
 msgid "Add a new tag for the current commit."
 msgstr "为当前提交添加新标签。"
 
-msgctxt "wnd(Log|Project|Std|).tbtCheckout"
+msgctxt "wnd(Log|Project|Std|).tbtCheckout:"
 msgid "Check out an existing commit."
 msgstr "检出一个现有提交。"
 
-msgctxt "wnd(Log|Project|Std|).tbtCherryPick"
+msgctxt "wnd(Log|Project|Std|).tbtCherryPick:"
 msgid "Cherry-pick commits from other branches."
 msgstr "合并来自其他分支的修改."
 
-msgctxt "wnd(Log|Project|Std|).tbtClearOutput"
+msgctxt "wnd(Log|Project|Std|).tbtClearOutput:"
 msgid "Clear output pane."
 msgstr "清除输出窗格。"
 
-msgctxt "wnd(Log|Project|Std|).tbtCommit"
+msgctxt "wnd(Log|Project|Std|).tbtCommit:"
 msgid "Commit local changes."
 msgstr "提交本地变更。"
 
-msgctxt "wnd(Log|Project|Std|).tbtConflictSolver"
+msgctxt "wnd(Log|Project|Std|).tbtConflictSolver:"
 msgid "Open the Conflict Solver \\(or configured external merge tool\\) to resolve conflicts."
 msgstr "打开冲突解决进程 \\(或配置的外部合并工具\\) 以解决冲突。"
 
-msgctxt "wnd(Log|Project|Std|).tbtDelete"
+msgctxt "wnd(Log|Project|Std|).tbtDelete:"
 msgid "Delete the selected local files or directory."
 msgstr "删除选定的本地文件或目录。"
 
-msgctxt "wnd(Log|Project|Std|).tbtDiscard"
+msgctxt "wnd(Log|Project|Std|).tbtDiscard:"
 msgid "Discard local changes."
 msgstr "丢弃本地变更。"
 
-msgctxt "wnd(Log|Project|Std|).tbtFetch"
+msgctxt "wnd(Log|Project|Std|).tbtFetch:"
 msgid "Fetch commits from a remote repository and \\(optionally\\) integrate them with possible local commits."
 msgstr "从远程仓库获取提交并 \\(可选\\) 将它们与本地提交集成。"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowContext"
+msgctxt "wnd(Log|Project|Std|).tbtFlowContext:"
 msgid "Finish a Git-Flow feature."
 msgstr "完成 Git 工作流功能。"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixFinish"
+msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixFinish:"
 msgid "Finish a Git-Flow hotfix."
 msgstr "完成 Git 流热修复进程。"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixStart"
+msgctxt "wnd(Log|Project|Std|).tbtFlowHotfixStart:"
 msgid "Start a new Git-Flow hotfix."
 msgstr "启动新的 Git 流热修复进程。"
 
-msgctxt "wnd(Log|Project|Std|).tbtFlowIntegrateDevelop"
+msgctxt "wnd(Log|Project|Std|).tbtFlowIntegrateDevelop:"
 msgid "Integrate new base commits into a Git-Flow feature."
 msgstr "将新的基本提交集成到 Git 流功能中。"
 
-msgctxt "wnd(Log|Project|Std|).tbtGoto-next-diff"
+msgctxt "wnd(Log|Project|Std|).tbtGoto-next-diff:"
 msgid "Go to next change."
 msgstr "下一处差异。"
 
-msgctxt "wnd(Log|Project|Std|).tbtGoto-previous-diff"
+msgctxt "wnd(Log|Project|Std|).tbtGoto-previous-diff:"
 msgid "Go to previous change."
 msgstr "上一处差异。"
 
-msgctxt "wnd(Log|Project|Std|).tbtIgnore"
+msgctxt "wnd(Log|Project|Std|).tbtIgnore:"
 msgid "Mark unversioned local files/directories to be ignored."
 msgstr "标记要忽略的未版本控制的本地文件/目录。"
 
-msgctxt "wnd(Log|Project|Std|).tbtIndexEditor"
+msgctxt "wnd(Log|Project|Std|).tbtIndexEditor:"
 msgid "Edit the Index state of the selected file, e.g. to decide which lines should be staged."
 msgstr "编辑所选文件的索引状态，例如：决定哪些行应该被暂存."
 
-msgctxt "wnd(Log|Project|Std|).tbtInvestigate"
+msgctxt "wnd(Log|Project|Std|).tbtInvestigate:"
 msgid "Investigate history line-wise with DeepGit."
 msgstr "使用 DeepGit 逐行审查历史记录。"
 
-msgctxt "wnd(Log|Project|Std|).tbtLog"
+msgctxt "wnd(Log|Project|Std|).tbtLog:"
 msgid "Show the history for selected file or directory."
 msgstr "显示所选文件或目录的历史日志。"
 
-msgctxt "wnd(Log|Project|Std|).tbtLogRepository"
+msgctxt "wnd(Log|Project|Std|).tbtLogRepository:"
 msgid "Show the history for the whole repository."
 msgstr "显示整个仓库的历史日志。"
 
-msgctxt "wnd(Log|Project|Std|).tbtMerge"
+msgctxt "wnd(Log|Project|Std|).tbtMerge:"
 msgid "Merge changes from other branches."
 msgstr "合并来自其他分支的变更。"
 
-msgctxt "wnd(Log|Project|Std|).tbtPreviewRefresh"
+msgctxt "wnd(Log|Project|Std|).tbtPreviewRefresh:"
 msgid "Reload the previewed file contents."
 msgstr "重新加载预览的文件内容。"
 
-msgctxt "wnd(Log|Project|Std|).tbtPush"
+msgctxt "wnd(Log|Project|Std|).tbtPush:"
 msgid "Push local commits to the remote origin repository."
 msgstr "将本地提交推送到远程源仓库。"
 
-msgctxt "wnd(Log|Project|Std|).tbtPushTo"
+msgctxt "wnd(Log|Project|Std|).tbtPushTo:"
 msgid "Push local commits to a remote repository, allowing to choose the target repository."
 msgstr "将本地提交推送到远程仓库，允许选择目标仓库。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRebaseHeadTo"
+msgctxt "wnd(Log|Project|Std|).tbtRebaseHeadTo:"
 msgid "Apply commits from your current branch to the selected commit."
 msgstr "将 HEAD 提交应用于所选提交。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRefresh"
+msgctxt "wnd(Log|Project|Std|).tbtRefresh:"
 msgid "Refresh the log view."
 msgstr "刷新日志视图。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch"
+msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from current remote repository."
 msgstr ""
 
@@ -16222,123 +16222,123 @@ msgctxt "wnd(Log|Project|Std|).tbtRemoteFetch:"
 msgid "Fetch commits from current remote repository."
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtRemove"
+msgctxt "wnd(Log|Project|Std|).tbtRemove:"
 msgid "Remove selected files or directories from repository."
 msgstr "从仓库中删除选定的文件或目录。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositoryAdd"
+msgctxt "wnd(Log|Project|Std|).tbtRepositoryAdd:"
 msgid "Add or create a new repository."
 msgstr "添加或创建新的仓库。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositoryClone"
+msgctxt "wnd(Log|Project|Std|).tbtRepositoryClone:"
 msgid "Clone a new repository."
 msgstr "克隆新的仓库。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRepositorySearch"
+msgctxt "wnd(Log|Project|Std|).tbtRepositorySearch:"
 msgid "Search for existing repositories."
 msgstr "搜索现有仓库。"
 
-msgctxt "wnd(Log|Project|Std|).tbtReset"
+msgctxt "wnd(Log|Project|Std|).tbtReset:"
 msgid "Reset current HEAD to another commit."
 msgstr "将当前 HEAD 重置为新的提交。"
 
-msgctxt "wnd(Log|Project|Std|).tbtResetAdvanced"
+msgctxt "wnd(Log|Project|Std|).tbtResetAdvanced:"
 msgid "Reset current HEAD to another commit and keep the difference in Index or Working Tree."
 msgstr "将当前 HEAD 重置为新的提交，并保留索引或工作区中的差异。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealHomeCommit"
+msgctxt "wnd(Log|Project|Std|).tbtRevealHomeCommit:"
 msgid "Reveal HEAD/working tree in graph."
 msgstr "在图表中显示 HEAD/工作区."
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealPrevCommit"
+msgctxt "wnd(Log|Project|Std|).tbtRevealPrevCommit:"
 msgid "Reveal selected commits before invoking Reveal Working Tree."
 msgstr "在调用显示工作区之前显示所选的提交。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRevealWorkingTree"
+msgctxt "wnd(Log|Project|Std|).tbtRevealWorkingTree:"
 msgid "Reveal working tree node in graph."
 msgstr "在图中显示工作区节点。"
 
-msgctxt "wnd(Log|Project|Std|).tbtRevert"
+msgctxt "wnd(Log|Project|Std|).tbtRevert:"
 msgid "Undo the changes of an existing commit by \"reverse\" merging it."
 msgstr "通过 \"反向\" 合并来撤销现有提交的修改。"
 
-msgctxt "wnd(Log|Project|Std|).tbtShowChanges"
+msgctxt "wnd(Log|Project|Std|).tbtShowChanges:"
 msgid "Open the file compare for the selected file."
 msgstr "打开所选文件的文件比较。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStage"
+msgctxt "wnd(Log|Project|Std|).tbtStage:"
 msgid "Store working tree files in the index to prepare the next commit."
 msgstr "将工作区文件暂存在索引中以准备下一次提交。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStashApply"
+msgctxt "wnd(Log|Project|Std|).tbtStashApply:"
 msgid "Reapply local changes from a stash."
 msgstr "从贮藏中重新应用本地变更。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStashDrop"
+msgctxt "wnd(Log|Project|Std|).tbtStashDrop:"
 msgid "Drop one or more stashes from the repository."
 msgstr "从仓库中删除一个或多个贮藏。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStashSave"
+msgctxt "wnd(Log|Project|Std|).tbtStashSave:"
 msgid "Stash current local changes."
 msgstr "贮藏当前的本地变更。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStdSetModeHistory"
+msgctxt "wnd(Log|Project|Std|).tbtStdSetModeHistory:"
 msgid "Show the history view."
 msgstr "显示历史记录视图。"
 
-msgctxt "wnd(Log|Project|Std|).tbtStdSetModeWt"
+msgctxt "wnd(Log|Project|Std|).tbtStdSetModeWt:"
 msgid "Show the local files of the repository \\(Working Tree\\)."
 msgstr "显示仓库 \\(工作区\\)的本地文件。"
 
-msgctxt "wnd(Log|Project|Std|).tbtSync"
+msgctxt "wnd(Log|Project|Std|).tbtSync:"
 msgid "Push local commits of the current branch and pull remote changes."
 msgstr "推送当前分支的本地提交并拉取远程变更。"
 
-msgctxt "wnd(Log|Project|Std|).tbtUnstage"
+msgctxt "wnd(Log|Project|Std|).tbtUnstage:"
 msgid "Remove staged changes from index."
 msgstr "从索引中删除暂存变更。"
 
-msgctxt "wnd(Log|Project|Std|).tbtView-ignore-whitespaces"
+msgctxt "wnd(Log|Project|Std|).tbtView-ignore-whitespaces:"
 msgid "Ignore irrelevant whitespace"
 msgstr ""
 
-msgctxt "wnd(Log|Project|Std|).tbtViewFromSubmodules"
+msgctxt "wnd(Log|Project|Std|).tbtViewFromSubmodules:"
 msgid "If selected, files from submodules will be shown."
 msgstr "如果选中，将显示子模块中的文件。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewIgnored"
+msgctxt "wnd(Log|Project|Std|).tbtViewIgnored:"
 msgid "If selected, ignored files will be shown."
 msgstr "如果选中，将显示忽略的文件。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewRenameSource"
+msgctxt "wnd(Log|Project|Std|).tbtViewRenameSource:"
 msgid "If selected, removed/missing source files of detected renames will be shown."
 msgstr "如果选中，将显示检测到的重命名的已删除/丢失的源文件。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewSkipped"
+msgctxt "wnd(Log|Project|Std|).tbtViewSkipped:"
 msgid "If selected, skipped files will be shown."
 msgstr "如果选中，将显示跳过的文件。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewStaged"
+msgctxt "wnd(Log|Project|Std|).tbtViewStaged:"
 msgid "If selected, files with staged \\(Index\\) changes and without working tree changes will be shown."
 msgstr "如果选中，将显示具有暂存 \\(Index\\) 变更且未变更工作区的文件。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnchanged"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnchanged:"
 msgid "If selected, unchanged files will be shown."
 msgstr "如果选中，将显示未变更的文件。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnchangedAssumed"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnchangedAssumed:"
 msgid "If selected, files having the 'assume-unchanged' flag will be shown."
 msgstr "如果选中，将显示具有 “假设不变” 标志的文件。"
 
-msgctxt "wnd(Log|Project|Std|).tbtViewUnversioned"
+msgctxt "wnd(Log|Project|Std|).tbtViewUnversioned:"
 msgid "If selected, not yet version controlled files will be shown."
 msgstr "如果选中，未加入版本控制的文件将会显示。"
 
-msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetMain"
+msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetMain:"
 msgid "Switch to the Main perspective."
 msgstr "切换到主透视图。"
 
-msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetReview"
+msgctxt "wnd(Log|Project|Std|).tbtWindowLayoutSetReview:"
 msgid "Switch to the Review perspective."
 msgstr "切换到审阅透视图。"
 


### PR DESCRIPTION
These are entries collected from Version 24.1 (Build 21161) through the current 25.1.088 RC (#251088).

Please pay attention to entries that contain a line starting with `#| msgid`. These are items that either changed from the contents of the `unknown` file due to my conversion to variables, or may require source fixes on the SmartGit side.

Additionally, entries that include proper nouns (e.g., GitHub, GitLab) or strings beginning with `http(s):` may or may not need substitution with variables. Please double-check these and apply corrections as needed.
